### PR TITLE
Lemma relations && english translations

### DIFF
--- a/.github/workflows/citation.yml
+++ b/.github/workflows/citation.yml
@@ -1,0 +1,18 @@
+---
+
+name: citation
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: clone repo
+        uses: actions/checkout@v2
+
+      - name: validate CITATION.cff
+        uses: LutrisEng/validate-cff@v1.0.0
+
+...

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,6 +12,6 @@ version: "1.1.0-dev"
 identifiers:
   - type: doi
     value: "10.5281/zenodo.3580939"
-license: cc-by-sa-4.0
+license: CC-BY-SA-4.0
 ...
 #  vim: set ts=2 sw=2 tw=500 et ft=yaml :

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,9 @@
 ---
 cff-version: 1.2.0
+message: >
+  Please cite using these metadata when using this dataset.
+title: >
+  Corpus of Egyptian Texts for the AED - Ancient Egyptian Dictionary
 authors:
   - family-names: Schweitzer
     given-names: Simon D.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,13 @@
+---
+cff-version: 1.2.0
+authors:
+  - family-names: Schweitzer
+    given-names: Simon D.
+  - name: Ancient Egyptian Dictionary
+version: "1.1.0-dev"
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.3580939"
+license: cc-by-sa-4.0
+...
+#  vim: set ts=2 sw=2 tw=500 et ft=yaml :

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3580939.svg)](https://doi.org/10.5281/zenodo.3580939)
+
 # aed-tei
 Corpus of Egyptian Texts for the AED - Ancient Egyptian Dictionary
 

--- a/files/aed_schema.xsd
+++ b/files/aed_schema.xsd
@@ -401,6 +401,18 @@
                                         </xs:sequence>
                                     </xs:complexType>
                                 </xs:element>
+                                <xs:element name="xr" minOccurs="0" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                        <xs:sequence>
+                                            <xs:element name="ref" minOccurs="0" maxOccurs="unbounded">
+                                                <xs:complexType>
+                                                    <xs:attribute name="target" type="xs:string"/>
+                                                </xs:complexType>
+                                            </xs:element>
+                                        </xs:sequence>
+                                        <xs:attribute name="type"/>
+                                    </xs:complexType>
+                                </xs:element>
                             </xs:sequence>
                             <xs:attribute ref="xml:id" />
                         </xs:complexType>

--- a/files/aed_schema.xsd
+++ b/files/aed_schema.xsd
@@ -73,7 +73,17 @@
                                 <xs:element name="sourceDesc" minOccurs="0" maxOccurs="1">
                                     <xs:complexType>
                                         <xs:sequence>
-                                            <xs:element name="p" minOccurs="0" maxOccurs="1" />
+                                            <xs:element name="p" minOccurs="0" maxOccurs="1">
+                                                <xs:complexType mixed="true">
+                                                    <xs:sequence>
+                                                        <xs:element name="ref" minOccurs="0">
+                                                            <xs:complexType mixed="true">
+                                                                <xs:attribute name="target" type="xs:string"/>
+                                                            </xs:complexType>
+                                                        </xs:element>
+                                                    </xs:sequence>
+                                                </xs:complexType>
+                                            </xs:element>
                                             <xs:element name="msDesc" minOccurs="0" maxOccurs="1">
                                                 <xs:complexType>
                                                     <xs:sequence>

--- a/files/aed_schema.xsd
+++ b/files/aed_schema.xsd
@@ -4,6 +4,8 @@
     xmlns:ns1="http://www.tei-c.org/ns/1.0" targetNamespace="http://www.tei-c.org/ns/1.0"
     vc:minVersion="1.1">
 
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace"/>
+
     <xs:override schemaLocation="https://tei-c.org/release/xml/tei/custom/schema/xsd/tei_all.xsd">
         <xs:element name="teiHeader">
             <xs:complexType>

--- a/files/aed_schema.xsd
+++ b/files/aed_schema.xsd
@@ -410,7 +410,7 @@
                                                 </xs:complexType>
                                             </xs:element>
                                         </xs:sequence>
-                                        <xs:attribute name="type"/>
+                                        <xs:attribute name="type" type="xs:string"/>
                                     </xs:complexType>
                                 </xs:element>
                             </xs:sequence>

--- a/files/aed_schema.xsd
+++ b/files/aed_schema.xsd
@@ -284,7 +284,7 @@
                                     <xs:complexType>
                                         <xs:sequence>
                                             <xs:element name="prefixDef" minOccurs="0" maxOccurs="unbounded">
-                                                <xs:complexType>
+                                                <xs:complexType mixed="true">
                                                     <xs:attribute name="ident" type="xs:string" />
                                                     <xs:attribute name="matchPattern" />
                                                     <xs:attribute name="replacementPattern" />

--- a/files/aed_schema.xsd
+++ b/files/aed_schema.xsd
@@ -404,11 +404,7 @@
                                 <xs:element name="xr" minOccurs="0" maxOccurs="unbounded">
                                     <xs:complexType>
                                         <xs:sequence>
-                                            <xs:element name="ref" minOccurs="0" maxOccurs="unbounded">
-                                                <xs:complexType>
-                                                    <xs:attribute name="target" type="xs:string"/>
-                                                </xs:complexType>
-                                            </xs:element>
+                                            <xs:element ref="ns1:ref" minOccurs="0" maxOccurs="unbounded"/>
                                         </xs:sequence>
                                         <xs:attribute name="type" type="xs:string"/>
                                     </xs:complexType>

--- a/files/aed_schema.xsd
+++ b/files/aed_schema.xsd
@@ -4,7 +4,7 @@
     xmlns:ns1="http://www.tei-c.org/ns/1.0" targetNamespace="http://www.tei-c.org/ns/1.0"
     vc:minVersion="1.1">
 
-    <xs:override schemaLocation="http://www.tei-c.org/release/xml/tei/custom/schema/xsd/tei_all.xsd">
+    <xs:override schemaLocation="https://tei-c.org/release/xml/tei/custom/schema/xsd/tei_all.xsd">
         <xs:element name="teiHeader">
             <xs:complexType>
                 <xs:sequence>

--- a/files/thesaurus.xml
+++ b/files/thesaurus.xml
@@ -20,7 +20,7 @@
         <date>heute</date>
       </publicationStmt>
       <sourceDesc>
-        <p>Based on <link target="urn:nbn:de:kobv:b4-opus4-29190"/> = Thesaurus of the TLA (<link target="http://aaew.bbaw.de/tla"/>)</p>
+        <p>Based on <ref target="urn:nbn:de:kobv:b4-opus4-29190">Teilauszug der Datenbank des Vorhabens "Strukturen und Transformationen des Wortschatzes der ägyptischen Sprache" vom Januar 2018</ref></p>
       </sourceDesc>
     </fileDesc>
     <encodingDesc>

--- a/files/thesaurus.xml
+++ b/files/thesaurus.xml
@@ -1,9616 +1,9617 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" version="5.0">
-<teiHeader>
-<fileDesc>
-<titleStmt>
-<title>Taxonomies for the AED - Version 0.1</title>
-<respStmt>
-<resp>compiler</resp>
-<name>Peter Dils</name>
-<name>Angela Böhme</name>
-<name>Altägyptisches Wörterbuch</name>
-<name>Anja Weber</name>
-</respStmt>
-</titleStmt>
-<publicationStmt>
-<publisher>someone</publisher>
-<availability xml:lang="en" status="free">
-<licence target="http://creativecommons.org/licenses/by-sa/4.0/">Metadata and texts are released as Creative Commons, Attribution-ShareAlike 4.0 (CC BY-SA 4.0)</licence>
-</availability>
-<date>heute</date>
-</publicationStmt>
-<sourceDesc>
-<p>Based on <link target="urn:nbn:de:kobv:b4-opus4-29190" /> = Thesaurus of the TLA (<link target="http://aaew.bbaw.de/tla" />)</p>
-</sourceDesc>
-</fileDesc>
-<encodingDesc>
-<classDecl>
-<taxonomy>
-<category xml:id="tlaZZWYPESU5FAC7D5ECPUHG44NO4">
-<catDesc>31 = Zustand</catDesc>
-<category xml:id="tlaEICEWSLI4RFWHMCXGBCXS4TETM">
-<catDesc>fragmentarisch</catDesc>
-</category>
-<category xml:id="tlaEPPC4OJ555HDTBPYWWL7XCG56A">
-<catDesc>vollständig</catDesc>
-</category>
-<category xml:id="tlaJ6AQL2TE6VH3RKTBK6FHAGQJ6A">
-<catDesc>unbestimmt</catDesc>
-</category>
-</category>
-<category xml:id="tla42VQWCPXKRA4VCE4WKSGZMTSWY">
-<catDesc>22 = Komponente</catDesc>
-<category xml:id="tla2CBV5TBESBA3DDRJGFY5S4XWFA">
-<catDesc>Stütze</catDesc>
-<category xml:id="tla3E6OENGZ3NB7VGUHAS5WEV26H4">
-<catDesc>Säule</catDesc>
-<category xml:id="tla2ZL4XRLN4VHHTKCREGH2F564E4">
-<catDesc>Lotossäule</catDesc>
-</category>
-<category xml:id="tlaA3XMXLX36JC5TNCGDPFCZQGQXM">
-<catDesc>Halbsäule</catDesc>
-</category>
-<category xml:id="tlaUAXPZZF4FZB7FPSJKBEZOB6DDQ">
-<catDesc>Zeltstangensäule</catDesc>
-</category>
-<category xml:id="tlaUCNYVVRUIJERVEM6PO7AIJJRMI">
-<catDesc>Papyrusbündelsäule</catDesc>
-</category>
-<category xml:id="tlaYCLNKJNVOZFRFAYNQJEUDNYZ6Y">
-<catDesc>protodorische Säule</catDesc>
-</category>
-</category>
-<category xml:id="tla7VEAOTTHR5D3DMYJDV2U5HLMZY">
-<catDesc>Pfeiler</catDesc>
-<category xml:id="tla2IWK4VOUDZAUTEU5IS3P4GUXTE">
-<catDesc>Rückenpfeiler</catDesc>
-</category>
-<category xml:id="tlaEA4PO22EERABDFK5UULHOTFCZU">
-<catDesc>Statuenpfeiler</catDesc>
-<category xml:id="tlaVETN43WACRGCVFQGK4YCNVOMTI">
-<catDesc>Osirispfeiler</catDesc>
-</category>
-</category>
-<category xml:id="tlaES7MCMBMGNGJ7E6M5X626PB7E4">
-<catDesc>Reliefpfeiler</catDesc>
-<category xml:id="tlaIK2YYENWGZAZBFSL4MIEDGV6SM">
-<catDesc>Hathorsäule / -pfeiler</catDesc>
-</category>
-<category xml:id="tlaIREACYALRRBURGP4MKYMDJTSAA">
-<catDesc>Wappenpflanzenpfeiler</catDesc>
-</category>
-</category>
-<category xml:id="tlaQSF7VQGYQFB5DBYI23GFW5I5NE">
-<catDesc>Oktogonalpfeiler</catDesc>
-</category>
-</category>
-<category xml:id="tlaHRUHQD5C2FHSTJYXW5Q7Q6AAGQ">
-<catDesc>Pilaster</catDesc>
-</category>
-</category>
-<category xml:id="tla3DYLEF6K45DTRMKYFVDZSRWL2U">
-<catDesc>Pyramidion</catDesc>
-</category>
-<category xml:id="tla4BRO67SGNRBJXPNF3PN4JCZRYQ">
-<catDesc>Säulentrommel</catDesc>
-</category>
-<category xml:id="tla4JO3TTA3JJBBFPVI466MLWKSOY">
-<catDesc>Altar</catDesc>
-</category>
-<category xml:id="tla4X5ASCFQXRECLMHVT6HO35A32Q">
-<catDesc>Fixierelement</catDesc>
-<category xml:id="tlaJFL52MW6WBAU5KHGVBSZV3OOYU">
-<catDesc>Flachdübel</catDesc>
-</category>
-<category xml:id="tlaRLCJUW4TXFERPBNBF5AWWLEQEE">
-<catDesc>Schwalbenschwanzklammer</catDesc>
-</category>
-</category>
-<category xml:id="tla55YZ4SFE5JH63BBO4G6V4FYNQY">
-<catDesc>Rahmen</catDesc>
-</category>
-<category xml:id="tla5I2ZW5FHC5EGTJAPOK74GJ6H6Y">
-<catDesc>Abacus</catDesc>
-</category>
-<category xml:id="tla5YZWVI3KP5HQRJCV7L2TTRXWGE">
-<catDesc>Obelisk</catDesc>
-</category>
-<category xml:id="tla6KHHGJLJ35GPNMKND64IBPWXXE">
-<catDesc>Basis / Standplatte</catDesc>
-</category>
-<category xml:id="tla6WLOEG2MORAWLNEZPZBHNUASWA">
-<catDesc>Mauer</catDesc>
-<category xml:id="tlaVJONX36OKNA3VLZEIOVNZ37AFA">
-<catDesc>Umfassungsmauer</catDesc>
-</category>
-<category xml:id="tlaXL76XAXJ5BBKTKUKNYQCNVRDTQ">
-<catDesc>Palastfassadenmauer</catDesc>
-</category>
-<category xml:id="tlaYRDE7JAJANG7LITTW4PJ2ZEBGU">
-<catDesc>Wellenmauer</catDesc>
-</category>
-</category>
-<category xml:id="tla7QDLKQDQSRENHNADLIFETVUHEY">
-<catDesc>Ständer</catDesc>
-</category>
-<category xml:id="tlaBWBUYO5XKFHXND2Q22HDNGPBX4">
-<catDesc>Verschluss</catDesc>
-<category xml:id="tlaFQZPT6WLOBDRJB2PUM4YHXCRXI">
-<catDesc>Riegel</catDesc>
-</category>
-<category xml:id="tlaIR7KWBPA5NBJRAV7HBUIU4UPUQ">
-<catDesc>Stopfen</catDesc>
-</category>
-<category xml:id="tlaNGU5WOAESVEOVK6FBF74ZKLQYI">
-<catDesc>Deckel</catDesc>
-</category>
-<category xml:id="tlaRW4WWT3MKNCSZKOZXGAMSH5XAI">
-<catDesc>Plombierung</catDesc>
-<category xml:id="tlaJIJLTWRSGJHLPNM6AX76SJJ2BI">
-<catDesc>Klumpen</catDesc>
-</category>
-</category>
-<category xml:id="tlaZKLDI6SUCZA4XOSV3PJNALBTRQ">
-<catDesc>Knauf</catDesc>
-</category>
-</category>
-<category xml:id="tlaCP5BO2LDS5EXTCBIK7PQYRONFE">
-<catDesc>Pylon</catDesc>
-</category>
-<category xml:id="tlaCTXME3US35BCFGZFSKEECMIXEE">
-<catDesc>Pyramide</catDesc>
-</category>
-<category xml:id="tlaD2TBGO3L3VB2XMVS3FGKIYKICI">
-<catDesc>Einlage</catDesc>
-<category xml:id="tla5A62UW4HVRGTRNABJRIV5VBYVM">
-<catDesc>Grabkegel</catDesc>
-</category>
-<category xml:id="tlaVWMPIUY3FJF2TEUYOARB6ZR6SE">
-<catDesc>Kachel</catDesc>
-</category>
-</category>
-<category xml:id="tlaDRJ4J5PX5RGEFAWL3QY5CNP5G4">
-<catDesc>Griff &amp; Henkel</catDesc>
-</category>
-<category xml:id="tlaDZAW646H4ZBQHEEZZHLE24VR4M">
-<catDesc>Raum</catDesc>
-<category xml:id="tla32WTLATMOVGQXFD6G2XCGLVAQA">
-<catDesc>Speisesaal</catDesc>
-<category xml:id="tlaKVNDPPBIFZGGBAQXWVGE45EY5Q">
-<catDesc>Opfertischsaal (Tempel)</catDesc>
-</category>
-<category xml:id="tlaLMFRX3ZEVFA55H7ZBS7KD6YXQQ">
-<catDesc>Refektorium</catDesc>
-</category>
-</category>
-<category xml:id="tla3AASO4EHYRD6VMAMPM2MISN66U">
-<catDesc>Barkenraum</catDesc>
-</category>
-<category xml:id="tla7NKDXUABEJCETNYNKYQXXJXUBU">
-<catDesc>Krypta</catDesc>
-</category>
-<category xml:id="tlaC24FBQDROJEWNOI3ZK2CIZILYI">
-<catDesc>Sanktaur / Allerheiligstes</catDesc>
-</category>
-<category xml:id="tlaDN77FVWFYFFHPJOKZMVJGY3VNI">
-<catDesc>Serdab</catDesc>
-</category>
-<category xml:id="tlaDWEWYQUVW5F2ZDLIM2MD73IK5I">
-<catDesc>Grabkammer</catDesc>
-</category>
-<category xml:id="tlaECROFKMWINBO7IY4ZETDPLMAZI">
-<catDesc>Treppenhaus</catDesc>
-</category>
-<category xml:id="tlaEROENXHNDBDB3IXLXN3MGWQGYI">
-<catDesc>Längshalle (TT)</catDesc>
-</category>
-<category xml:id="tlaHIKUSPBKJFC5RDCFIMPTCHASZA">
-<catDesc>Entlastungskammer</catDesc>
-</category>
-<category xml:id="tlaI5GWESQ6RVCEXLWOFCL7FKGDII">
-<catDesc>Querhalle (TT)</catDesc>
-</category>
-<category xml:id="tlaJWJ7HWJUUNC5FEEQ7GKCJI4ZGA">
-<catDesc>Kolonnade</catDesc>
-</category>
-<category xml:id="tlaK737M2VGRFDSLLHMXETLSGJGHE">
-<catDesc>Hypostyl / Säulenhalle</catDesc>
-</category>
-<category xml:id="tlaKKMBVKIKQBGKHFWDU4K76V3QGY">
-<catDesc>Schacht</catDesc>
-</category>
-<category xml:id="tlaL22ZAGE7XZHV7BWX7HEKQ7G6VA">
-<catDesc>Hof</catDesc>
-<category xml:id="tlaIDE6SM4VHJFEXD5NBMJ32QJITA">
-<catDesc>Lichthof</catDesc>
-</category>
-<category xml:id="tlaVE6HF2APKRGDRIJQ6JZHFSL63Q">
-<catDesc>Vorhof / Vorplatz</catDesc>
-</category>
-<category xml:id="tlaW5JIOWYPSZCXRHAKUPBORDIUUE">
-<catDesc>Säulenhof / Peristylhof</catDesc>
-</category>
-<category xml:id="tlaZD54ACJMXRHK3O4Z3LKFB7GEHI">
-<catDesc>Sonnenaltarhof</catDesc>
-</category>
-</category>
-<category xml:id="tlaRWQCB5LXKJEHHFPIESQSO34HAU">
-<catDesc>Magazinraum</catDesc>
-</category>
-<category xml:id="tlaRWXDM4BCE5AUHLT7G5WBC2HTK4">
-<catDesc>Barkensanktuar</catDesc>
-</category>
-<category xml:id="tlaUZLZJ7COMZBFBF7GVW7KTCQZCI">
-<catDesc>Totenopferraum</catDesc>
-</category>
-<category xml:id="tlaV22IABB6YFBAVLSKWLHTFOLUMU">
-<catDesc>Korridor</catDesc>
-</category>
-<category xml:id="tlaVG2L3E5RLFCULEK5CZRNVPOI6E">
-<catDesc>Reinigungsraum</catDesc>
-<category xml:id="tlaJAGXC6GPQJH3ZOHEKPALX3YV3Q">
-<catDesc>Reinigungsbrunnen (Moschee)</catDesc>
-</category>
-<category xml:id="tlaS7QU7NEC65EHRNITXTWLDV22OA">
-<catDesc>Bad</catDesc>
-</category>
-</category>
-<category xml:id="tlaYUMSK4GHU5E2DH2YS2JS3OLS4A">
-<catDesc>Pronaos</catDesc>
-</category>
-</category>
-<category xml:id="tlaEQF3JGXWIRDFRC7SGIXK4UPUFU">
-<catDesc>Wasserspeier</catDesc>
-</category>
-<category xml:id="tlaF3BRJFT7U5HJ7MXZ47RJ44HXJU">
-<catDesc>Decke</catDesc>
-<category xml:id="tlaIIUJ6RUFLNDSJN5N64KALE5KV4">
-<catDesc>Balkendecke</catDesc>
-</category>
-<category xml:id="tlaTEJYLHONBBCPVHW5XWMAJNIKXE">
-<catDesc>Gewölbe</catDesc>
-<category xml:id="tlaFOSXMHMJKZA6HE4A5SPBWNRV6Y">
-<catDesc>Scheingewölbe</catDesc>
-</category>
-<category xml:id="tlaQVTETO5MBNBPNC2HL2CEYW62RA">
-<catDesc>Tonnengewölbe</catDesc>
-</category>
-<category xml:id="tlaZCS4ESJOLFHU7KSN6YJ5QP2VDA">
-<catDesc>Kraggewölbe</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaGHMRAQY5Z5DTPLAXWE57EKWC2Y">
-<catDesc>Laibung</catDesc>
-</category>
-<category xml:id="tlaID2IA3T5PREWRGADU7VVBIDZRI">
-<catDesc>Sockel</catDesc>
-</category>
-<category xml:id="tlaIGXF5ZVEI5ALPHRZKHMJFUA2FQ">
-<catDesc>Architrav</catDesc>
-</category>
-<category xml:id="tlaISLG6MXASBFKJD3RYBEVXQ4LBU">
-<catDesc>Tür</catDesc>
-<category xml:id="tla2L6RZ4PAZREGDE4E7WLH255UGI">
-<catDesc>Scheintür</catDesc>
-<category xml:id="tlaIXXEPFLHGJGXJJLEW33LE4QYKA">
-<catDesc>Prunkscheintür</catDesc>
-</category>
-<category xml:id="tlaS3VSVDAGIRGAPHUGFBL4BKO2Z4">
-<catDesc>Mittelstützenscheintür</catDesc>
-</category>
-<category xml:id="tlaZJIVEZKTMFDILDEOQKI33YYW24">
-<catDesc>Normalscheintür</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaJ3ZM4CQXGBBARBBNWN3TVXJH2Y">
-<catDesc>Fassade</catDesc>
-</category>
-<category xml:id="tlaJ43UX5HS3REBHETB744F5VZYYI">
-<catDesc>unbekannt</catDesc>
-</category>
-<category xml:id="tlaJKM6TBMSG5AUPBPGOX62FUTN54">
-<catDesc>Terrasse</catDesc>
-</category>
-<category xml:id="tlaKECXMHLYQNHHRPPWVM4ELXLCFE">
-<catDesc>Ziegel</catDesc>
-<category xml:id="tla4VSRXVGX6BGOFJLYK5G7SBNVRU">
-<catDesc>Friesziegel</catDesc>
-<category xml:id="tlaPMZMQEWSP5HUHBO5BJESAMWW4U">
-<catDesc>Grabkegel</catDesc>
-</category>
-</category>
-<category xml:id="tlaJ7NTYP4WFNDKPJ5MZEGESVDLGE">
-<catDesc>Mauerziegel</catDesc>
-</category>
-</category>
-<category xml:id="tlaKEH3I2FU65AK3JY3XQN2Q6CPCY">
-<catDesc>Nische</catDesc>
-<category xml:id="tlaFBDSJJRBUFESBKA2DXTSMX6GBU">
-<catDesc>Tornische (Spätzeitgräber</catDesc>
-</category>
-<category xml:id="tlaJO46ZD3ULZEZDHB4QWB6QMB35M">
-<catDesc>Gebetsnische</catDesc>
-</category>
-<category xml:id="tlaTVLT4A4BHRARFMUSVGNVW5NG7A">
-<catDesc>Fahnenmastnische</catDesc>
-</category>
-<category xml:id="tlaUTOHZ3KHONHYLA46AQSMGIGEYQ">
-<catDesc>Statuennische</catDesc>
-</category>
-<category xml:id="tlaYQ5R65R6FRB6JDCCYD5V6T2OWY">
-<catDesc>Scheintürnische</catDesc>
-</category>
-</category>
-<category xml:id="tlaLB4BCDDMWZCJ5GBVNUVP6ELV5Y">
-<catDesc>Steinblock</catDesc>
-<category xml:id="tla6N6MLULAR5FBZCG65ZD4TDLUAQ">
-<catDesc>Spolie</catDesc>
-</category>
-<category xml:id="tla756O4LU6DBD73AKXGDJC554AMY">
-<catDesc>coping block</catDesc>
-</category>
-<category xml:id="tlaCKA5PIRNDBG2JLRW7KRJADNQ6E">
-<catDesc>Gesimsblock</catDesc>
-</category>
-<category xml:id="tlaER33D7RKHBA7BLNLBNHRPA7IN4">
-<catDesc>casing stone</catDesc>
-</category>
-<category xml:id="tlaLX3Y4CC32VEK7AEFIR24H5WLCQ">
-<catDesc>Talatat</catDesc>
-</category>
-<category xml:id="tlaTA2WZDK3UFD7XN5AIU3NB66LUA">
-<catDesc>Fallstein</catDesc>
-</category>
-</category>
-<category xml:id="tlaLPN6Y6VN4JCRPPVBJ4XODXB6FE">
-<catDesc>Fenster</catDesc>
-<category xml:id="tlaFPJDBNF3GRG7LDWISQGBBMNHEY">
-<catDesc>Lichtschacht</catDesc>
-</category>
-<category xml:id="tlaYGCBSINXMRB7FAHNP6YQJ75NM4">
-<catDesc>Erscheinungsfenster</catDesc>
-</category>
-</category>
-<category xml:id="tlaM74COZQB5JD25M2HPEWPFXU334">
-<catDesc>Gitter</catDesc>
-<category xml:id="tla7ML2BZPRFNBIFKJ5P6BCYFIZ4Y">
-<catDesc>Lattenrost</catDesc>
-</category>
-<category xml:id="tlaJKIVOS4WKVGZBPEH6KK4RG7QVU">
-<catDesc>Fenstergitter</catDesc>
-</category>
-</category>
-<category xml:id="tlaN7CPDTDAZZC57E5N56HKNXAEDQ">
-<catDesc>Flügel / Blatt</catDesc>
-</category>
-<category xml:id="tlaNZSM5HFQYNHLHFZJUHHCYD3Z74">
-<catDesc>Zuwege / Wege</catDesc>
-<category xml:id="tlaHVJLOIF4UFBFLPFGJ3LV2CDWOQ">
-<catDesc>Sphinxallee</catDesc>
-</category>
-<category xml:id="tlaXUYBXBA6XFBW3JR7LQGCNWZDSA">
-<catDesc>Aufweg</catDesc>
-</category>
-</category>
-<category xml:id="tlaPWGM75NZGRA57OF5OMLBT7LMPI">
-<catDesc>Hohlkehle + Rundstab</catDesc>
-</category>
-<category xml:id="tlaPZOFZZSGIBC57JWRXFJ3PNJ7KI">
-<catDesc>Giebel</catDesc>
-<category xml:id="tlaU32IERSR7NE6XLLUC6R5DDKZ4A">
-<catDesc>Sprenggiebel</catDesc>
-</category>
-</category>
-<category xml:id="tlaQ2SYQ5XAZJG7HIEUSSLOP4I7OU">
-<catDesc>Wand</catDesc>
-<category xml:id="tlaMDOE7AUJDZF4PNZJ26FFXI45L4">
-<catDesc>Nischenwand</catDesc>
-</category>
-<category xml:id="tlaMGZVRRGHONCKZLR63ZJOXAO7FE">
-<catDesc>Interkolumnium</catDesc>
-</category>
-</category>
-<category xml:id="tlaSSTXKEQK2REINMKVMJ7Y4T7SVM">
-<catDesc>Aufgang</catDesc>
-<category xml:id="tlaCF7DBMTN2REZ7HFYMRTCD75YJQ">
-<catDesc>Rampe</catDesc>
-</category>
-<category xml:id="tlaWNN3BAMQYZEGFO3RJXDWY6FHZA">
-<catDesc>Treppe</catDesc>
-</category>
-</category>
-<category xml:id="tlaTA6Q2AX6WNDLXEQMPCMABU6QHY">
-<catDesc>Mumienporträt</catDesc>
-</category>
-<category xml:id="tlaTF7EPBLNS5HGNHFJBSOTDPA7R4">
-<catDesc>Kopf- / Aufsatzstück</catDesc>
-</category>
-<category xml:id="tlaU3LTOG7CZZGAZNAE2FOPGQOXD4">
-<catDesc>Türrolle</catDesc>
-</category>
-<category xml:id="tlaVHZ5AFIKHBCGFFLWC7MYJB7EQE">
-<catDesc>Bein</catDesc>
-</category>
-<category xml:id="tlaVPNPQPLHDBE7RJMZ7G4EFUDD2A">
-<catDesc>Schaft</catDesc>
-</category>
-<category xml:id="tlaW45TXQORPZA3FJDFPJFBNZLD6U">
-<catDesc>Kapitell</catDesc>
-<category xml:id="tla7RPOC2C7S5DBNGTZ25SJ6F44TE">
-<catDesc>dorisches Kapitell</catDesc>
-</category>
-<category xml:id="tlaA44PJPEO75HRVOPXQ3ZDFB4AWU">
-<catDesc>Papyruskapitell</catDesc>
-<category xml:id="tlaSOIHFQHJZNFBHCTLSI4U6Q3OUE">
-<catDesc>offenes Papyruskapitell</catDesc>
-</category>
-<category xml:id="tlaUJW4APUQPBD7BFBYOKEP3XMEI4">
-<catDesc>geschlossenes Papyruskapitell</catDesc>
-</category>
-</category>
-<category xml:id="tlaARHP3FALBJA5HDDSA56PSHJBGE">
-<catDesc>Palmenkapitell</catDesc>
-</category>
-<category xml:id="tlaGHAQMG6CE5BNVEWVNFTGUAO5MU">
-<catDesc>Kompositkapitell</catDesc>
-</category>
-<category xml:id="tlaNK4ENUFGUFB23ASLPK55MDH7DE">
-<catDesc>Hathorkapitell</catDesc>
-</category>
-</category>
-<category xml:id="tlaW4UDOKUXIFG25MI3IZGMHWEJQ4">
-<catDesc>Lunette</catDesc>
-</category>
-<category xml:id="tlaWCICGZUQKVEBRAG5PVX7VHS5LY">
-<catDesc>Pfosten</catDesc>
-</category>
-<category xml:id="tlaWLBV5TPMDRH2PJ23FIYN6LBNHI">
-<catDesc>Dach</catDesc>
-<category xml:id="tlaH2I24BJF5BAPZFBYKWVVXXAN2I">
-<catDesc>Flachdach</catDesc>
-</category>
-<category xml:id="tlaWRPREVWANJCAPOWWUKQRTNIPHU">
-<catDesc>Giebeldach</catDesc>
-</category>
-</category>
-<category xml:id="tlaWQGBNVOZQZD7FECJPRLX724TWM">
-<catDesc>Fußboden</catDesc>
-</category>
-<category xml:id="tlaX5C6WY3M7VBWZBEQHR5EYMK7UM">
-<catDesc>unbestimmt</catDesc>
-</category>
-<category xml:id="tlaXUJVLCQKKZDSXDCE7Y6TWZGPYY">
-<catDesc>Supraporte</catDesc>
-</category>
-<category xml:id="tlaXZYBOSB3RJFPDEAMFEXKEDQYN4">
-<catDesc>Klinge</catDesc>
-<category xml:id="tla7UMTHAL2UBFA7P4VAPLSTSL37A">
-<catDesc>Netjerui-Klinge</catDesc>
-</category>
-</category>
-<category xml:id="tlaYPVD27R3SBHPLJUFB5SJYAHBMQ">
-<catDesc>Sturz</catDesc>
-</category>
-</category>
-<category xml:id="tlaRJLJDROM3ZAH7DOSBYM3YZC5XY">
-<catDesc>2 = Aufbewahrungsorte, Museen</catDesc>
-<category xml:id="tla3FCBF7YMYBDXLEBSFXKBWTAXCE">
-<catDesc>(unbestimmt)</catDesc>
-</category>
-<category xml:id="tlaDO564E6CRJC4BJJJZIPHCFXZHM">
-<catDesc>(Privatsammlung)</catDesc>
-</category>
-<category xml:id="tlaHPUFUHJMEZF7ZGM2VXBQNHZUYM">
-<catDesc>Europa</catDesc>
-<category xml:id="tla37NMIQHT5FAOVISLYKNKP2HGYY">
-<catDesc>Schweden</catDesc>
-<category xml:id="tla6EQ2CASSQFF5VBTYOJU3VL4POQ">
-<catDesc>Malmö</catDesc>
-<category xml:id="tlaM5Z3ORYCPVFF3PI3WPH5ND3MYE">
-<catDesc>Museer, Ägyptische Sammlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaQOWEQH5UBJFPPFUEL6Y26XSDPM">
-<catDesc>Mora</catDesc>
-<category xml:id="tla2NZP4HLIFRE4ZA3EUDXA2EVYUU">
-<catDesc>Zornsamlingarna</catDesc>
-</category>
-</category>
-<category xml:id="tlaQVZ5VE5L3ZHXHNWCPBMSTVBWHA">
-<catDesc>Stockholm</catDesc>
-<category xml:id="tlaGRENVJZJUBFK7J7CGIXNNRN3J4">
-<catDesc>Medelhavsmuseet</catDesc>
-</category>
-<category xml:id="tlaQXVL656JQZE55K7WRUIX2ESREA">
-<catDesc>Cypernsamlingarna</catDesc>
-</category>
-<category xml:id="tlaTBHPPILVFNHTHF7DTH6KUF4PCA">
-<catDesc>Nationalmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tlaRESFLL5O3FGRXKJ64YHEDV425U">
-<catDesc>Linköping</catDesc>
-<category xml:id="tlaJNWO4U3TEVCAVL6UMH2A6VLSOM">
-<catDesc>Stifts och Landsbibliothek</catDesc>
-</category>
-<category xml:id="tlaLXKVR7K3HVAMPPXCOXO4W3KPH4">
-<catDesc>Östergötlands och Linköpings Stadsmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tlaTC74N3OJMNEGBP2H5DZVMJ5XVA">
-<catDesc>Vanersborg</catDesc>
-<category xml:id="tlaBUQCIAN4ONC6NI7UZBAASVYEB4">
-<catDesc>Vanersborgs Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaUXRD63GUDNGYBNO2WEL254T6AA">
-<catDesc>Kristianstad</catDesc>
-<category xml:id="tlaTFT7IPO45BEM5NEAPDTXVBXTS4">
-<catDesc>Kristianstads Landsmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tlaVYV63BTZU5GIFCF4MWN52HFAL4">
-<catDesc>Lund</catDesc>
-<category xml:id="tlaISPFLTPGD5GIZMS5NUTKVEYE7A">
-<catDesc>Kulturhistoriska Museet</catDesc>
-</category>
-</category>
-<category xml:id="tlaZBQYEE43IVHMDAIW5O2B6AFWPI">
-<catDesc>Uppsala</catDesc>
-<category xml:id="tla2EZGVZFPFRG4HPBO3544PM55FE">
-<catDesc>Victoriamuseet för Egyptiska Fornsaker</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tla3RBC5HKEVRHSFBYBMPHCAXU2WE">
-<catDesc>Griechenland</catDesc>
-<category xml:id="tlaGBX34TGAMJFE3DNY34GW4MIXYE">
-<catDesc>Sparta</catDesc>
-<category xml:id="tlaYKWOUYRWHFFMZI2L2H3Z5IQTRE">
-<catDesc>Archaeological Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaI2QZVIMZKNAINCTJNIVGGKUQRY">
-<catDesc>Delos</catDesc>
-<category xml:id="tlaVJ67ZJBBTJGGDCEMEG3GW4BBRE">
-<catDesc>Archaeological Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaJNDEKHFPV5EOFJUOBS6TEMUXQI">
-<catDesc>Athen</catDesc>
-<category xml:id="tla7LKLWZRVQBBD7B26FT6OZSX7WA">
-<catDesc>National Archaeological Museum</catDesc>
-</category>
-<category xml:id="tlaO6RLNOMQXVHR5F72F3S24RZVVY">
-<catDesc>Kanellopoulos Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaLP43BXG7NJCRBBDM6ZYEZCS4PE">
-<catDesc>Iraklion</catDesc>
-<category xml:id="tlaTBZFB4OXOJF4XDTRHLO57M5XQM">
-<catDesc>Archaeological Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaNERPVQEKCNGPLN4YOUWL54TZIA">
-<catDesc>Chios</catDesc>
-<category xml:id="tlaKH46WS664VHRJLSXYPEDOSMA2E">
-<catDesc>Archaeological Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaNZPTUNNRTBDT3BQKY2CV3I4JGE">
-<catDesc>Phaistos</catDesc>
-<category xml:id="tlaDJOVKFVYBFHKNHV7KFMM3ZKEMI">
-<catDesc>Museum Candia</catDesc>
-</category>
-</category>
-<category xml:id="tlaPVXJQAVDORDFLLWICCZCPEOR4M">
-<catDesc>Rhodos</catDesc>
-<category xml:id="tlaSIKXUNJBLJCR7BV7GZCYVE5HJA">
-<catDesc>Rhodos Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaU4UK6OULCJCKDDPYLYL2ANMGFE">
-<catDesc>Samos</catDesc>
-<category xml:id="tlaZTBKPCOOLJDL7H3UEYVCHQ32TA">
-<catDesc>Archaeological Museum of Vathy</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tla52CWIGKMEBFGLBT5CAL7V2PECQ">
-<catDesc>Ungarn</catDesc>
-<category xml:id="tla6PMFVRIHG5H4FIEQICRY5FMN6Y">
-<catDesc>Budapest</catDesc>
-<category xml:id="tlaHTTJJDSLQFFMVPOIIYLZT4TNB4">
-<catDesc>Szépmüvészeti Múzeum</catDesc>
-</category>
-<category xml:id="tlaMES6PQUTJRD2FBMNLWI2MTZEPM">
-<catDesc>Magyar Nemzeti Muzeum</catDesc>
-</category>
-</category>
-<category xml:id="tla6ZXQXRMMGRC2FJB743EADHBQ7E">
-<catDesc>Zirc</catDesc>
-<category xml:id="tlaH35ZPICQXBBQ7LBOGCCO5WYIOM">
-<catDesc>Múzeum Antal Regály</catDesc>
-</category>
-</category>
-<category xml:id="tlaA6OZZVJWJFHINGHWFUDBBJBGX4">
-<catDesc>Papa</catDesc>
-<category xml:id="tlaFHAQ3YO5XRGFVMMXAL5REU77AU">
-<catDesc>Dunántuli Egyháztorteneti és Egyházmüvészeti Múzeum</catDesc>
-</category>
-</category>
-<category xml:id="tlaALNQ5AYNWBAFTH6XIKE5T77A7U">
-<catDesc>Szombathely</catDesc>
-<category xml:id="tla5CMFBNW4OJFB7FNSJ3MNE44BCM">
-<catDesc>Savaria Múzeum</catDesc>
-</category>
-</category>
-<category xml:id="tlaFKZFA4S76JBVTD3HUO3CJATQII">
-<catDesc>Székesfehérvár</catDesc>
-<category xml:id="tlaJPWEBBYODZHZ5FYNPRYPGXMFPM">
-<catDesc>István Király Múzeum</catDesc>
-</category>
-</category>
-<category xml:id="tlaTDSYQV2KQRFUFFPNEAKN66KG64">
-<catDesc>Debrecen</catDesc>
-<category xml:id="tla572DX2U7MNA33HUCK2QJKCVP7E">
-<catDesc>Déri Múzeum</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaALPPWH2JPVE5BH4BZMPCTP7EVM">
-<catDesc>Irland</catDesc>
-<category xml:id="tla22SGRPV56NGFBEBA446MV4LKZY">
-<catDesc>Island</catDesc>
-<category xml:id="tla46DF53SQXRAUNE373LKKHQHIDY">
-<catDesc>Reykjavik</catDesc>
-<category xml:id="tla6CPFQFH7BBGX3ITZBP6WW3EPSY">
-<catDesc>Thjodminjasafn</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaKNUADDX6PZABDCJU5DARMHPCE4">
-<catDesc>Cork</catDesc>
-<category xml:id="tlaMMHNK5ABVRGG7JQER7E7BASUDM">
-<catDesc>Boole Library, University College</catDesc>
-</category>
-</category>
-<category xml:id="tlaMN6YZGZYC5GGXOBRNMKDEG7DGE">
-<catDesc>Dublin</catDesc>
-<category xml:id="tla3AIH5N3DDBAZTCZ7QSHSEG52KM">
-<catDesc>Chester Beatty Library</catDesc>
-</category>
-<category xml:id="tlaJFGDOUD2BVDJLDBZU7VZTMDJZU">
-<catDesc>National Museum of Ireland</catDesc>
-</category>
-<category xml:id="tlaM7GSGJLTV5HUJITBRZCLG5XPT4">
-<catDesc>Trinity College, Weingreen Museum</catDesc>
-</category>
-<category xml:id="tlaPTZGAFFCPNFYRJJZ2T2A2NQGV4">
-<catDesc>University College</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaB2JLY6JETRGCLFE6BUCQW23AAU">
-<catDesc>Jugoslawien</catDesc>
-<category xml:id="tla4M55E5BDSZDILGBQW4N4MF66XM">
-<catDesc>Belgrad</catDesc>
-<category xml:id="tlaCVN6XIIMBNGSNEMKIU35SDXUD4">
-<catDesc>Narodni Muzej</catDesc>
-</category>
-<category xml:id="tlaFB4SXC7EYRGLFDQJ6UYGDFVX3E">
-<catDesc>Memorial Centre Josip Broz Tito</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaBJ6BV7WHJVCRDJQH6AVCGDLYSE">
-<catDesc>Russland</catDesc>
-<category xml:id="tla3TAFQPV63FATHF4UNMSU5GN6WY">
-<catDesc>Kazan</catDesc>
-<category xml:id="tlaQNJMT4YSPFDGRHN3MNTRTTN66E">
-<catDesc>State Republical Museum of Tatarstan</catDesc>
-</category>
-<category xml:id="tlaQRLSIA6TKFEWPBPJGWCMB3WWBM">
-<catDesc>Regional Museum of the Chechen Republic</catDesc>
-</category>
-</category>
-<category xml:id="tla4SHPASAHSBDWJLMRKXTIBK3ONM">
-<catDesc>Rostow</catDesc>
-<category xml:id="tlaFGNKQZOZXJDJZLPUFXL274VWZI">
-<catDesc>Rostov Regional Museum of Fine Arts</catDesc>
-</category>
-</category>
-<category xml:id="tla7265TWEHZBDWRHUNNAYI7UMH5U">
-<catDesc>Jekaterinenburg</catDesc>
-<category xml:id="tla6BPV4LYUVBC27L75WYUGIEWHZ4">
-<catDesc>Jekaterinenburg State Museum of History</catDesc>
-</category>
-</category>
-<category xml:id="tla7WFPRL5U6BCBPCY6IJ63NXPMBU">
-<catDesc>Tambow</catDesc>
-<category xml:id="tla5CMTOWOERNBEPNKHGLK64ALBKA">
-<catDesc>Tambov Regional Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaBX25OPHACFH6PFGGR73OLMKAHA">
-<catDesc>Irkutsk</catDesc>
-<category xml:id="tlaLWK7WRXVINGVXKG3K2NWNTL4UQ">
-<catDesc>Irkutsk Regional Museum of Art</catDesc>
-</category>
-</category>
-<category xml:id="tlaEEMGG645AJDWHD56D7E7BMKK7Q">
-<catDesc>Moskau</catDesc>
-<category xml:id="tlaBZPDEX62XBAFDPOBXKYGDMHCUM">
-<catDesc>State Pushkin Museum of Fine Arts</catDesc>
-</category>
-<category xml:id="tlaDVNBKBS3GREXBCHDHPMUWZF644">
-<catDesc>State Historical Museum</catDesc>
-</category>
-<category xml:id="tlaEEIVGEWIPZGA3IK6HQIWG5PP4M">
-<catDesc>Glinka State Central Museum, Central State Museum of Musical Culture</catDesc>
-</category>
-<category xml:id="tlaEY5RRZIDOZDDRCI5GBYNAJMLGQ">
-<catDesc>State Museum of Oriental Art</catDesc>
-</category>
-<category xml:id="tlaQZXWIZJNJNEIVATVX7BX74WFQU">
-<catDesc>Country Museum Arkhangelskoya</catDesc>
-</category>
-<category xml:id="tlaZ5JZKIN6NNCQTNKGUEFGR2YEQM">
-<catDesc>State Abramtsevo Museum, Collection of History, Art and Literature</catDesc>
-</category>
-</category>
-<category xml:id="tlaEGJ3AKIS6RFAPMI67D4L2PVNBQ">
-<catDesc>Woronesh</catDesc>
-<category xml:id="tlaK623WPDFSNBLJOMESEMFFJZZKM">
-<catDesc>Oblastnoj chud. Muzej</catDesc>
-</category>
-</category>
-<category xml:id="tlaGFYOWA2JRRCKLG6IXEKM56T33M">
-<catDesc>Ivanova</catDesc>
-<category xml:id="tla6EW2ANCWIRHJNHX4LLZIDNO2XI">
-<catDesc>Ivanova Regional Museum of Art</catDesc>
-</category>
-</category>
-<category xml:id="tlaLL2EFFZHWJHKXNTLGHLSJNLSLY">
-<catDesc>Murom</catDesc>
-<category xml:id="tla5KFTM6UMBVGC5JREY7P5ICUKBM">
-<catDesc>Murom Regional Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaNFI7AKDVEFCQBHNH6HYHRXD4EA">
-<catDesc>Kertsch</catDesc>
-<category xml:id="tlaDVSAGXELTFEKJBXDV5SFP3RB3Q">
-<catDesc>Kerch Museum of History and Archaeology</catDesc>
-</category>
-</category>
-<category xml:id="tlaNWFNAAKNJVESRH2OWF7O455E4A">
-<catDesc>St. Petersburg</catDesc>
-<category xml:id="tlaAA6TRKGF2BAVNDT3IFAHEW3FQY">
-<catDesc>Museum of the History of Religion</catDesc>
-</category>
-<category xml:id="tlaDLE7NWSLKZEQ3A2SLB6H5K2MDA">
-<catDesc>Museum of Arts</catDesc>
-</category>
-<category xml:id="tlaNPKWBKFOYRGB3P6WT2ZMXPCLBM">
-<catDesc>State Hermitage Museum</catDesc>
-</category>
-<category xml:id="tlaPPHFEANV5REZFDQ23LEK2SOXLU">
-<catDesc>Museum of the Ecclesiastical Academy</catDesc>
-</category>
-<category xml:id="tlaPYCNJJ3G7VDNHBRL26HRA5HXBQ">
-<catDesc>Imperial Museum of the Russian Archaeological Society</catDesc>
-</category>
-</category>
-<category xml:id="tlaOX7JACLRPVBXRONCP75N73B3BQ">
-<catDesc>Sarapul</catDesc>
-<category xml:id="tlaAMLVROP3KZDARB3LSCG37SNVUU">
-<catDesc>Museum of History and Culture of Middle Kama Region</catDesc>
-</category>
-</category>
-<category xml:id="tlaR2L4RRDFDZEPTJP4FBVNMZZH3A">
-<catDesc>Grozny</catDesc>
-<category xml:id="tlaMY3I63V3XRHGZKCRB4HBUQWTXE">
-<catDesc>Regional Museum of the Chechen Republic</catDesc>
-</category>
-</category>
-<category xml:id="tlaRFGPXBCZPBDAFIT4TNTN4Q6KKU">
-<catDesc>Perm</catDesc>
-<category xml:id="tlaB7OABOTLIZF4DFDHRHKTV7Y5TY">
-<catDesc>Perm State University</catDesc>
-</category>
-<category xml:id="tlaNWR4KUMYOVFB3AXRDKYYFRH6LE">
-<catDesc>Perm State Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaRHMY7PVMKJA77NVHBMJRN4GGWY">
-<catDesc>Kaliningrad</catDesc>
-<category xml:id="tlaSUTZXRQCKVH3FOUJNOKQQFJFIA">
-<catDesc>Institute of Archaeology</catDesc>
-</category>
-</category>
-<category xml:id="tlaSBT6FLF6PVBSZJ3DE7HM6IKITM">
-<catDesc>Taganrog</catDesc>
-<category xml:id="tlaWZMDA2T5RFFBRI2JCGVNODIHWE">
-<catDesc>Taganrog Regional Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaT22KKDWXLVEBFLKF2O4J3L53Z4">
-<catDesc>Polenova</catDesc>
-<category xml:id="tlaDYCPJMAQDRC5BJV53KN5BYKRWY">
-<catDesc>State Historical, Art and Landscape Museum, Collection of V.D. Polenov</catDesc>
-</category>
-</category>
-<category xml:id="tlaYPXTV4ZD65D5HINR643ZYO4E3U">
-<catDesc>Smolensk</catDesc>
-<category xml:id="tlaQGC2OYQCRVEGRBE7H3FGPYRYQM">
-<catDesc>Smolensk State Museum, Collection of History, Architecture and Art</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaCHO4GHR5UJF7FLGW72I7XO34WM">
-<catDesc>Schweiz</catDesc>
-<category xml:id="tlaGUNIHTMVV5GCTCO2VUOFSWOLMA">
-<catDesc>(Städte L-Z)</catDesc>
-<category xml:id="tla4GB7OJLOMNFO5NUKTTNNPLLQYE">
-<catDesc>Winterthur</catDesc>
-<category xml:id="tlaNJNGTTO575C6JHHLB66DWMDTNQ">
-<catDesc>Ethnographische Sammlung (Naturwissenschaftliche Sammlungen)</catDesc>
-</category>
-<category xml:id="tlaQMGA4KXGPZCYVMXTT2WLGJIG6M">
-<catDesc>Antikensammlung des Münzenkabinetts</catDesc>
-</category>
-</category>
-<category xml:id="tla5IW6QEQV7ZANBG7ZSZK5KO4HRM">
-<catDesc>Solothurn</catDesc>
-<category xml:id="tlaN6PRUB5EDBEJDB3LX5LSKF4WWI">
-<catDesc>Kunsthaus</catDesc>
-</category>
-<category xml:id="tlaOLFLFEWQC5EKDD26SFZGI47JWM">
-<catDesc>Musée d&#039;Histoire Naturelle</catDesc>
-</category>
-</category>
-<category xml:id="tla5VOXFUEZJ5D4XEGJYSEDRP45T4">
-<catDesc>Schönenwerd</catDesc>
-<category xml:id="tlaM33GEHHL7ZFERBCX3IAKMWWF3E">
-<catDesc>Museum für Naturkunde</catDesc>
-</category>
-<category xml:id="tlaUH2AZHJH5VHYBBH2G4DSTQJ3MY">
-<catDesc>Bally Schuhmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tlaB3X47AEIJRBABLHNJTC7RBO2VM">
-<catDesc>Pregny-Chambésy</catDesc>
-<category xml:id="tlaSOEZB4MFENFTFC5I54A3WRTVQA">
-<catDesc>Musée des Suisses à l&#039;Étranger</catDesc>
-</category>
-</category>
-<category xml:id="tlaCWJ6V3F2MNDX5CRA23Y2XSQB2Q">
-<catDesc>Nyon</catDesc>
-<category xml:id="tlaE35AV65YIJFLPDY2YS3SY3AN4E">
-<catDesc>Musée Romain</catDesc>
-</category>
-</category>
-<category xml:id="tlaDTASLBBQNRHWLL7SKQJV2VECBE">
-<catDesc>Riggisberg</catDesc>
-<category xml:id="tla3PIF3AZMK5HOBLOY67NUFDEQE4">
-<catDesc>Abegg-Stiftung Bern</catDesc>
-</category>
-</category>
-<category xml:id="tlaDYV4SS7JJBGOVGAIPE3N2R3FFE">
-<catDesc>Schaffhausen</catDesc>
-<category xml:id="tla3PXY3P325BDNTA22JDYMCM54BM">
-<catDesc>Museum zu Allerheiligen</catDesc>
-</category>
-</category>
-<category xml:id="tlaEIFP6IPPEBFIDNULW3G56F3EQM">
-<catDesc>Lenzburg</catDesc>
-<category xml:id="tlaKH3DZYH73FCOHPSKMAN2Z2MQSU">
-<catDesc>Historisches Museum Aargau, Kantonale Sammlungen</catDesc>
-</category>
-</category>
-<category xml:id="tlaGBA7JB5VDVCS3CUCOZKEVB5KGU">
-<catDesc>La-Chaux-de-Fonds</catDesc>
-<category xml:id="tlaX4D35VNIR5GDZJAF2NDJF4PQ6A">
-<catDesc>Musée des Beaux-Arts</catDesc>
-</category>
-</category>
-<category xml:id="tlaHP23RTJ6GBDEVC34URJUPJDECA">
-<catDesc>Lausanne</catDesc>
-<category xml:id="tlaGADLBBQHTFDSDLGFGPXZ3JJXJ4">
-<catDesc>Musée Historique</catDesc>
-</category>
-<category xml:id="tlaIYDZTKRUKVCQNF72MYFYCEULDQ">
-<catDesc>Musée Romain de Lausanne-Vidy</catDesc>
-</category>
-<category xml:id="tlaQINZPP5ZIFE3NBDX27UF54RYFI">
-<catDesc>Musée Cantonal d&#039;Archéologie et d&#039;Histoire</catDesc>
-</category>
-<category xml:id="tlaSG5TAX6ATBBS7MBZ627YPAFBU4">
-<catDesc>Musée Cantonal des Beaux-Arts</catDesc>
-</category>
-</category>
-<category xml:id="tlaIMUBHZGA4BDQTIQDNAKOGKOYYM">
-<catDesc>Sion</catDesc>
-<category xml:id="tlaYPKZGADW4RGRJC6UCQRGWMF7FA">
-<catDesc>Musée Cantonal d&#039;Archéologie du Valais</catDesc>
-</category>
-</category>
-<category xml:id="tlaJ3LOP25LRVFD3EYO6ID6DFITBE">
-<catDesc>Neuchâtel</catDesc>
-<category xml:id="tlaUP67FT6VRJFFNL6MO7MDGBDWPE">
-<catDesc>Musée d&#039;Art et d&#039;Histoire</catDesc>
-</category>
-<category xml:id="tlaV34JC2CWRJHJHHQJVS65UEPDG4">
-<catDesc>Musée d&#039;Ethnographie</catDesc>
-</category>
-</category>
-<category xml:id="tlaJQM2UZG6IJEQPFKZBSCCEFFJHQ">
-<catDesc>Olten</catDesc>
-<category xml:id="tlaPUUPEDXAY5AOVI6KFJTP4F3DCI">
-<catDesc>Historisches Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaQQWU7V3F7FBENKUPND2GEWMPXA">
-<catDesc>Sankt Gallen</catDesc>
-<category xml:id="tla2PHXAUBCCBH6HD2G3FRTXK2Y74">
-<catDesc>Stifts-Bibliothek</catDesc>
-</category>
-<category xml:id="tlaXFVNGTBDIFDXRELQOSMOETWZR4">
-<catDesc>Historisches Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaRHXZXNCW5VAI5CSLMLZKJB5O3E">
-<catDesc>Yverdon</catDesc>
-<category xml:id="tla2E7F5EPXOVF3FO5GGDFU4EC4WM">
-<catDesc>Musée du Chateau</catDesc>
-</category>
-</category>
-<category xml:id="tlaT4QONYQ3V5FTVCS2YNCHV66T7I">
-<catDesc>Locarno</catDesc>
-<category xml:id="tlaAXM5GZCACBAUXEAEWEHEQSNVSE">
-<catDesc>Museo Civico Visconti</catDesc>
-</category>
-</category>
-<category xml:id="tlaTI2RD3XJIRGTHFUFVGHCGILPRY">
-<catDesc>Môtiers</catDesc>
-<category xml:id="tlaJOU7RFRFONEUXGQVKOGXMXQGRY">
-<catDesc>Musée Régional d&#039;Histoire et d&#039;Artisanat du Val-de-Travers</catDesc>
-</category>
-</category>
-<category xml:id="tlaU44WWAED7RBYLA2FKN3JHOBULY">
-<catDesc>Tour-de-Peilz</catDesc>
-<category xml:id="tlaLJV6QVPCOFBVFIWW475WQVQ2ME">
-<catDesc>Musée Suisse du Jeu</catDesc>
-</category>
-</category>
-<category xml:id="tlaUKVUFS6I5BGMLB5AYNXMYJDP5Y">
-<catDesc>Liestal</catDesc>
-<category xml:id="tla7IRHFUZXOBFG5GIPOHJQ3HGXRE">
-<catDesc>Kantonsmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tlaVAELYUTGUFFURMSTVVU34DAONQ">
-<catDesc>Saint-Imier</catDesc>
-<category xml:id="tla4S7WDDMMEVDAJCTFR4Z3KR44XY">
-<catDesc>Musée Municipal</catDesc>
-</category>
-</category>
-<category xml:id="tlaVIDMYE7Z2BFC7BDG42IYQJTTZE">
-<catDesc>Vevey</catDesc>
-<category xml:id="tlaDSTSATVUEFEQLGY5RUK6CAXAQM">
-<catDesc>Musée Historique du Vieux-Vevey</catDesc>
-</category>
-<category xml:id="tlaVYUZHH2AUBF7BNLMWAEAIPOT6Q">
-<catDesc>Musée des Beaux-Arts</catDesc>
-</category>
-<category xml:id="tlaZTTMDSB34FEQNA2I3377HHRYIQ">
-<catDesc>Musée Suisse du Jeu</catDesc>
-</category>
-</category>
-<category xml:id="tlaVLTOT4PXPVBXNNWXDNIU6G6VFE">
-<catDesc>Zürich</catDesc>
-<category xml:id="tla5IYWCRIEKRHITIS5BEVCWAJ4AA">
-<catDesc>Museum Bellerive</catDesc>
-</category>
-<category xml:id="tlaDCMDNN3QBVAIBHKKAVDLSYSBNM">
-<catDesc>Kunsthaus</catDesc>
-</category>
-<category xml:id="tlaGNGMIFZN5JHRRDRVMQTTWMLYNU">
-<catDesc>Schweizerisches Landesmuseum</catDesc>
-</category>
-<category xml:id="tlaP6SW2T6K4NAVHJ2SFD7W7LRBWI">
-<catDesc>Völkerkundemuseum</catDesc>
-</category>
-<category xml:id="tlaRTBHRS74LBHIDAAXEHGBGX7QXQ">
-<catDesc>Museum Rietberg</catDesc>
-</category>
-<category xml:id="tlaT4KXCM3GYZDBRMAQO7FYRQ2PYE">
-<catDesc>Archäologische Sammlung der Universität Zürich</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaP3QTRAGUOBEOLOWBEIIJQHWNA4">
-<catDesc>(Städte A-K)</catDesc>
-<category xml:id="tla2EKQHEKPFFCJ5H5TR2BCEMN6CM">
-<catDesc>Fribourg</catDesc>
-<category xml:id="tlaJAN26N2C3JCGVL3L73HNFE3DBA">
-<catDesc>Institut Biblique de l&#039;Université</catDesc>
-</category>
-<category xml:id="tlaLHPQIRDU7RCVHIHGJ6GQGKXDJE">
-<catDesc>Service Archéologique Cantonal</catDesc>
-</category>
-</category>
-<category xml:id="tla2FOMNU2M7ZEPVN7U7QNAZFX2IY">
-<catDesc>Chur</catDesc>
-<category xml:id="tlaDT3RS3JLAJC7JFIX7M2YJZSG5I">
-<catDesc>Rhätisches Museum</catDesc>
-</category>
-</category>
-<category xml:id="tla2JJQ6GOM2BFPFCIKCKECV4GMOU">
-<catDesc>Augst</catDesc>
-<category xml:id="tlaWJIXFRIEIFFAVHVT64576TMLV4">
-<catDesc>Römermuseum</catDesc>
-</category>
-</category>
-<category xml:id="tla5OA3PS6DJJDZ7OXS5AA2TG4SAE">
-<catDesc>Aarau</catDesc>
-<category xml:id="tlaPYWM5TSSVRHVZPUBRSCTAAHKXY">
-<catDesc>Aargauer Kunsthaus</catDesc>
-</category>
-</category>
-<category xml:id="tlaBSRQLJR2KNBKPCDVYFWEG4RBVY">
-<catDesc>Cologny</catDesc>
-<category xml:id="tla3RIHQ7RXGFF67H7ZUMPK6GEDWE">
-<catDesc>Fondation Bodmer</catDesc>
-</category>
-</category>
-<category xml:id="tlaBYMJUU4VNNFI7E5PCPL4TSUOMU">
-<catDesc>Brissago</catDesc>
-<category xml:id="tlaZZE4AUUHZFEZZDJL7GK24TLKSQ">
-<catDesc>Municipalité</catDesc>
-</category>
-</category>
-<category xml:id="tlaC3QUWQZFWBHEFNAUCGP5W6XOAM">
-<catDesc>Burgdorf</catDesc>
-<category xml:id="tla4TEIGMBT2FG4DK6D7WSD65F3ME">
-<catDesc>Museum für Völkerkunde</catDesc>
-</category>
-</category>
-<category xml:id="tlaFWMJZREC6NGR5LKE5NG5Z3ATAI">
-<catDesc>Genf</catDesc>
-<category xml:id="tlaAKQYRURTZJEOJIHR7OI6VMPN6A">
-<catDesc>Musée d&#039;Art et d&#039;Histoire</catDesc>
-</category>
-<category xml:id="tlaCHJCPB7RIBDMHDKDYRQLNTAQQE">
-<catDesc>Musée Barbier-Muller</catDesc>
-</category>
-<category xml:id="tlaFTAAHSL4WVHH5COW67SIXIHI7Y">
-<catDesc>Musée Historique de la Réformation et Musée Jean-Jacques Rousseau</catDesc>
-</category>
-<category xml:id="tlaGFDTQSLFYVEYVAOR7VF37HUPPE">
-<catDesc>Fondation M. Bodmer</catDesc>
-</category>
-<category xml:id="tlaJFRBJ4OEANFYDAQV22IMMZGCUY">
-<catDesc>Bibliothèque Publique et Universitaire</catDesc>
-</category>
-<category xml:id="tlaWESKCSPLAVGQTPCHA6MEOLRMVM">
-<catDesc>Musée d&#039;Ethnographie</catDesc>
-</category>
-</category>
-<category xml:id="tlaFWXTWMRRAFD3VKIV26A5RXBICM">
-<catDesc>Frauenfeld</catDesc>
-<category xml:id="tlaEAEN42MSUBEEDKAAYQXAOAPDWA">
-<catDesc>Museum des Kantons Thurgau</catDesc>
-</category>
-<category xml:id="tlaLTP3BNNO6NGLDCEJL3VEE4UQLY">
-<catDesc>Historisches Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaG7E4AKCSZZFXFE6PI4E5Y3TJUI">
-<catDesc>Bellinzona</catDesc>
-<category xml:id="tlaSAA3EV4NBZH4FFSJAL2ZRECEAU">
-<catDesc>Museo Civico</catDesc>
-</category>
-</category>
-<category xml:id="tlaGYWBHJMFDJADXAELH53ZXJ57CI">
-<catDesc>Binn</catDesc>
-<category xml:id="tlaHGYUSNMSANGSFOD7YP7C5DQUW4">
-<catDesc>Regionalmuseum Graeser-Andenmatten</catDesc>
-</category>
-</category>
-<category xml:id="tlaHSMNBEGOCFHUFJASQCYTJYTHAU">
-<catDesc>Appenzell</catDesc>
-<category xml:id="tlaWYZVUX364FGLRPBIZPKL765YPM">
-<catDesc>Museum Appenzell</catDesc>
-</category>
-</category>
-<category xml:id="tlaNH7TFE5PTBEHRIUXSVCKRPXZU4">
-<catDesc>Brugg</catDesc>
-<category xml:id="tlaEI3Q2WEZAVBTJAFWBE73GQCFTY">
-<catDesc>Vindonissa-Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaTNSGMX6UOBFN7MBJF7SMPNRRBE">
-<catDesc>Chambésy</catDesc>
-<category xml:id="tla5AQHXY3K3NEBLMJEPRW4IXFSWA">
-<catDesc>Musée des Suisses</catDesc>
-</category>
-</category>
-<category xml:id="tlaVNOHGYPO4ZFSTD747AXDQRP3TM">
-<catDesc>Bern</catDesc>
-<category xml:id="tlaHKFUA2X7KBASJPZ6VCMZHR6YZQ">
-<catDesc>Historisches Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaW3EUJYBTLNBWRIZT2TJMDPNRG4">
-<catDesc>Basel</catDesc>
-<category xml:id="tla26KAT7KXABA3RBUMT53CYQHUWU">
-<catDesc>Historisches Museum</catDesc>
-</category>
-<category xml:id="tla4MMERKR2TREI5IPKUDMMNEL334">
-<catDesc>Schweizerisches Sportmuseum</catDesc>
-</category>
-<category xml:id="tlaAXEQBTP3OJA3LOVYLUN73LSW54">
-<catDesc>Museum der Kulturen</catDesc>
-</category>
-<category xml:id="tlaDOBOPJ5ZQND6NMYKXDZKQBGTAI">
-<catDesc>Antikenmuseum</catDesc>
-</category>
-<category xml:id="tlaK7ZLDPXOKRCQBCD7EYZPEHHOO4">
-<catDesc>Ägyptologisches Seminar</catDesc>
-</category>
-</category>
-<category xml:id="tlaWRAOEBQIONABRNYFY77T3U74TM">
-<catDesc>Avenches</catDesc>
-<category xml:id="tla2CCASUSKQBC55IXIX2JBDLSTJM">
-<catDesc>Musée Romain d&#039;Avenches</catDesc>
-</category>
-</category>
-<category xml:id="tlaXBYWHTQCXREMFATPO6FOUEI4TM">
-<catDesc>Herisau</catDesc>
-<category xml:id="tlaM5ZJSUWXSNBCZPLVONX4ZFKPA4">
-<catDesc>Historisches Museum</catDesc>
-</category>
-</category>
-</category>
-</category>
-<category xml:id="tlaD7ZO3GF7QJCXBH32UVUNUSVBJQ">
-<catDesc>Österreich</catDesc>
-<category xml:id="tla2LUNK54PZRBITJTLGHX2AB44ZY">
-<catDesc>Wien</catDesc>
-<category xml:id="tla7AFQFIQLZBGKLDFREJCVYIWEAU">
-<catDesc>Kunsthistorisches Museum</catDesc>
-</category>
-<category xml:id="tlaGVQEIIVN4BBTHLNRIB25URIY5U">
-<catDesc>Museum für Völkerkunde</catDesc>
-</category>
-<category xml:id="tlaIMWDV7E4KRD2POO6HI3QBOOACE">
-<catDesc>Theresianische Akademie</catDesc>
-</category>
-<category xml:id="tlaMIJE6VYTD5BULLBWPYAZGSDSCU">
-<catDesc>Papyrusmuseum</catDesc>
-</category>
-<category xml:id="tlaYVNQORT5NNE5JFT4WDYMWXTF2M">
-<catDesc>S. Freud-Haus</catDesc>
-</category>
-</category>
-<category xml:id="tla3CLBHWFCLFCNVPPBCL6N5S5VWA">
-<catDesc>Graz</catDesc>
-<category xml:id="tlaLM4NBUYXHJHR5GTW6W6VABKIUI">
-<catDesc>Steiermärkisches Landesmuseum Joanneum</catDesc>
-</category>
-</category>
-<category xml:id="tla3GTKC2FSJVAMHEHB244DUJBOSQ">
-<catDesc>Innsbruck</catDesc>
-<category xml:id="tlaCY5JRTL2DNEG3MI2YA6DVHQV3Q">
-<catDesc>Tiroler Landesmuseum Ferdinandeum</catDesc>
-</category>
-</category>
-<category xml:id="tla5OIMHA3JXBACDHGSJXLT2XVA5Y">
-<catDesc>Linz</catDesc>
-<category xml:id="tla2JCS6H2M4ZA67NU3OQDSOZRIS4">
-<catDesc>Stadtmuseum Nordico</catDesc>
-</category>
-<category xml:id="tlaLRCK3EV5KZF23PZOEENQEWGTSM">
-<catDesc>Oberösterreichisches Landesmuseum Francisco-Carolinum</catDesc>
-</category>
-</category>
-<category xml:id="tla5V7APDEQ3VGNTDQP6IRSS7XUWY">
-<catDesc>Kremsmünster</catDesc>
-<category xml:id="tlaPU3IQTL2IBF4NKPJNTM5HWZGSE">
-<catDesc>Benediktinerstift</catDesc>
-</category>
-</category>
-<category xml:id="tla7VSATVGONVCWFNZAUNZRDP6K5A">
-<catDesc>Klagenfurt</catDesc>
-<category xml:id="tla2NCRDS6GMFGSFFZUJ46G6DIVFQ">
-<catDesc>Kärntner Landesmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tlaH4GXYW5AYVD7FFBVFSIN7CF4SY">
-<catDesc>Obertraun am Hallstättersee</catDesc>
-<category xml:id="tlaDCJP5NVOWBFS3PLMZPQNZ2JOP4">
-<catDesc>Dachsteinmuseum (Höhlenmuseum)</catDesc>
-</category>
-</category>
-<category xml:id="tlaQPCUAM4BGJA7LH66WMKALKGQ2I">
-<catDesc>Baden (bei Wien)</catDesc>
-<category xml:id="tlaTPAXV2OPKVETRLT2UL3L33KIU4">
-<catDesc>Rolettmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tlaUNGFYUKJQBB4XIDXA5RT7T5JXM">
-<catDesc>Bad Deutsch-Altenburg</catDesc>
-<category xml:id="tlaHQVX4GHSUVHHFPNEPY3MGXXMDY">
-<catDesc>Museum Carnuntinum</catDesc>
-</category>
-</category>
-<category xml:id="tlaYBTKWUAB2NCJHDYLSBAGZQ6T2Q">
-<catDesc>Hallstatt</catDesc>
-<category xml:id="tlaVVYHNG7LPJDKBHBTUDUNM6IM7I">
-<catDesc>Prähistorisches Museum / Heimathaus</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaE4RVNBDYJFCK5K5OZJ66CTGYTA">
-<catDesc>Kroatien</catDesc>
-<category xml:id="tla2EZIWRFNENDBBK7BOCOVCUKNAQ">
-<catDesc>Varazdin</catDesc>
-<category xml:id="tlaXZ5YVBGWWFFMJPX5DD4N7ZU2RA">
-<catDesc>Ägyptische Sammlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaEEJSNJ5RAJARVJAYOZGXSSO6VQ">
-<catDesc>Osijek</catDesc>
-<category xml:id="tlaB3ASSJSSYZARNCDQLFKY4RIQ2A">
-<catDesc>Ägyptische Sammlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaJ54KHDMX4BCB5H6EQMB3YIOQAI">
-<catDesc>Pula</catDesc>
-<category xml:id="tlaSDJ2B2QKONESFFAY4ARALLFDBE">
-<catDesc>Arheoloski Muzej Istre</catDesc>
-</category>
-</category>
-<category xml:id="tlaK4ZL3X6DOFDOVA2XEZYN2Z34PY">
-<catDesc>Split</catDesc>
-<category xml:id="tlaLKR4BWWLNBF2XJUEF6SAK53WU4">
-<catDesc>Ägyptische Sammlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaY5TEAWFPOZDGNBM7YVUWJSAS74">
-<catDesc>Zagreb</catDesc>
-<category xml:id="tlaBPTMUR64FNGB7FDANZ7EA4LANQ">
-<catDesc>Arheoloski Muzei</catDesc>
-</category>
-<category xml:id="tlaHMYPPLQF5ZADJA3ZFHZSNGK2VI">
-<catDesc>Muzej Mimara</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaISBVIZAHLZAAZHXKTYYS5ISAIA">
-<catDesc>Vatikan</catDesc>
-<category xml:id="tlaVUCVXRSCINADZJQHITJQKYJ7VE">
-<catDesc>Vaticanstadt</catDesc>
-<category xml:id="tla72OFJF74IBC4XDLVCB5WN4QT7Y">
-<catDesc>Museo Gregoriano Egizio</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaK2HUMC6E2RGP7DUT6FLV6LKSHI">
-<catDesc>Rumänien</catDesc>
-<category xml:id="tla3AI4VEYAEVF3HECRKKCHPGVMA4">
-<catDesc>Bukarest</catDesc>
-<category xml:id="tlaHI2ITBZT3BDPBAPNO4MZGU5U7I">
-<catDesc>Muzeul National de Antichitatí</catDesc>
-</category>
-<category xml:id="tlaQSOKFRSVIBD3XGMMJEPQY7PX3U">
-<catDesc>Museum of History</catDesc>
-</category>
-</category>
-<category xml:id="tla4KUGR2PLKJD4LBGQCHNDJ6EEUY">
-<catDesc>Iasi</catDesc>
-<category xml:id="tlaYBFDYCY4QFGR7GTM6QJTYWIHGE">
-<catDesc>Historical and Archaeological Institute</catDesc>
-</category>
-</category>
-<category xml:id="tlaGNS2OUBKZRBQRMVTOQCTLLP674">
-<catDesc>Oradea</catDesc>
-<category xml:id="tlaP3QHMCBANZGJVNGA7VD33WZA34">
-<catDesc>Muzeul Tarii Crisurilor</catDesc>
-</category>
-</category>
-<category xml:id="tlaIHW6JCI5EBFO7M7UEQK3QROWXA">
-<catDesc>Cluj-Napoca</catDesc>
-<category xml:id="tla4CQ4MOKMA5EZVLZWVZN2AGWXWQ">
-<catDesc>Muzeul de Istorie al Transilvaniei</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaKPHLVU2DQ5HEJDGBEBKS6DDCLI">
-<catDesc>Gibraltar</catDesc>
-<category xml:id="tla5BIKTQRFQBHYLC23MHGTDW476U">
-<catDesc>Gibraltar</catDesc>
-<category xml:id="tlaARBUCRCLRBHU3BTKUNG74OR2FE">
-<catDesc>Gibraltar Museum</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaL4HM5COZSVEW5NOJOOJWRZGTMU">
-<catDesc>Polen</catDesc>
-<category xml:id="tla2AKPM2P7DFD3JIGWMNCNTNJGDA">
-<catDesc>Warschau</catDesc>
-<category xml:id="tlaXGKCTTRAGVDJPB6RDU62JI5AMQ">
-<catDesc>Muzeum Narodowe</catDesc>
-</category>
-</category>
-<category xml:id="tlaACW7IA36ZRG6ZLQHF4TKNIC2UY">
-<catDesc>Goluchow</catDesc>
-<category xml:id="tla7HA3JFOOPBHBXE4L5NB5L32J24">
-<catDesc>Muzeum</catDesc>
-</category>
-</category>
-<category xml:id="tlaDMLWBVDOZZBWDECVFEZ4RK37JY">
-<catDesc>Raciborz</catDesc>
-<category xml:id="tla7JYJAZXD7FECDP447DLSY2CERU">
-<catDesc>Muzeum w Raciborzu</catDesc>
-</category>
-</category>
-<category xml:id="tlaHCY4KWPDRVFIZOBSHHTBUBMLKY">
-<catDesc>Poznan</catDesc>
-<category xml:id="tla2AV2LYGFZBGIVI374AP2DTJWYM">
-<catDesc>Muzeum Archeologiczne</catDesc>
-</category>
-<category xml:id="tlaXD2Y6GVGPRHTXGE44QSRT24VZE">
-<catDesc>Muzeum Narodowe w Poznaniu</catDesc>
-</category>
-</category>
-<category xml:id="tlaKN5SJXTZ4FB4DEJFF5SUUUKR3M">
-<catDesc>Krakau</catDesc>
-<category xml:id="tlaEZOEUUO7U5HRPFNO663SWM463M">
-<catDesc>Katedra Archeologii Srodziemnomorskiej Uniwersystetu Jagiellonskiego</catDesc>
-</category>
-<category xml:id="tlaLCVIA7MNIFDUVADPPJHCH6RU24">
-<catDesc>Muzeum Archeologiczne w Krakowie</catDesc>
-</category>
-<category xml:id="tlaMUZAUBPY6FBUHM3PJ2ZJPDMMDA">
-<catDesc>Muzeum Narodowe w Krakowie (Muzeum Czartoryskich)</catDesc>
-</category>
-</category>
-<category xml:id="tlaO2DJLRV72NEKRLKTQOBOW26E7A">
-<catDesc>Bielsko Biala</catDesc>
-<category xml:id="tlaUXKM5RICOFDGZENPO7OYAEUOO4">
-<catDesc>Muzeum Okregowe</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaLDK6YGSMAJEWFESCY56W6OGVMQ">
-<catDesc>Slowakei</catDesc>
-<category xml:id="tla5JRKTDPLAZBMZMYKB3MPKCQPFA">
-<catDesc>Buchlov</catDesc>
-<category xml:id="tla74PZR7J7ZRHQFJ4EJSFI2JEV6A">
-<catDesc>Státní Hrad</catDesc>
-</category>
-</category>
-<category xml:id="tlaMLUIJSSJ3VBQPJJJHGYLWKZGIM">
-<catDesc>Rimavská Sobota</catDesc>
-<category xml:id="tla2JVRBV4FQNDNPKKFNBOPXWZZSI">
-<catDesc>Gemerské Muzeum</catDesc>
-</category>
-</category>
-<category xml:id="tlaNYUASDMZHFHSPGLZUE4SEYBWXM">
-<catDesc>Betliar</catDesc>
-<category xml:id="tlaFK4JFLV64RFMRO5GARXAWD5F3Q">
-<catDesc>Státny Kultúrny Majetok</catDesc>
-</category>
-</category>
-<category xml:id="tlaSSHXE7EC5NFH7N6J6HJPT7SY6Q">
-<catDesc>Bratislava</catDesc>
-<category xml:id="tlaVVS3V25BCVAHHDZSC247MP2SAA">
-<catDesc>Slovenské Národné Muzeum, Prírodovedecky Ustav</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaM5FWTACXIFHZXK3QHQGJVCQYEA">
-<catDesc>Portugal</catDesc>
-<category xml:id="tla3GYD2QRZ5RCATDJMMXFU2YELDA">
-<catDesc>Cascais</catDesc>
-<category xml:id="tlaQE75IWW2IJDP3EPT6WQ2WJJNTY">
-<catDesc>Museu Condes de Castro Guimaraes</catDesc>
-</category>
-</category>
-<category xml:id="tlaI42ED2QRQFHWRFTMVBRI2VK6WU">
-<catDesc>Vila Viçosa</catDesc>
-<category xml:id="tlaFRWVEDOQOFD6XDH43PKWMSVJVQ">
-<catDesc>Casa de Bragança</catDesc>
-</category>
-</category>
-<category xml:id="tlaJYMLAQCNKFDUVAJ6D25SC2OO7I">
-<catDesc>Porto</catDesc>
-<category xml:id="tlaZFZU4PWKJBG7DIGCV56ADVDDBA">
-<catDesc>Museu Nacional</catDesc>
-</category>
-</category>
-<category xml:id="tlaPSTNV7S45BGG7NB5AB4UX3KY2Y">
-<catDesc>Caramulo</catDesc>
-<category xml:id="tlaPCEBWVYS35FQRCY7PU5AKJR4QI">
-<catDesc>Museu</catDesc>
-</category>
-</category>
-<category xml:id="tlaSEBAFUVEYVFPZHGXAHXJ4ZRHVU">
-<catDesc>Lissabon</catDesc>
-<category xml:id="tlaA2R6NGXAEJCYRDLV2WE5545F4A">
-<catDesc>Sociedade de Geografia</catDesc>
-</category>
-<category xml:id="tlaKBY6TFZUCJFULMEMFF2HSEWI5Q">
-<catDesc>Museu Nac. de Arte Antiga</catDesc>
-</category>
-<category xml:id="tlaLJIGPTQ225B4TGJO5E5LRKPOLQ">
-<catDesc>Museu Nac. de Arqueologia, Museu Etnológico do Ultramar</catDesc>
-</category>
-<category xml:id="tlaVROYEIGGEFD2ZFPDOOC27KAZZQ">
-<catDesc>Museu Calouste Gulbenkian</catDesc>
-</category>
-<category xml:id="tlaXUI5Z2BZ3ZDHZMSQNPNNLRKP4Y">
-<catDesc>Museu Arqueológico</catDesc>
-</category>
-</category>
-<category xml:id="tlaWKBR5KY5XJC4JOHIWFJIOELVPA">
-<catDesc>Alenquer</catDesc>
-<category xml:id="tlaHW3VBRV7BNAOZAMXGX7HLYZTIM">
-<catDesc>Museu H. Cabaço</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaNHYYWK2VKRFDLCHPWC7ZZCDLPA">
-<catDesc>Estland</catDesc>
-<category xml:id="tlaSUQWT6KAYVBFLPOVFEDT45ITHY">
-<catDesc>Tallin</catDesc>
-<category xml:id="tla2NIDW5JIOFAR3FEL4WTREMILXU">
-<catDesc>Museum of History of Estonia</catDesc>
-</category>
-</category>
-<category xml:id="tlaYATZQV7YYZFK7BXWODSYV5TVPQ">
-<catDesc>Tartu</catDesc>
-<category xml:id="tlaO3XEVTB5FVD6VAA4P4R3UOZHQQ">
-<catDesc>Tartu University Museum of Classical Antiquities</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaNIQ5LRVEXVFSZMOTLAE5KCLK64">
-<catDesc>Frankreich</catDesc>
-<category xml:id="tla2BDOFKIH2NB6JHSC7GOL7K2NGU">
-<catDesc>(Städte M-P)</catDesc>
-<category xml:id="tla3ATAT65MORBOHBFIUA4SCYWP2U">
-<catDesc>Mülhausen (Muhouse)</catDesc>
-<category xml:id="tlaK2H74IJIQZBZRO2CRJNGDE6DNQ">
-<catDesc>Musée Historique</catDesc>
-</category>
-<category xml:id="tlaNGGUKMHVWFEV7HT5O6VYNKCD24">
-<catDesc>Musée de la Chapelle Saint-Jean</catDesc>
-</category>
-</category>
-<category xml:id="tla5T2YIUE5JBDUXIXTK2JAMP35PU">
-<catDesc>Provins</catDesc>
-<category xml:id="tlaPYWMRTSEL5HJRIJPQKPRQS46QA">
-<catDesc>Bibliothèque Municipal</catDesc>
-</category>
-</category>
-<category xml:id="tla6QESVROOSRCKJET3ZSA4A36CJA">
-<catDesc>Meudon</catDesc>
-<category xml:id="tla5PH5OTPQUZEYVIEXWKO6GC55EM">
-<catDesc>Musée d&#039;Art et d&#039;Histoire</catDesc>
-</category>
-</category>
-<category xml:id="tlaCRKL5Y562ZHBJHDLCV5PHJUNXM">
-<catDesc>Paris</catDesc>
-<category xml:id="tla4KU3JRSY4BBVJFOH3FB57I3Y6Y">
-<catDesc>Musée Guimet</catDesc>
-</category>
-<category xml:id="tlaBTWIPDBCP5DVBI4WM7DOKUC2N4">
-<catDesc>Musée du Louvre</catDesc>
-</category>
-<category xml:id="tlaDG64QZYUV5F6LNZ5L7B2XM656E">
-<catDesc>École Pratique des Hautes Études, 5ème Section, Sciences Religieuses</catDesc>
-</category>
-<category xml:id="tlaEBJFFB3SJRD4DK2SKMNDBNNJDU">
-<catDesc>Musée du Théâtre National de l&#039;Opéra</catDesc>
-</category>
-<category xml:id="tlaFYVLU536IZBOXFOJQWJUZAFOBQ">
-<catDesc>Musée Auguste Rodin</catDesc>
-</category>
-<category xml:id="tlaIBB52CZLFJHCZIRU7ZOY7SWDDY">
-<catDesc>Musée Jacquemart-André</catDesc>
-</category>
-<category xml:id="tlaMDXWG5HUFJHHXN5NP2DLBMIDIY">
-<catDesc>Fondation Custodia</catDesc>
-</category>
-<category xml:id="tlaOQR6AIYX5FFJ7BW7EQIUBIEL6E">
-<catDesc>Musée du Petit Palais</catDesc>
-</category>
-<category xml:id="tlaUIMFZ7SGL5FKFJCKKDR5K3AFFM">
-<catDesc>Museum National d&#039;Histoire Naturelle, Musée de l&#039;Homme</catDesc>
-</category>
-<category xml:id="tlaYAP2DV4PVBBITNRDUTZU7UZTOU">
-<catDesc>Bibliothèque Nationale, Cabinet des Médailles</catDesc>
-</category>
-</category>
-<category xml:id="tlaFF7GAHFIGBHSZK43753XXJ476I">
-<catDesc>Mâcon</catDesc>
-<category xml:id="tla2UNCY5AAXFFHHDCVT5DCJALXUU">
-<catDesc>Musée Municipal des Ursulines</catDesc>
-</category>
-<category xml:id="tlaXMGUWJF36ZHITNWGBZB5KHC244">
-<catDesc>Musée Lamartine</catDesc>
-</category>
-</category>
-<category xml:id="tlaFTJDINOA5ZHPDAWFFPPQFEHOGI">
-<catDesc>Nîmes</catDesc>
-<category xml:id="tlaJHZSXEQ7HBE3NNG4UP6FMBXENI">
-<catDesc>Musée des Antiques, Musée Archéologique</catDesc>
-</category>
-</category>
-<category xml:id="tlaIBGUJSR7ONE3BFSVXQB3YI7I5Y">
-<catDesc>Narbonne</catDesc>
-<category xml:id="tlaFMFLGKEMSFENTECPWNSY776TKA">
-<catDesc>Musée d&#039;Archéologie et de Préhistoire</catDesc>
-</category>
-</category>
-<category xml:id="tlaKKIOU2KO7JDFZFLL26C56N7IUQ">
-<catDesc>Nantes</catDesc>
-<category xml:id="tla5T73WFP7WRHIZJO5EKTLX2GX7Y">
-<catDesc>Musée Dobrée</catDesc>
-</category>
-<category xml:id="tlaZAQQVYHC5ZBMFBAXTRSVH3TDN4">
-<catDesc>Musée du Château, Musée des Arts Décoratifs et d&#039;Art Populaire</catDesc>
-</category>
-</category>
-<category xml:id="tlaKMTS72KBHZGWLBQP4N63KC4U5Y">
-<catDesc>Périgueux</catDesc>
-<category xml:id="tlaAIL6UEAEZJGO5BMS44ZAEGVHKI">
-<catDesc>Musée du Périgord</catDesc>
-</category>
-</category>
-<category xml:id="tlaLTF3FVLBZRAB5A4F7OF43LA7YU">
-<catDesc>Moûtiers</catDesc>
-<category xml:id="tlaDKTVKCZT6BHSBDERQCPL3D7P2Q">
-<catDesc>Musée de l&#039;Académie</catDesc>
-</category>
-</category>
-<category xml:id="tlaNNX5RWFRZJAHRPCUDBX3Q4PHU4">
-<catDesc>Morlaix</catDesc>
-<category xml:id="tla6ENT5TYNYZEGZN36Y5YHTUZ2CM">
-<catDesc>Musée des Jacobines</catDesc>
-</category>
-</category>
-<category xml:id="tlaP65IVL6MZBFJBHMAI5VYOONAYY">
-<catDesc>Marseille</catDesc>
-<category xml:id="tlaRHVGLZMZZRASTKOBEC4IT7QVPM">
-<catDesc>Musée d&#039;Archéologie Mediterranéenne</catDesc>
-</category>
-<category xml:id="tlaZGMJESBWQRGBTDX4YAVOMA5X7I">
-<catDesc>Musée de la Vieille Charité</catDesc>
-</category>
-</category>
-<category xml:id="tlaPJGOFMSSMRDBROFHAQ66A3Z2IA">
-<catDesc>Nancy</catDesc>
-<category xml:id="tlaGIKQ2JE4PRFNXER3IECRPZWNDI">
-<catDesc>Musée Historique Lorrain</catDesc>
-</category>
-</category>
-<category xml:id="tlaQMJ3GP2RWZD35E7Q7RM2F46BYA">
-<catDesc>Paray-le-Monial</catDesc>
-<category xml:id="tlaJGSYSWT3HVB35DHWFEFPITOKFM">
-<catDesc>Musée Municipal, Musée d&#039;Art Sacré le Hiéron</catDesc>
-</category>
-</category>
-<category xml:id="tlaQPBDPJRQ2VHDBO2JNMDW6QHTPE">
-<catDesc>Malmaison (Rueil-Malmaison)</catDesc>
-<category xml:id="tla3JWUCBL5B5AV3BZTO2RU6T5P3M">
-<catDesc>Châteaux de Malmaison</catDesc>
-</category>
-</category>
-<category xml:id="tlaR5QC36FC6ZBRZJWEFFI362MCNI">
-<catDesc>Pau</catDesc>
-<category xml:id="tlaYGC2OBP5PVGBDE22TH7JFSPJII">
-<catDesc>Musée des Beaux-Arts</catDesc>
-</category>
-</category>
-<category xml:id="tlaSGS7KCYJJNEK5HTHWT66JYRI3A">
-<catDesc>Montbrison</catDesc>
-<category xml:id="tlaRBD6NQFSBFEGFNBPGKWZ5QEZSQ">
-<catDesc>Musée d&#039;Allard</catDesc>
-</category>
-</category>
-<category xml:id="tlaTQDHU76W55BYHEL5LDU6KKCNJQ">
-<catDesc>Montargis</catDesc>
-<category xml:id="tlaZIX5N3P3QRCAJPCWB2TCWRZ66Y">
-<catDesc>Musée du Gâtinais</catDesc>
-</category>
-</category>
-<category xml:id="tlaTVBNTFROSZBFNLL6O3CHDUZLMM">
-<catDesc>Orléans</catDesc>
-<category xml:id="tlaXAI5V5CGH5EFZMLF5PQIMSL26Q">
-<catDesc>Musée d&#039;Histoire</catDesc>
-</category>
-</category>
-<category xml:id="tlaUKPK4LCCW5HWRP6MXL6COVJQXI">
-<catDesc>Poitiers</catDesc>
-<category xml:id="tla5DQ3CF7KWNCNRJNITFRCX77N2E">
-<catDesc>Musée de l&#039;Hypogée des Dunes</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaCXFNJ3BHZ5FOVLW5UP5SFSMBUY">
-<catDesc>(Städte C)</catDesc>
-<category xml:id="tla3AYQZKQOLFAWVBOLQPW6GCZ5BY">
-<catDesc>Carpentras</catDesc>
-<category xml:id="tlaZHUOA2BOQVDQHLENIHBJALPYAU">
-<catDesc>Musée Lapidaire</catDesc>
-</category>
-</category>
-<category xml:id="tla4M52RKA74JFL7BSQ6WZ4MRCBCI">
-<catDesc>Clamécy</catDesc>
-<category xml:id="tlaOTHTCMGAX5DRLMM3IE3X4AF22Q">
-<catDesc>Musée Romain Rolland</catDesc>
-</category>
-</category>
-<category xml:id="tla6X4KSDEIKVGDBIYSLFIKCXJWMY">
-<catDesc>Chartres</catDesc>
-<category xml:id="tlaNIBA7SCA7VBF3KLEETCNLIKNBY">
-<catDesc>Musée Municipal</catDesc>
-</category>
-</category>
-<category xml:id="tla7U7AHKDKBZBUVAEIOTF67IUTIY">
-<catDesc>Colmar</catDesc>
-<category xml:id="tlaJXN4OSLUIJALVCS5Q43C5DWUJ4">
-<catDesc>Musée d&#039;Histoire Naturelle</catDesc>
-</category>
-</category>
-<category xml:id="tlaAGALNC42UZFP5JFYLP6OUQB6RA">
-<catDesc>Caen</catDesc>
-<category xml:id="tla7CMXRITPEBDTJHPWYGFHOB6QQI">
-<catDesc>Musée Langlois</catDesc>
-</category>
-</category>
-<category xml:id="tlaB5W4NQRIQJA2PEYYL65MHEED2M">
-<catDesc>Chateau-Gontier</catDesc>
-<category xml:id="tlaU6PWETSDYVCY7MXIGTKG33HMKU">
-<catDesc>Musée Municipal</catDesc>
-</category>
-</category>
-<category xml:id="tlaDAK4KVQRWRCVRIMWYXYO4NESHU">
-<catDesc>Cognac</catDesc>
-<category xml:id="tla4NSQ7OOCJJAXXAPKK5N6DSFKXE">
-<catDesc>Musée de Cognac</catDesc>
-</category>
-</category>
-<category xml:id="tlaGNGN2PIYEVFALE766YIH5SHIMA">
-<catDesc>Châteauneuf-sur-Loire</catDesc>
-<category xml:id="tlaVGAP6FKWFRDKJF4H5U63C5VJRE">
-<catDesc>Ägyptische Sammlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaMSWKV5SNGNG3FBTFVWKK25SP7I">
-<catDesc>Chateaudun</catDesc>
-<category xml:id="tlaZZLZSQHCFJAYBFVAGMLHWQLONM">
-<catDesc>Musée Municipal</catDesc>
-</category>
-</category>
-<category xml:id="tlaNYC43X53RFA2LCRNHXGQZOHVXA">
-<catDesc>Calais</catDesc>
-<category xml:id="tla3QO4PTAGKNA5BENINLPDRWW3DU">
-<catDesc>Musée des Beaux-Arts</catDesc>
-</category>
-</category>
-<category xml:id="tlaPDBC4YCEQRGHZJJ7FFTLEJRHNQ">
-<catDesc>Chalon-sur-Saône</catDesc>
-<category xml:id="tlaTSRPSFRMANEIHCCLEG2AFFBIEA">
-<catDesc>Musée Denon</catDesc>
-</category>
-</category>
-<category xml:id="tlaPEI4BO52JZHIDM4V5BXWPGZUN4">
-<catDesc>Clermont-Ferrand</catDesc>
-<category xml:id="tlaEF3FUGUJ6NC5LGWJLYL47M353Q">
-<catDesc>Musée des Beaux-Arts</catDesc>
-</category>
-<category xml:id="tlaQEZ72H6S7RD2FGFVGIDZG7YR5A">
-<catDesc>Musées Municipaux</catDesc>
-</category>
-</category>
-<category xml:id="tlaPGEZO2NRARE7RAOM2ZSBYVMJLY">
-<catDesc>Cannes</catDesc>
-<category xml:id="tla4SXYS4TMWVBVZFZNWV4JH7MKDI">
-<catDesc>Musée de la Castre</catDesc>
-</category>
-</category>
-<category xml:id="tlaPOUN7TGZYZCJ7DCM6YBKR5JA7A">
-<catDesc>Chateauroux</catDesc>
-<category xml:id="tlaKG6C7UEL7RBLNOY35XA7LMAUGI">
-<catDesc>Musée Bertrand</catDesc>
-</category>
-</category>
-<category xml:id="tlaRDD4FHZRSVCG3M4DLDSYUUZBNI">
-<catDesc>Cherbourg</catDesc>
-<category xml:id="tlaIMUBR7Z3CNF4VDSGKILUYPOAMM">
-<catDesc>Ägyptische Sammlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaS6ROZ6MX3FBBHEC4ZCBY2V3ZTE">
-<catDesc>Cahors</catDesc>
-<category xml:id="tlaGI2RL67MONB6LJBOBQ6NQ5X6PE">
-<catDesc>Musée Municipal</catDesc>
-</category>
-</category>
-<category xml:id="tlaYBWBNVGCLVEADBDAPF2UAO5PJU">
-<catDesc>Cluny</catDesc>
-<category xml:id="tlaWFEY5OQTP5HI3L4OPNCNQQN33Q">
-<catDesc>Musée Ochier</catDesc>
-</category>
-</category>
-<category xml:id="tlaYYQG4PUCQRBNBN2VKQ5V5TNZV4">
-<catDesc>Chambéry</catDesc>
-<category xml:id="tlaVXLKI3X3SND4PLCD4CSBZG3YTI">
-<catDesc>Musée Savoisien</catDesc>
-</category>
-</category>
-<category xml:id="tlaZ5TVRLTOFZFWTBSAPXZKRM3RSU">
-<catDesc>Compiègne</catDesc>
-<category xml:id="tlaWHXNO6B6K5BJFADNGOL3GTOTXE">
-<catDesc>Musée Municipal Antoine Vivenel</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaOX66QGQOTFHFJG4ZFSPB6XYWFU">
-<catDesc>(Städte Q-Z)</catDesc>
-<category xml:id="tla3BZIFME2EJE45PLKFYUBRKNWHY">
-<catDesc>Varzy</catDesc>
-<category xml:id="tlaEM3NKIOKOBBEXGYI6UAXA4D3RA">
-<catDesc>Musée Municipal</catDesc>
-</category>
-</category>
-<category xml:id="tla3X4IRKLGZVF7XNTGQHD4MY4UZU">
-<catDesc>Troyes</catDesc>
-<category xml:id="tlaT5LZPEE5CRBZHIGSSV2KEBW7SU">
-<catDesc>Musée des Beaux-Arts et d&#039;Archéologie</catDesc>
-</category>
-</category>
-<category xml:id="tla53TYR2JZVZHABP7RMGZFHKRP2Y">
-<catDesc>Toulon</catDesc>
-<category xml:id="tla46XFFO2E4NAJBBCFJFIVNZXWWM">
-<catDesc>Musées de Toulon, Musée d&#039;Art et d&#039;Histoire</catDesc>
-</category>
-</category>
-<category xml:id="tla62WCAHWOQBEQRH7FGGOCFN36ZY">
-<catDesc>Saint-Omer</catDesc>
-<category xml:id="tlaIDZUARBCUVEXFBUUO4HOXVXCAY">
-<catDesc>Musée Sandelin et Musée Henri-Dupuis</catDesc>
-</category>
-</category>
-<category xml:id="tla6OQTJ67DEVH5VPHLBP3IF7FRNI">
-<catDesc>Verdun</catDesc>
-<category xml:id="tlaUNCRPVLPCZEWVIW7TTMSCIRI6M">
-<catDesc>Musée de la Princerie</catDesc>
-</category>
-</category>
-<category xml:id="tlaCBGVXVQVEVFW5KJTEWBF44FDXM">
-<catDesc>Vienne</catDesc>
-<category xml:id="tlaQNG4FOCUTZDXHHO4OOWMGR53LQ">
-<catDesc>Musée des Beaux-Arts et d&#039;Archéologie</catDesc>
-</category>
-</category>
-<category xml:id="tlaFOE2MNJF2ZDPLCVUI5Z6OVPQDE">
-<catDesc>Vendôme</catDesc>
-<category xml:id="tla22DL5YQQL5BU7ILVNE7CIBHL5A">
-<catDesc>Musée Municipal</catDesc>
-</category>
-</category>
-<category xml:id="tlaGXCHJMAMLNGUJFRLDQ63KJC66Q">
-<catDesc>Vannes</catDesc>
-<category xml:id="tlaUWTQPGDETBESXP2DWAB7EJOWMI">
-<catDesc>Musée de la Société Polymathique du Morbihan</catDesc>
-</category>
-</category>
-<category xml:id="tlaJAP32FUWWFCPZADHS32KZ6P5C4">
-<catDesc>Sault</catDesc>
-<category xml:id="tlaNWTMJYGO5FCR7JLDBESX5MBBXE">
-<catDesc>Musée Municipal</catDesc>
-</category>
-</category>
-<category xml:id="tlaJCT33SYM6RB3BEIXRALAKHTN7M">
-<catDesc>Vitre</catDesc>
-<category xml:id="tlaB3BI5LCZLFGJPOXY62ZVNPQTMM">
-<catDesc>Musée d&#039;Arte d&#039;Histoire</catDesc>
-</category>
-</category>
-<category xml:id="tlaN5OCZG2IYRG3DHM6F2NZ6I7OAM">
-<catDesc>Sèvres</catDesc>
-<category xml:id="tla3QGBVITKEZDRLGE2O6EG2XFFXI">
-<catDesc>Musée de Céramique</catDesc>
-</category>
-</category>
-<category xml:id="tlaNX64K5XCL5BJ3PVP7QAXTMSRIE">
-<catDesc>Soissons</catDesc>
-<category xml:id="tlaPBRHID6CBJFHLL32LT5SHZ2JBQ">
-<catDesc>Musée Municipal</catDesc>
-</category>
-</category>
-<category xml:id="tlaQT34GO2UPBHLZDQGEOFUCEKJOY">
-<catDesc>Tours</catDesc>
-<category xml:id="tlaTWSAQ5DM7NFYDEMO4ZPFSKLZNU">
-<catDesc>Musée des Beaux-Arts</catDesc>
-</category>
-</category>
-<category xml:id="tlaRZ7KBAAUDBGJXOQMF2MB62XNAE">
-<catDesc>Saint-Germain-en-Laye</catDesc>
-<category xml:id="tlaRLDFYFP6DFHHHCJJ2USM5WPY4A">
-<catDesc>(Seine-et-Oise), Musée des Antiquités Nationales</catDesc>
-</category>
-</category>
-<category xml:id="tlaS2I33R7OUJBLDADPO6LCROIBLM">
-<catDesc>Strasbourg</catDesc>
-<category xml:id="tlaKP646R3SN5HRROIQAKCCUMCERU">
-<catDesc>Château des Rohan, Musée des Arts Décoratifs</catDesc>
-</category>
-<category xml:id="tlaXV3LUKW7GNE2HMPRKGCPKL3G2Y">
-<catDesc>Institut d&#039;Égyptologie</catDesc>
-</category>
-</category>
-<category xml:id="tlaU6REAHIN6FCF7D5D2X5O7SGCOU">
-<catDesc>Toulouse</catDesc>
-<category xml:id="tlaGALWZ2YYLFCY5KFEVQ7ZFR6MJE">
-<catDesc>Musée Georges Labit</catDesc>
-</category>
-</category>
-<category xml:id="tlaUR5IA7GG6VG7BMWBRN4QXOMOMQ">
-<catDesc>Sens</catDesc>
-<category xml:id="tlaTF7YJBM3WRB3JHKQLP4JEFGZUA">
-<catDesc>Musée Municipal</catDesc>
-</category>
-</category>
-<category xml:id="tlaVSDXPP3NDNGLTGL2ZI5TE27D6U">
-<catDesc>Quimper</catDesc>
-<category xml:id="tlaJJYL5TE72NHRXOODFEJS46DDEI">
-<catDesc>Musée des Beaux-Arts</catDesc>
-</category>
-</category>
-<category xml:id="tlaXGXJO7XFXBBBHCJJK63OZ4EKAA">
-<catDesc>Vesoul</catDesc>
-<category xml:id="tlaPN5HUH7YQBAEBHAWBFQJ3Q4NXY">
-<catDesc>Musée Georges-Garret</catDesc>
-</category>
-</category>
-<category xml:id="tlaYDSTTX2FIJDR5HJ7MGDLK4U4QU">
-<catDesc>Rodez</catDesc>
-<category xml:id="tlaLRNQIDGTLNDPNERE4KECDLXMQ4">
-<catDesc>Musée Fenaille</catDesc>
-</category>
-</category>
-<category xml:id="tlaYEFM6NKHY5BANFZCACHJ2YAARU">
-<catDesc>Rouen</catDesc>
-<category xml:id="tlaQVWIOZDQMRAEDFW5VXO3VM5DHU">
-<catDesc>Musée Départemental des Antiquités de la Seine-Maritime</catDesc>
-</category>
-</category>
-<category xml:id="tlaYX6SJUAI2VE4PC226NIBIB342E">
-<catDesc>Rennes</catDesc>
-<category xml:id="tlaBDOBWALADJGFZJI4ZIUBM7Q454">
-<catDesc>Musée des Beaux-Arts</catDesc>
-</category>
-</category>
-<category xml:id="tlaZFP2P4K26NCQFP7I5NSSQFEYRE">
-<catDesc>Saint-Rambert-sur-Loire</catDesc>
-<category xml:id="tlaSX6F4OTTK5FFDBFCAJFAENZLKI">
-<catDesc>Musée de Saint-Rambert-sur-Loire</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaVXGF6WZHQZENDHMTA5DHYHOX3U">
-<catDesc>(Städte D-L)</catDesc>
-<category xml:id="tla2DHUP22VYREQ7LBYKUVI6AJMYE">
-<catDesc>Lunéville</catDesc>
-<category xml:id="tlaBIZ6NNNRTZGEPCE55E6PJFW64I">
-<catDesc>Musée du Château</catDesc>
-</category>
-</category>
-<category xml:id="tla2QVVYXUSGRGPPMYBL5NTU3YYGY">
-<catDesc>Figeac</catDesc>
-<category xml:id="tlaTCIN3363MFFIHKSMOTLZZRDS4U">
-<catDesc>Musée Champollion</catDesc>
-</category>
-</category>
-<category xml:id="tla3GMMTM3WBBCORJDQB6ZEQ2PPKA">
-<catDesc>Dijon</catDesc>
-<category xml:id="tlaLUX6YKVLKBHG7I5JDFPTGZA3IU">
-<catDesc>Musée des Beaux Arts</catDesc>
-</category>
-</category>
-<category xml:id="tla3IYB3LQFTNGSZLKFFHQBGIPSME">
-<catDesc>Langres</catDesc>
-<category xml:id="tlaBQHZ5PVEONH5JI3AMDDXR35ZHE">
-<catDesc>Musée Hotel du Breuil de Saint Germain</catDesc>
-</category>
-</category>
-<category xml:id="tla4NL4BRNUUJEKPLIT5RGQ2MW324">
-<catDesc>Lille</catDesc>
-<category xml:id="tlaAN3XA7UQWZDW7JFYVMKS6EIS2Y">
-<catDesc>Institut de Papyrologie et d&#039;Égyptologie, Université de Lillle III</catDesc>
-</category>
-<category xml:id="tlaDUKL6MXVZRHWVFULFD6OZBGQ2A">
-<catDesc>Musée des Beaux Arts</catDesc>
-</category>
-<category xml:id="tlaGKIOCXAYBJFY5F3EAGMXXF2XZI">
-<catDesc>Université, Faculté des Lettres et des Sciences Humaines</catDesc>
-</category>
-</category>
-<category xml:id="tlaAT5B7NQPNZGUBNM2GOEAGFDJRU">
-<catDesc>Fécamp</catDesc>
-<category xml:id="tlaDKT6LXZVVFDOBPORTDTI2LDMUU">
-<catDesc>Musée Centre des Arts</catDesc>
-</category>
-</category>
-<category xml:id="tlaCA47DC42JNDDFGMZ3I6MQDJODY">
-<catDesc>Loudun</catDesc>
-<category xml:id="tlaTPIDXAN5X5BO3LPXGNMJO2XPMA">
-<catDesc>Musée Louis Charbonneau-Lassay</catDesc>
-</category>
-</category>
-<category xml:id="tlaCDAYNCMS3BAH7BMCW5JT5AAOA4">
-<catDesc>Le-Puy-en-Velay</catDesc>
-<category xml:id="tlaNNXNTZ5ZUVAVTATEXOJWW7CNJQ">
-<catDesc>Musée Crozatier</catDesc>
-</category>
-</category>
-<category xml:id="tlaDDWPGBLFOVEH5O3XC4YAPLTRXA">
-<catDesc>Gap</catDesc>
-<category xml:id="tla7HFEWCOOZVFCNIUCBHCWHUE3MY">
-<catDesc>Musée Dépt. des Hautes Alpes</catDesc>
-</category>
-</category>
-<category xml:id="tlaEG5F3TM27BAZDMRYH7SZYV6SWU">
-<catDesc>Laôn</catDesc>
-<category xml:id="tlaKMS5HFKV7BGZPF5OL2UQ55UWTY">
-<catDesc>Musée Archéologique</catDesc>
-</category>
-</category>
-<category xml:id="tlaERE2RZ2XXFDHZHWOVGZIESNQB4">
-<catDesc>Die</catDesc>
-<category xml:id="tlaLISFVTFD2JEPVPSDI4DB5E6W7I">
-<catDesc>Musée Municipal</catDesc>
-</category>
-</category>
-<category xml:id="tlaJJAEJZUUDZDERASH4GN7NOB7WY">
-<catDesc>Guéret</catDesc>
-<category xml:id="tla5K2L6KETUJF5FPHP2YHPBLKH3I">
-<catDesc>Musée de Guéret</catDesc>
-</category>
-</category>
-<category xml:id="tlaL4AB5ZWNPZE3TGEXP6RCUUXRLM">
-<catDesc>Louviers</catDesc>
-<category xml:id="tlaHYQKJVAGINCY3FL3Q4D2RZIWQA">
-<catDesc>Musée Municipal</catDesc>
-</category>
-</category>
-<category xml:id="tlaLBD4K6ERTBDDHCJEIHTAIVOXY4">
-<catDesc>Dôle</catDesc>
-<category xml:id="tlaDKCETGUN6BHDBGA3Y77WE4ETQM">
-<catDesc>Musée des Beaux-Arts</catDesc>
-</category>
-<category xml:id="tlaR6MJR22LEZGITDTG7A3XQUVYAU">
-<catDesc>Musée Municipal</catDesc>
-</category>
-</category>
-<category xml:id="tlaMWFVDBQOCZFR3IYH4RMCNTTR2I">
-<catDesc>Limoges</catDesc>
-<category xml:id="tlaPLCLHRL3JFED5BFQIB3Q4PDEZ4">
-<catDesc>Musée de l&#039;Evêche</catDesc>
-</category>
-<category xml:id="tlaRRNMILK6FBARBONDKRDPIXVINA">
-<catDesc>Musée Municipal</catDesc>
-</category>
-</category>
-<category xml:id="tlaNAKWLGJOOZEUDED5OYMFJ3HJ2A">
-<catDesc>Lons-le-Saunier</catDesc>
-<category xml:id="tla4XAWYF7SPRDRVPRYBNSJIAITAE">
-<catDesc>Musée Municipal</catDesc>
-</category>
-</category>
-<category xml:id="tlaOLH7KI6IFJC5LNFOXEHOO72NM4">
-<catDesc>Laval</catDesc>
-<category xml:id="tla3NJIWT34BRESJBQIXTFQNAWWZE">
-<catDesc>Musée du Vieux-Château</catDesc>
-</category>
-</category>
-<category xml:id="tlaPNA62SL3MNDUPKGJIKQ2VE6YCE">
-<catDesc>Le Havre</catDesc>
-<category xml:id="tlaCMK4D2OECNADPJ2AEFXQSF7EKQ">
-<catDesc>Musées de l&#039;Ancien Havre</catDesc>
-</category>
-</category>
-<category xml:id="tlaT4AQ4ID7DNB3PJNGWUUCQNTNAY">
-<catDesc>Issoudun</catDesc>
-<category xml:id="tla6K5TC22OGNCBRBGBZMA2XURPAQ">
-<catDesc>Musée de l&#039;Ancien Hospice Saint Roch</catDesc>
-</category>
-<category xml:id="tla7S4O4HQIMFHJ7GXCPJZKIZ2UFY">
-<catDesc>Musée d&#039;Art et d&#039;Archéologie (Musée de Moulins)</catDesc>
-</category>
-</category>
-<category xml:id="tlaW3GM543SPVHU3LMVLDNB2KLGKI">
-<catDesc>Fontaine-Chaalis</catDesc>
-<category xml:id="tlaUHALYBFJJJBV5IBMWKTZVZPSUQ">
-<catDesc>Musée Jacquemart-André</catDesc>
-</category>
-</category>
-<category xml:id="tlaWE43IHP5JRE7RLPBPVKZOZNV6Y">
-<catDesc>Hyères</catDesc>
-<category xml:id="tlaUY3UAC7LQ5BWBIQAEJMBZ77JNE">
-<catDesc>Musée d&#039;Art et d&#039;Archéologie</catDesc>
-</category>
-</category>
-<category xml:id="tlaWPOXBKNLN5BDROASSV5OPID4BM">
-<catDesc>Louhans</catDesc>
-<category xml:id="tlaSY3DNUOH3BA7HNNMBCGMUNJEGU">
-<catDesc>Ägyptische Sammlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaWYO46CPDXRHMLNGKWRFJJKZYZU">
-<catDesc>Lyon</catDesc>
-<category xml:id="tla54F3MNSPMJHQZPICTJ4LRIO2AE">
-<catDesc>Musée d&#039;Histoire Naturelle</catDesc>
-</category>
-<category xml:id="tlaOEFCR3G2ABFSFPNNTNI6ESJ7R4">
-<catDesc>Institut d&#039;Égyptologie Victor Loret, Université Lyon II</catDesc>
-</category>
-<category xml:id="tlaOXEWIOPO3BD2TEKFJUTYFJLSDI">
-<catDesc>Musée Guimet</catDesc>
-</category>
-<category xml:id="tlaP5FXI3YRBZG4NDWXXQ26ZASRZI">
-<catDesc>Musée des Beaux-Arts, Palais Saint-Pierre</catDesc>
-</category>
-<category xml:id="tlaSJS6PKU4ERC4TAKGCUEC753354">
-<catDesc>Musée des Frères des Écoles Chrétiennes</catDesc>
-</category>
-</category>
-<category xml:id="tlaXPR5AEVAXNCHPMYX77DHK522DI">
-<catDesc>Grenoble</catDesc>
-<category xml:id="tlaGAZ6MYYKNNG6VB7YEWPFVP3TCA">
-<catDesc>Musée de Peinture et de Sculpture</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaW6F4NVVPHVFEPNSXBSSVH6GCYQ">
-<catDesc>(Städte A-B)</catDesc>
-<category xml:id="tla4FVME7EXWBCWDKFNVK7N6FW63E">
-<catDesc>Avignon</catDesc>
-<category xml:id="tlaPYGJNJLOIBEZHG6RBWX37WJJSY">
-<catDesc>Musée Calvet</catDesc>
-</category>
-</category>
-<category xml:id="tla4NJ2I26ZNBDNRMX5UM5C23JE44">
-<catDesc>Avallon</catDesc>
-<category xml:id="tlaT5UO4R3KKRA4HA44QFJATAPIQI">
-<catDesc>Musée de l&#039;Avallonais</catDesc>
-</category>
-</category>
-<category xml:id="tla57D5R2AOBVDY7PPZAOUXKUBA2E">
-<catDesc>Auch</catDesc>
-<category xml:id="tlaWHC2RNLQSVE3RPBMUABZNYQPEA">
-<catDesc>Musée d&#039;Art et d&#039;Archéologie</catDesc>
-</category>
-</category>
-<category xml:id="tla5FU4FS3HIBA27B2AKRYMBHCSFI">
-<catDesc>Boulogne-sur-Mer</catDesc>
-<category xml:id="tlaNA7XYAQAKNCTRFN3GE62LLATE4">
-<catDesc>Musée des Beaux-Arts et d&#039;Archéologie</catDesc>
-</category>
-</category>
-<category xml:id="tla6VY2XFZTG5GNJMYHSBSLPY5B7M">
-<catDesc>Bessines-sur-Gartempe</catDesc>
-<category xml:id="tla4O4CAW4OLBCATD7CVZYRIWGQ2E">
-<catDesc>Ägyptische Sammlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaA7GZR4NPOFBVBNVUVXTYCYKSEA">
-<catDesc>Bayonne</catDesc>
-<category xml:id="tlaIH2CI3KWEJBE7E4EC37LYQ342M">
-<catDesc>Musée Bonnat</catDesc>
-</category>
-</category>
-<category xml:id="tlaAPUZJ2SANNC6FLPKT5UFTKRHMA">
-<catDesc>Bar-le-Duc</catDesc>
-<category xml:id="tla7U63AYPXABARPPFBSVVWXLIIQ4">
-<catDesc>Musée Barrois</catDesc>
-</category>
-</category>
-<category xml:id="tlaCWDKMMM4RFBCTMR3HYUOP3UO4M">
-<catDesc>Angers</catDesc>
-<category xml:id="tla3W3O3QWKR5F67MQRPJFBQYR74U">
-<catDesc>Musée Turpin de Crisse, Musée Pincé</catDesc>
-</category>
-<category xml:id="tla6XJB7XKDQRA7DC5JGRUPGCTQ7I">
-<catDesc>Musée des Beaux-Arts</catDesc>
-</category>
-</category>
-<category xml:id="tlaF7Z62AHX2ZFBNNWEVOM3PZQYR4">
-<catDesc>Beaufort-en-Vallée</catDesc>
-<category xml:id="tlaO5V4W4EVLBEC3G4FH2WZEKJPC4">
-<catDesc>Musée Joseph-Denais</catDesc>
-</category>
-</category>
-<category xml:id="tlaHWVPAG7JVZGALHJZAHQL6UUESY">
-<catDesc>Annécy</catDesc>
-<category xml:id="tla7HWS5AUBFZE5XO5WWQOHBSPBUE">
-<catDesc>Musée-Chateau d&#039;Annécy</catDesc>
-</category>
-</category>
-<category xml:id="tlaI7F34UO7OVHRJJ6OOG3VQJUV7U">
-<catDesc>Beaune</catDesc>
-<category xml:id="tla43BXUOSOSFEZHHHHWOZHSXKDEY">
-<catDesc>Musée des Beaux-Arts et Marey</catDesc>
-</category>
-</category>
-<category xml:id="tlaL4L7ESLLQFEN3INONTKLCRZAVA">
-<catDesc>Bourges</catDesc>
-<category xml:id="tlaVBRN2CGOHZGGZNJXT6UJ4TIGF4">
-<catDesc>Musée du Berry</catDesc>
-</category>
-</category>
-<category xml:id="tlaM5E6E56IOJDWRGDORZWIRMKIZQ">
-<catDesc>Bordeaux</catDesc>
-<category xml:id="tlaAIUH62EVKFFM3M2VVYG2SPLJZY">
-<catDesc>Musée des Beaux-Arts</catDesc>
-</category>
-<category xml:id="tlaDGDMWPA66VGUZBBLTSYACDVYYA">
-<catDesc>Musée d&#039;Aquitaine</catDesc>
-</category>
-</category>
-<category xml:id="tlaMIO23EUMQBAY3GOXY4D3LEUVBM">
-<catDesc>Albi</catDesc>
-<category xml:id="tlaULJP3U7335DLTHMCDPV4MWDWBU">
-<catDesc>Musée Toulouse-Lautrec</catDesc>
-</category>
-</category>
-<category xml:id="tlaMLHJ3GJK2NBZ7OFT5X3NGZ7PPM">
-<catDesc>Bernay</catDesc>
-<category xml:id="tlaAV7I6ISCHNADHNUGQQXADU6WNQ">
-<catDesc>Musée Municipal</catDesc>
-</category>
-</category>
-<category xml:id="tlaNOVVIYVFOBF5NMTQVABFCIISIM">
-<catDesc>Autun</catDesc>
-<category xml:id="tlaBW6EQCCKMFA3DBWXFF5VFSMITY">
-<catDesc>Musée Rolin</catDesc>
-</category>
-</category>
-<category xml:id="tlaOW5MDHUEEJE2LHRQ6EOJUP3QUE">
-<catDesc>Bourg-en-Bresse</catDesc>
-<category xml:id="tlaECGYKE3MBVGWLBXLTDKA4XXLB4">
-<catDesc>Musée de l&#039;Ain</catDesc>
-</category>
-</category>
-<category xml:id="tlaQLQXZUXISFAWHPLIMP7DZN4Z7U">
-<catDesc>Amiens</catDesc>
-<category xml:id="tlaWX4BPPATVNAVFJGSEWYD5AN77I">
-<catDesc>Musée de Picardie</catDesc>
-</category>
-</category>
-<category xml:id="tlaQQLCDKCX6BD3POWTR45RWVAOL4">
-<catDesc>Auxerre</catDesc>
-<category xml:id="tlaBCFUUVCFDZH6BGHE2GY7BIG5NA">
-<catDesc>Ancien Abbaye St.-Germain</catDesc>
-</category>
-<category xml:id="tlaVJYH7GEYHVDRFC6KWTCZCCNL64">
-<catDesc>Musée d&#039;Art et d&#039;Histoire</catDesc>
-</category>
-</category>
-<category xml:id="tlaRJ3GVDQJ7NE5ZM4Y4RMMUWRTK4">
-<catDesc>Brest</catDesc>
-<category xml:id="tlaU3KTKPM5RVHQ3EWUOWHCVR245M">
-<catDesc>Musée des Beaux-Arts</catDesc>
-</category>
-</category>
-<category xml:id="tlaSHEQMIM5PJGFLJ4KUCRQ2UAKAM">
-<catDesc>Brou</catDesc>
-<category xml:id="tlaNOJIKWMCFBHCJEHCWIZOAVTX3Q">
-<catDesc>Musée de Brou (Chateau des Allymes)</catDesc>
-</category>
-</category>
-<category xml:id="tlaT3QS6RRM5ZE3RLVTVSNWQF6J5U">
-<catDesc>Besançon</catDesc>
-<category xml:id="tla5FCLLEXI2VDRVDV5JGOQMJZ7DE">
-<catDesc>Musée des Beaux-Arts</catDesc>
-</category>
-</category>
-<category xml:id="tlaTNWSGJG65ZGNBFKA77IJHYKHUU">
-<catDesc>Aix-les-Bains</catDesc>
-<category xml:id="tla3M25SFJQDVGO3CUNXNY2TSDD74">
-<catDesc>Musée Archéologique</catDesc>
-</category>
-</category>
-<category xml:id="tlaVOAGIVINXZBZVPLWJFLYEBOGGQ">
-<catDesc>Angoulême</catDesc>
-<category xml:id="tlaKN42EA2YO5BRBG22EAJAWFPUPE">
-<catDesc>Societé Archéologique</catDesc>
-</category>
-</category>
-<category xml:id="tlaW4BIX6EILVB5DNE6GFGF7OT3G4">
-<catDesc>Aix-en-Provence</catDesc>
-<category xml:id="tlaUN2KLBABMJCMDCY5BP3H2M7FYY">
-<catDesc>Musée Granet</catDesc>
-</category>
-</category>
-<category xml:id="tlaXATJZ3X6QJB23EG4FGYHHRCVIM">
-<catDesc>Avranches</catDesc>
-<category xml:id="tlaYO3J23ZV6RCZ5A7QPHAM5EQQ2Y">
-<catDesc>Musée de l&#039;Avranchin</catDesc>
-</category>
-</category>
-<category xml:id="tlaXSNELPTTNBGDDOVETKFX3W6TJY">
-<catDesc>Barcelonnette</catDesc>
-<category xml:id="tlaNRFDUBN6YFHRPPHJSSUNERQNFQ">
-<catDesc>Musée de la Ville</catDesc>
-</category>
-</category>
-<category xml:id="tlaYEZWD45O6RBXNHAC6FJYHGQDE4">
-<catDesc>Arles</catDesc>
-<category xml:id="tlaL4WYOLCC4ZFT5JXYQIFRSGPI2Q">
-<catDesc>Musée Lapidaire d&#039;Art Pasen</catDesc>
-</category>
-<category xml:id="tlaUTQAD3737JDMZHHPEHETVCDS6I">
-<catDesc>Musée de l&#039;Arles Antique</catDesc>
-</category>
-</category>
-<category xml:id="tlaYMYPMRGS7NAVFETQX43DYBIYKI">
-<catDesc>Bagnols-sur-Cèze</catDesc>
-<category xml:id="tlaHP4LDQNERNDX3J6MJIK7I67XK4">
-<catDesc>Fond. Léon Alègre</catDesc>
-</category>
-</category>
-</category>
-</category>
-<category xml:id="tlaNS3AU3HLWZAOPPM5HJKHRE6CJ4">
-<catDesc>Italien</catDesc>
-<category xml:id="tlaPUUVVBSUOBAARBLNNMXNP3NOMM">
-<catDesc>(Städte Q-Z)</catDesc>
-<category xml:id="tla36MN6AEUDJEY7FU4M5C4KVTOSI">
-<catDesc>Sassari</catDesc>
-<category xml:id="tlaKH3ZMRUZDZCM7HS4NCL5RBCJCU">
-<catDesc>Museo Nazionale G.A. Sanna, Museo Archeologico</catDesc>
-</category>
-</category>
-<category xml:id="tla3P76PWKAHNBOHJCOQMC7SSYDLY">
-<catDesc>Trient</catDesc>
-<category xml:id="tlaXX6QMTNSKVBC7MMUMB3K4SDQGY">
-<catDesc>Museo Provinciale d&#039;Arte</catDesc>
-</category>
-</category>
-<category xml:id="tla54BGO4QVWFH7PGDM32J5INSLPU">
-<catDesc>Syrakus</catDesc>
-<category xml:id="tlaA4BTEKEGXZEYTMJ654LKA37BWU">
-<catDesc>Museo Archeologico Regionale</catDesc>
-</category>
-</category>
-<category xml:id="tla5XMEL2K27JFBPOFU4HDGO3YXSI">
-<catDesc>Triest</catDesc>
-<category xml:id="tla2IL3KH2EGNAINE4IWA6LNSJPSM">
-<catDesc>Civico Museo &#039;Revoltella&#039; e Galleria d&#039;Arte Moderna</catDesc>
-</category>
-<category xml:id="tlaALXELVY5YNH2DI5WH7GZTIK2UQ">
-<catDesc>Museo Storico del Castello di Miramar</catDesc>
-</category>
-<category xml:id="tlaTW2WMXAUEJGKBBWFO367XNVW4I">
-<catDesc>Museo Civico di Storia ed Arte di Trieste</catDesc>
-</category>
-<category xml:id="tlaYKMEB6727VAULIYORNYRHJDY2E">
-<catDesc>Museo Civico di Storia Naturale</catDesc>
-</category>
-</category>
-<category xml:id="tlaAKSJTSTJZRCLLLM3JEZPUCAXEA">
-<catDesc>Rovigo</catDesc>
-<category xml:id="tlaS5EXKM7AJJBVHKDWOWCLSSFTEI">
-<catDesc>Museo dell&#039;Accademia dei Concordi</catDesc>
-</category>
-</category>
-<category xml:id="tlaJ7JAWOYU7NGJHG7RFSID7PTQP4">
-<catDesc>Turin</catDesc>
-<category xml:id="tlaFKUH2YNGFZEDBDX3NMLWNU4EBA">
-<catDesc>Palazzo Reale</catDesc>
-</category>
-<category xml:id="tlaFS47WR3XHJD2FJ2NUC4OLS3CIY">
-<catDesc>Museo Egizio</catDesc>
-</category>
-<category xml:id="tlaZJFDMG4QJZFOTL52RFU6P27ZT4">
-<catDesc>Galleria Sabauda</catDesc>
-</category>
-</category>
-<category xml:id="tlaLIC7HZPYHBDALJWVXKGZ4YLZ2U">
-<catDesc>Rolandi</catDesc>
-<category xml:id="tlaFVO4AFICBJCF7DMPGDHK2ZADPU">
-<catDesc>Ägyptische Sammlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaN5YFA6II3RE2TKX62HOTWA4PK4">
-<catDesc>Vercelli</catDesc>
-<category xml:id="tlaO2GFQXDOGJH7BDY775NG5KEFAE">
-<catDesc>Museo Camillo Leone</catDesc>
-</category>
-</category>
-<category xml:id="tlaNO4HOUA27VBYNC556RI5GKPNLU">
-<catDesc>Regio Emilia</catDesc>
-<category xml:id="tlaQVLD7VUUEREC5IGPRE3SR2FL7A">
-<catDesc>Museo Civico</catDesc>
-</category>
-</category>
-<category xml:id="tlaOWHYA22FLNHGLPNEGSEVXBM5MI">
-<catDesc>Volterra</catDesc>
-<category xml:id="tlaRKQO33WISBBRHDAAAE2XYRZ5ZE">
-<catDesc>Museo Etrusco</catDesc>
-</category>
-</category>
-<category xml:id="tlaQV7URQTH4FF4FF2HLAC4AVASRU">
-<catDesc>Venedig</catDesc>
-<category xml:id="tlaB4BAOB2RDZGVNGG7HVMOML3EHY">
-<catDesc>Tesoro di San Marco</catDesc>
-</category>
-<category xml:id="tlaCZ3UWAHSTFAA3NSKUE2DSYYVBY">
-<catDesc>Museo Archeologico del Palazzo Reale di Venezia</catDesc>
-</category>
-<category xml:id="tlaGIWTNKK5JZFKDPMALCMJII6GBE">
-<catDesc>Museo Storico Navale</catDesc>
-</category>
-</category>
-<category xml:id="tlaRINIKV235ZFAHK3YGDG2FUOZOA">
-<catDesc>Verona</catDesc>
-<category xml:id="tla2FWA26TDABCNVEV3VR6VD5OGLY">
-<catDesc>Museo Calceolari</catDesc>
-</category>
-<category xml:id="tla3MPFFN77RZHKHBYITBAF65U7ZE">
-<catDesc>Museo Lapidario Maffeiana</catDesc>
-</category>
-<category xml:id="tlaG4JJQJFTHNF4VLPR2W6TEZO6P4">
-<catDesc>Museo de Castel Vecchio</catDesc>
-</category>
-<category xml:id="tlaY4YL72XANJCDVGIIF7MTGMITDQ">
-<catDesc>Museo Archeologico al Teatro Romano</catDesc>
-</category>
-</category>
-<category xml:id="tlaTXQ7EHZXENAQLF2Z4ESFEZSWD4">
-<catDesc>Rom</catDesc>
-<category xml:id="tla2JXJ4SDY5VGTNLZDKRNFJCRRFM">
-<catDesc>Museo Lapidario Paoliano</catDesc>
-</category>
-<category xml:id="tla6IIEQMLTLBGE5GJ4AEHWYIQ63Y">
-<catDesc>Museo Nazionale di Villa Giulia</catDesc>
-</category>
-<category xml:id="tlaEM5RWDBWUFB3TGIPJH3W4HZS6E">
-<catDesc>Villa Albani</catDesc>
-</category>
-<category xml:id="tlaKOW352DCXNHU5GF64YVU5PLTGA">
-<catDesc>Villa Ludovisi</catDesc>
-</category>
-<category xml:id="tlaMIMTIDYJCNHM5LAAUMWPTKM7T4">
-<catDesc>Università, Museo del Vicino Oriente Antico</catDesc>
-</category>
-<category xml:id="tlaO3BHF3B6DZEG7BEWRQOBNOLOEI">
-<catDesc>Museo Nazionale Romano</catDesc>
-</category>
-<category xml:id="tlaT7ZBSJHPNZDJRAGWEWIK66R44U">
-<catDesc>Museo Torlonia</catDesc>
-</category>
-<category xml:id="tlaTF7SKMFH35CC5JG2AUICE3ZOUE">
-<catDesc>Museo dei Conservatori</catDesc>
-</category>
-<category xml:id="tlaTSTTLG64WVGMRCTGOK54GQZYDY">
-<catDesc>Museo Capitolino</catDesc>
-</category>
-<category xml:id="tlaTZEA5KEWZFE23LORV7T2FTSEQI">
-<catDesc>Museo Barracco</catDesc>
-</category>
-<category xml:id="tlaXIFWTIKLNBDGVJ4JN2EHK4VSIE">
-<catDesc>Collegio Romano</catDesc>
-</category>
-</category>
-<category xml:id="tlaV6FIWMSOFJEGFFSDBIL3MOVDQI">
-<catDesc>Taranto</catDesc>
-<category xml:id="tlaNTM7BPDPIVBP7NYXFHUDQZJ7WY">
-<catDesc>Museo Nazionale, Museo Archeologico</catDesc>
-</category>
-</category>
-<category xml:id="tlaXS2EJZQDZ5GIXIOMSMRIA3NYB4">
-<catDesc>Sorrento</catDesc>
-<category xml:id="tlaZKDKINXXGFBWFD52TIVFMX7M7Y">
-<catDesc>Museo Correale di Terranova</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaU2PPBYY5AVGDRCMXMT6ZGUQCEQ">
-<catDesc>(Städte A-C)</catDesc>
-<category xml:id="tla274EBRTPFFDNVJGRRPIFINJCVU">
-<catDesc>Bologna</catDesc>
-<category xml:id="tlaK7XLLNZYINAGLPV3K67N2HBVXI">
-<catDesc>Museo Civico Archeologico</catDesc>
-</category>
-</category>
-<category xml:id="tla3LDEQNANFNF7RL7F7BAHEP4RMY">
-<catDesc>Aquileia</catDesc>
-<category xml:id="tlaJSHJHX6FCRAZNAQPCGOLPGEWFI">
-<catDesc>Museo Archeologico</catDesc>
-</category>
-</category>
-<category xml:id="tla4EYJJNIZX5CAVATMIXZZEL3GRI">
-<catDesc>Asti</catDesc>
-<category xml:id="tlaLRFCLXX4A5B3XK7C2I3O76FDGU">
-<catDesc>Museo Archeologico e Paleontologico</catDesc>
-</category>
-</category>
-<category xml:id="tla4VOZWF7VWVEABNEMPXQXLI3BGY">
-<catDesc>Cortona</catDesc>
-<category xml:id="tlaIV2YNHJRQ5AYDIW4XLEYV47CPQ">
-<catDesc>Museo dell&#039;Accademia Etrusca</catDesc>
-</category>
-</category>
-<category xml:id="tla6LDV52CG7ZDHNPAXPRSCPB3PLY">
-<catDesc>Brescia</catDesc>
-<category xml:id="tlaCAIPFUNW4NEZ3EZOGWD5ANCFGU">
-<catDesc>Museo Romano</catDesc>
-</category>
-</category>
-<category xml:id="tlaCN4JO257SBGUNHVZVFPHUO3AUU">
-<catDesc>Albenga</catDesc>
-<category xml:id="tlaSZ5XANG5RJFZNNPUEVVR27RDPE">
-<catDesc>Civico Museo Ingauno</catDesc>
-</category>
-</category>
-<category xml:id="tlaEG4DR67NAJHB5FVPLSKAKR7PRQ">
-<catDesc>Corneto</catDesc>
-<category xml:id="tlaFLOACCSI4BEPTLHVT4L5RK67GY">
-<catDesc>Municipal Museo Nazionale Tarquiniese (Botti)</catDesc>
-</category>
-</category>
-<category xml:id="tlaGEMD6EGJMBA7ZKQFBLHBTUAMPQ">
-<catDesc>Cagliari</catDesc>
-<category xml:id="tlaIOVOPG6BBFAADKXM3N2CWKTJVQ">
-<catDesc>Museo Archeologico Nazionale</catDesc>
-</category>
-</category>
-<category xml:id="tlaKZNUOIRYUNDQJLYH2MP7MUFNHY">
-<catDesc>Biella</catDesc>
-<category xml:id="tlaPHONYD7I6FBPBIVB6TA3T52KMQ">
-<catDesc>Museo Archeologico</catDesc>
-</category>
-</category>
-<category xml:id="tlaNEC6YEPBNZECTIA6XJYBWTMKJY">
-<catDesc>Adrano</catDesc>
-<category xml:id="tlaJZQE3NTXQVGPHLHGKQHO36GH5Q">
-<catDesc>Museo Archeologico Etneo</catDesc>
-</category>
-</category>
-<category xml:id="tlaNZTR3H6SIVG4HIDW5QIN52H5DU">
-<catDesc>Agrigent</catDesc>
-<category xml:id="tla4ZAM623VGFFGXL47FFMXUY5AB4">
-<catDesc>Museo Nazionale Archeologico</catDesc>
-</category>
-</category>
-<category xml:id="tlaOXZ6KOEJJZCHTOV5H65TRIQWUY">
-<catDesc>Assisi</catDesc>
-<category xml:id="tlaQCJZ7GS2VNGIFDRJS4TIB76VAE">
-<catDesc>Biblioteca Comunale</catDesc>
-</category>
-</category>
-<category xml:id="tlaRBY3ORCV2VF53PEEX57L2MKFX4">
-<catDesc>Aquila</catDesc>
-<category xml:id="tlaC65TOHVADRHF3P5KBE5N7LFWKY">
-<catDesc>Museo di Convento Francescano di S. Giuliano</catDesc>
-</category>
-</category>
-<category xml:id="tlaRGGR43HZXBEFFHVMGY5DG32YTI">
-<catDesc>Chieti</catDesc>
-<category xml:id="tla5L33EEYZO5D4JOQNAIABX4MECM">
-<catDesc>Museo Nazionale di Antichità</catDesc>
-</category>
-</category>
-<category xml:id="tlaRMGKHRERSJCLZJ5RFF7M3F5QFI">
-<catDesc>Ancona</catDesc>
-<category xml:id="tlaAT52UYSXHVDQ3HHBY7AITEF54I">
-<catDesc>Museo Archeologico Nazionale delle Marche</catDesc>
-</category>
-</category>
-<category xml:id="tlaTKWM75E5IFCRLFYVOGQTIM5CQE">
-<catDesc>Como</catDesc>
-<category xml:id="tlaBHHUJHKSBRFAJOWG5NDEMFBOUQ">
-<catDesc>Museo Civico Archeologico P. Giovio</catDesc>
-</category>
-</category>
-<category xml:id="tlaUMGWENNIVNELJGAGID5ALAN7HM">
-<catDesc>Catania</catDesc>
-<category xml:id="tla25MU6266ZNA3THETKDXJAKFS2Q">
-<catDesc>Museo Civico Castello Ursino</catDesc>
-</category>
-<category xml:id="tlaGD4M6EJDO5DNRCIIKB73O2E2HU">
-<catDesc>Museo Biscari</catDesc>
-</category>
-</category>
-<category xml:id="tlaVR7G3ADASRFUVLZSJVXSTKE56U">
-<catDesc>Asola</catDesc>
-<category xml:id="tlaK24S7EGCNFHSDPBZHTBOPE354Q">
-<catDesc>Museo Civico</catDesc>
-</category>
-</category>
-<category xml:id="tlaWD2USWWX4ZGRTJJ2YH7OC3RMOQ">
-<catDesc>Cremona</catDesc>
-<category xml:id="tlaZBVKC4CTVRGN3KDDGKYUQWI47M">
-<catDesc>Museo Civico</catDesc>
-</category>
-</category>
-<category xml:id="tlaWO7FOUBGXNHWZAPNGVS2YKE4VE">
-<catDesc>Bergamo</catDesc>
-<category xml:id="tlaKLHLDH7RIBDBJDFE64L52SPAPY">
-<catDesc>Civico Museo Archeologico</catDesc>
-</category>
-</category>
-<category xml:id="tlaXAXPQMJAMNCMRHF5CZVNUAWBMI">
-<catDesc>Benevent</catDesc>
-<category xml:id="tlaLAFLQZJLQBFVNOLUYFWRR656Y4">
-<catDesc>Museo del Sannio</catDesc>
-</category>
-<category xml:id="tlaLVJKHB6R2ZD4TM4AVXXY63JE5I">
-<catDesc>Museo Provinciale</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaWJAQ33CUFVDQDHCH5AI2ILMXUI">
-<catDesc>(Städte D-P)</catDesc>
-<category xml:id="tla4ACPAMYQD5CI3B2SMTPFJQLD7I">
-<catDesc>Florenz</catDesc>
-<category xml:id="tla7FMGIO5SCBGW5PVONNAOZFEZLU">
-<catDesc>Istituto Papirologico G. Vitelli</catDesc>
-</category>
-<category xml:id="tlaHDCQBURZ3VFV5NBRX2FZXTSJ2U">
-<catDesc>Museo Civico Archeologico</catDesc>
-</category>
-</category>
-<category xml:id="tla6R4XQIBMOZE7NATT5623UAD6JI">
-<catDesc>Domodossola</catDesc>
-<category xml:id="tlaYAWUXBEPJVAAJNRQZDT5B6BXLM">
-<catDesc>Museo di Palazzo Silva</catDesc>
-</category>
-</category>
-<category xml:id="tlaAGSHU4KD2NFSRJ5ZT3XOKTNLHQ">
-<catDesc>Parma</catDesc>
-<category xml:id="tlaOU4YCHALU5DPLF5QTOBDYYWGJM">
-<catDesc>Museo Archeologico Nazionale</catDesc>
-</category>
-</category>
-<category xml:id="tlaAJIADQV2KRAN7GDLPMVG72YAKY">
-<catDesc>Orbetello</catDesc>
-<category xml:id="tlaW355DG4GXJDK7I62LTDO2WJ6MM">
-<catDesc>Museo Archeologico</catDesc>
-</category>
-</category>
-<category xml:id="tlaATT65PA5EJEKRM6AO5IFMRG6V4">
-<catDesc>Grottaferrata</catDesc>
-<category xml:id="tlaSFJVGPDOKRD4VE4NQTKZFYEP64">
-<catDesc>Museo dell&#039;Abbazia</catDesc>
-</category>
-</category>
-<category xml:id="tlaB6YW7ADXCFAXXPFXDAFWWTFIEE">
-<catDesc>Pisa</catDesc>
-<category xml:id="tlaFLAT4EZU7ZHFFF2CKV3AZX7P4A">
-<catDesc>Instituto d&#039;Archeologia</catDesc>
-</category>
-<category xml:id="tlaWXPAZEUMLJGSRN5KPB2IIBHBPM">
-<catDesc>Museo dell&#039;Opera della Primaziale</catDesc>
-</category>
-</category>
-<category xml:id="tlaDD2F5U5XCVATJDGS3OXIV2UTNY">
-<catDesc>Pegli</catDesc>
-<category xml:id="tla23ACQIRA4JAXXMMGCYAWI4TNQE">
-<catDesc>Museo Civico di Archeologico Ligure, Villa Durazzo Pallavicini</catDesc>
-</category>
-</category>
-<category xml:id="tlaFZC6IXOJYRGWRLH2EXF62L3TBA">
-<catDesc>Ostia Antica</catDesc>
-<category xml:id="tlaPCSCHTWOGBFL7DNYS7LZJI7AWE">
-<catDesc>Museo Ostiense</catDesc>
-</category>
-</category>
-<category xml:id="tlaJGHBXNK2GZACXNAFNXULOA2NTM">
-<catDesc>Mailand</catDesc>
-<category xml:id="tlaJ2LJQEC7IJCEJEJJNOFSFCUERM">
-<catDesc>La Civica Raccolta Egizia, Castello Sforzesco</catDesc>
-</category>
-<category xml:id="tlaZO5PAPE7ABAVBGPCTPA6K3YUKY">
-<catDesc>Raccolte d&#039;Arte</catDesc>
-</category>
-</category>
-<category xml:id="tlaMF3LR5LBONA55JVTCCUTNBY3C4">
-<catDesc>Genova-Pegli</catDesc>
-<category xml:id="tla6IKZI7ZEY5HYNM6BPQRFVJTTDQ">
-<catDesc>Museo Civico</catDesc>
-</category>
-</category>
-<category xml:id="tlaMXH2TP6MXZCPLILJBCGUN5CF3Q">
-<catDesc>Fiesole</catDesc>
-<category xml:id="tlaUWP465DBCJAN7CI4C6JK5LDGUQ">
-<catDesc>Museo Etnologico Missionario di San Francesco</catDesc>
-</category>
-</category>
-<category xml:id="tlaNUG7IW6BOVGYBIY72BMFWRHMIU">
-<catDesc>Pavia</catDesc>
-<category xml:id="tlaO6ZDAQXANRAN3G34SYTCDOBXBY">
-<catDesc>Museo Civico</catDesc>
-</category>
-</category>
-<category xml:id="tlaNUTQHL4WHRCUPBSL2HYNMQOJDA">
-<catDesc>Ischia di Castro, Isola di</catDesc>
-<category xml:id="tla555BUOXMT5C7VKRO73IZL5VNU4">
-<catDesc>Museo Civico &#039;Pietro Lotti&#039;</catDesc>
-</category>
-</category>
-<category xml:id="tlaO3ECQKPMJJEXHAICTBMITH3UHM">
-<catDesc>Palermo</catDesc>
-<category xml:id="tlaFKPELVJATBDJLADL5CFV4KUQJA">
-<catDesc>Museo Archeologica Regionale</catDesc>
-</category>
-</category>
-<category xml:id="tlaRYTGNENPSRCD7PTW4L73ALEDAM">
-<catDesc>Modena</catDesc>
-<category xml:id="tla2W46J3OED5ACLGODKN2WQ2GF5M">
-<catDesc>Soprintendenza ai Beni Artistici e Storici per le Province de Modenae Reg</catDesc>
-</category>
-<category xml:id="tlaWY7KWDG36ZE5JHJI6NQT25ILBI">
-<catDesc>Museo Civico Archeologico e Etnologico</catDesc>
-</category>
-</category>
-<category xml:id="tlaTBQKLPOBD5CFTHFLX2TYCEB5JM">
-<catDesc>Ferrara</catDesc>
-<category xml:id="tla7UCVCBM6WVFEBM22WLFTPV453U">
-<catDesc>Museo Civico di Schifanoia</catDesc>
-</category>
-</category>
-<category xml:id="tlaTOEZF4RXKJFWBH7HMSBWLYH3SQ">
-<catDesc>Mantua</catDesc>
-<category xml:id="tlaDO5ETBDG2BGIXFM2LNIRBHPIR4">
-<catDesc>Galleria e Museo di Palazzo Ducale</catDesc>
-</category>
-</category>
-<category xml:id="tlaUZPF4YSB4VETBLKQK5B7YSDXXM">
-<catDesc>Neapel</catDesc>
-<category xml:id="tlaG7VZG6DL6ZEGNF46WUC74XX7ZQ">
-<catDesc>Museo Archeologico Nazionale &amp; Coll. Borbonica, Museo Real &amp; Collborgia</catDesc>
-</category>
-</category>
-<category xml:id="tlaV23362RJOJHA5IMPBYUCZJX7MY">
-<catDesc>Faenza</catDesc>
-<category xml:id="tla7RQOE7FUSZETNDR43TPOJ3QXBE">
-<catDesc>Museo Internazionale delle Ceramiche</catDesc>
-</category>
-</category>
-<category xml:id="tlaVG7MSOMRMFDC5K7KTOWL36XVO4">
-<catDesc>Messina</catDesc>
-<category xml:id="tla2MKKLYM75NCP7O7GNMRLZJUAOM">
-<catDesc>Museo Nazionale</catDesc>
-</category>
-</category>
-<category xml:id="tlaYSTPTI2N6VGRBKJ4WLNMM4YATM">
-<catDesc>Padua</catDesc>
-<category xml:id="tlaKSTJ4XIMZNFBBHAJCVB2YZDNGE">
-<catDesc>Palazzo della Ragione</catDesc>
-</category>
-<category xml:id="tlaUD4C77M27JGBROZ6ZMPW727UPE">
-<catDesc>Museo Civico di Padova, Museo Archeologico</catDesc>
-</category>
-<category xml:id="tlaWQGOLMGQOZBQDGIOOK7UYJWUDM">
-<catDesc>Museo di Storia Naturale dell&#039;Università</catDesc>
-</category>
-</category>
-</category>
-</category>
-<category xml:id="tlaOTDMR4T63BCJTDHOITFLHT46AA">
-<catDesc>Slowenien</catDesc>
-<category xml:id="tlaBCBAU7VN2VDJRFK232ADTBZ4KE">
-<catDesc>Ljubljana</catDesc>
-<category xml:id="tla6UUXC6HR5NC4JILMAYOMQBBGD4">
-<catDesc>Narodni Muzei</catDesc>
-</category>
-<category xml:id="tlaZUGV6IOSV5G45F5EUHHZDMB6Q4">
-<catDesc>Slovenski Etnografski Muzej</catDesc>
-</category>
-</category>
-<category xml:id="tlaFSX372KGINDEHJZWDSSG3B46XA">
-<catDesc>Ptui</catDesc>
-<category xml:id="tlaK6GMEWNR4JBB7CVNTHGLNR6CN4">
-<catDesc>Pokrajinski Muzej</catDesc>
-</category>
-</category>
-<category xml:id="tlaUDGWV64BNVB77C5753QN4PVQKA">
-<catDesc>Maribor</catDesc>
-<category xml:id="tlaST2UVZOMYRAXLFR2DTNWMZSCOM">
-<catDesc>Pokrajinski Muzej</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaRWBYFEPBKNGRFGMCM7RMGRQ4RE">
-<catDesc>Ukraine</catDesc>
-<category xml:id="tla3DXPJMFHQRHUPE7JKRDIHRTOBU">
-<catDesc>Nikolajew</catDesc>
-<category xml:id="tlaQ4GXP2AKFFELRIKFW3E6KZTQKE">
-<catDesc>Nikolayev Regional Museum</catDesc>
-</category>
-</category>
-<category xml:id="tla5YSOHXEW6BC47CYBICODRDE24E">
-<catDesc>Simferopol</catDesc>
-<category xml:id="tlaD4RPQWAWRNA3ZI33SPM33WUXBM">
-<catDesc>Crimea Regional Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaAGTDDVJYNFDEDO4JIHY4ALPUY4">
-<catDesc>Poltawa</catDesc>
-<category xml:id="tlaVMVDRKAZCZGWRDR5GA7K2R4HOU">
-<catDesc>Poltava Regional Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaBMUDDYUJNBEWHFM5LI5THDCF5Y">
-<catDesc>Lwow</catDesc>
-<category xml:id="tla3J74CLCLCVB7PGOGCWWUVBV6LY">
-<catDesc>Museum of Ethnography and Handicraft of Ukraine</catDesc>
-</category>
-</category>
-<category xml:id="tlaHEEDDQOH2VHGREDCFIUHHCTYKQ">
-<catDesc>Odessa</catDesc>
-<category xml:id="tlaBNEFNJ3WGZEEJEXRQR64MI3IZA">
-<catDesc>Odessa Archaeological Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaP6L6PYHBFBD5RPUHTVY5MOGWI4">
-<catDesc>Sewastopol</catDesc>
-<category xml:id="tla2ZCJWLOCTVCTHIFT4UGK4ZETBU">
-<catDesc>Khersones State Collection of History and Archaeology</catDesc>
-</category>
-</category>
-<category xml:id="tlaPVCLCJUY2FARRNSNMWLIY2AIGU">
-<catDesc>Bachtschisarai</catDesc>
-<category xml:id="tlaOBWAOI7CS5EWRJ2W7LBFM3N34Y">
-<catDesc>Bakhchisarai Museum of History and Archaeology</catDesc>
-</category>
-</category>
-<category xml:id="tlaTZF2UJTFHZBUNKFIQF4XBPGEMA">
-<catDesc>Kiew</catDesc>
-<category xml:id="tla4V6GMPBD7BADZE3WNPJZA23COM">
-<catDesc>State Historical Museum of Ukraine</catDesc>
-</category>
-<category xml:id="tlaMQOD6ZP2GZGEHJMKCV5VYHM5TY">
-<catDesc>Kiev Lavra Monastery</catDesc>
-</category>
-<category xml:id="tlaS2WLNJWNJBBTXDYIYHYJW6MKTU">
-<catDesc>Archaeological Museum of St. Vladimir University</catDesc>
-</category>
-<category xml:id="tlaW5PFQY3RZFHFHC4JAMEOZ76FRE">
-<catDesc>Kiev Museum of Western and Eastern Art</catDesc>
-</category>
-</category>
-<category xml:id="tlaW63FSRTBXJFY7AXPKTZIWBDT5Q">
-<catDesc>Jewpatoria</catDesc>
-<category xml:id="tlaEWWQ2VPW4ZBHDHLVTWNYXZOFMM">
-<catDesc>Evpatoria Regional Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaWWGVXI6RENBDDLQ5NCJABMP2ZI">
-<catDesc>Dnapropetrowsk</catDesc>
-<category xml:id="tlaQNZKL5WU2JA4PIWDGVNBA2VU54">
-<catDesc>Dnapropetrovsk Museum of History</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaSBDBXMJRGFARHA5WQGMRJ7CAFY">
-<catDesc>Lettland</catDesc>
-<category xml:id="tlaPBMJT2RAXZFQDKUZZFPSO7PZGE">
-<catDesc>Jelgava</catDesc>
-<category xml:id="tlaQOBA554BWNE73JAWALWDGBZOHI">
-<catDesc>Kurländisches Provinzialmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tlaUEDQAYQY6VFATFC5XYKWPMPDPI">
-<catDesc>Riga</catDesc>
-<category xml:id="tlaDYMQ2LG4AREPXNN7KUQBFDTMLI">
-<catDesc>Museum of Foreign Art</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaT3COBVD2SBGUHEOFKXAHVDXOPY">
-<catDesc>Malta</catDesc>
-<category xml:id="tlaY4WHXCUKGBDKBFK6ACK5N2W33Q">
-<catDesc>La Valetta</catDesc>
-<category xml:id="tla62SVAYTRH5GI5PWTGG6ALAPHZY">
-<catDesc>National Museum</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaTHUMNW4C2RDLRA5AGOOQZYJXHU">
-<catDesc>Großbritannien</catDesc>
-<category xml:id="tlaA2PMDEWNEZE4RNSKMGIAKMAPUY">
-<catDesc>(Städte D-J)</catDesc>
-<category xml:id="tla5NNWA5BOUNF5DBBE5QUJ43GDK4">
-<catDesc>Dundee</catDesc>
-<category xml:id="tla5FP7MGXYCRGBFMJILOF4CWPMKU">
-<catDesc>Central Museum</catDesc>
-</category>
-</category>
-<category xml:id="tla5RDTTOE42JF7XA7BDRYEDVUEKA">
-<catDesc>Greenock</catDesc>
-<category xml:id="tlaC4FE7UDBJ5GSJBC2WVA345TSCA">
-<catDesc>MacLean Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tla6Y5MYBFUPZG7PMMLJ5IEATPRKQ">
-<catDesc>Durham</catDesc>
-<category xml:id="tlaUJEYOIKSORHGTMNQ5CA2LFFPMQ">
-<catDesc>University Oriental Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaAOQA7KCT4RF2HKZA7CXBZ2O2LQ">
-<catDesc>Dorchester</catDesc>
-<category xml:id="tlaSCXHTJJBEZHF3CHJQXP3VRBT4M">
-<catDesc>Dorset Country Museum</catDesc>
-</category>
-<category xml:id="tlaVFIHCJTF55BH3OBG6DA22ZIGCQ">
-<catDesc>Tutankhamun Exhibition</catDesc>
-</category>
-</category>
-<category xml:id="tlaAVWMIIJ7HRBUPBXUPII6AKNCCQ">
-<catDesc>Harrow</catDesc>
-<category xml:id="tlaFKJHY6ZDGFHZRCQCBTEASHHRL4">
-<catDesc>School Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaCJ7DF3TJFBDTBGNBPMLQ4Y5MTY">
-<catDesc>Derby</catDesc>
-<category xml:id="tlaBLVIHNIS55E5RNV2263TVWYA64">
-<catDesc>Museums and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaCJHGE55MUZFU7JGR3MA5AC7WOU">
-<catDesc>Dewsbury</catDesc>
-<category xml:id="tlaZHYM4KHV7NFQXHLVWGJPOIYTSQ">
-<catDesc>Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaH6J4OXHCIBH4JF2CCHVXKKPPEU">
-<catDesc>Harrogate</catDesc>
-<category xml:id="tlaWXMVVOAIRNH2NHEZO2P3WTE3PE">
-<catDesc>Royal Pump Room Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaHHV66POYGZBYHOM2WFL5MY7HPA">
-<catDesc>Gloucester</catDesc>
-<category xml:id="tla4MQQUNVWGVBFTBBGQVLBOYS7JM">
-<catDesc>City Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaK7UZ2ZLWWNGAXA4H5GIASAIBDU">
-<catDesc>Haslemere</catDesc>
-<category xml:id="tlaDHUO2V6YCBGPTI2ZSYX5ZHHL6Y">
-<catDesc>Educational Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaKQFUOSSRBRFNHC6TNGIPOPOSTE">
-<catDesc>Godalming</catDesc>
-<category xml:id="tlaMCOPXKVSDBDIZEIKH5ZKK4IXQE">
-<catDesc>Charterhouse School Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaLIT6R454JBE3VAVDIW35I5CTIE">
-<catDesc>Ipswich</catDesc>
-<category xml:id="tlaXDH6WYS7F5APTHRZYKJDN6UY2I">
-<catDesc>Ägyptische Sammlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaLQXTJLRVLBHS7GW6CEHPAKGYIM">
-<catDesc>Edinburgh</catDesc>
-<category xml:id="tla6DVDOLKUJVE2RO3KN77EVGMADQ">
-<catDesc>National Museums of Scotland, The Royal Museum of Scotland</catDesc>
-</category>
-</category>
-<category xml:id="tlaN32BSIXINVADTEA62SEEQZE2SI">
-<catDesc>Hastings</catDesc>
-<category xml:id="tlaUQR4WQVNORBOHGNS7L3AHQTOMU">
-<catDesc>Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaPYG6I3CXQNHS7CCPO5YRJZOCYI">
-<catDesc>Enfield</catDesc>
-<category xml:id="tla555TFXGZFBABZJOUJ6PCJI5GWA">
-<catDesc>Forty Hall Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaQ35CCGARSBGLRO4HS62PGQ4YSU">
-<catDesc>Jersey</catDesc>
-<category xml:id="tla44YJNJ6FFFGI5MQNS6MNXGNBNM">
-<catDesc>Ägyptische Sammlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaS34IMLWVIJECXI4T6RZQYE4WWQ">
-<catDesc>Eton</catDesc>
-<category xml:id="tlaFUNCXVMZBFEARGARKXRKOXXZNI">
-<catDesc>Myers Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaU2K5SMHVENDHHNKTQA7VUB35JA">
-<catDesc>Glasgow</catDesc>
-<category xml:id="tla54WF4I6QCNBR7LKEAOBFU6UWCQ">
-<catDesc>Hunterian Museum</catDesc>
-</category>
-<category xml:id="tlaF2IPWKXUIJAU7AFVUSJPQ5BHLU">
-<catDesc>Art Gallery and Museum</catDesc>
-</category>
-<category xml:id="tlaYKVROYHE4VGQHDJR53RHKCPGDQ">
-<catDesc>Burrell Collection</catDesc>
-</category>
-</category>
-<category xml:id="tlaVVEECOLWCZF2JJNXUTJGUGL2MI">
-<catDesc>Grantham</catDesc>
-<category xml:id="tlaTI36WFQBWJDUVEC6YYDK6NZ75I">
-<catDesc>Ägyptische Sammlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaX2IQWO4G2JDJHFID5CMQ47E2HY">
-<catDesc>Exeter</catDesc>
-<category xml:id="tla37W2IPMDFNFEFPNYYO5XOZOD7E">
-<catDesc>Royal Albert Memorial Museum</catDesc>
-</category>
-<category xml:id="tlaQIKJIV6HN5HNVCR3EYVG2HUDX4">
-<catDesc>Rougemont House</catDesc>
-</category>
-</category>
-<category xml:id="tlaY55GLGXZ5RG63ASNKPVEVDBRDQ">
-<catDesc>Halifax</catDesc>
-<category xml:id="tlaO2CPYABZC5BDZKG4KVF7BFNX3Y">
-<catDesc>Bankfield Museum</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaBOMGVJHJWJC4ZPU4UEDSND7T3M">
-<catDesc>(Städte T-Z)</catDesc>
-<category xml:id="tla42ANXGDCHFD3TOA2PKLKNOT2JQ">
-<catDesc>Wimborne</catDesc>
-<category xml:id="tlaUT22S2P5DNBR3H7IH55VXNZ36I">
-<catDesc>Bankes Collections</catDesc>
-</category>
-</category>
-<category xml:id="tla6JU2NYWQRZG2DNKXZRPQCWBM4U">
-<catDesc>Wells</catDesc>
-<category xml:id="tlaA4NV6PEACNCYZKH7TGUCGYQKZU">
-<catDesc>City Library</catDesc>
-</category>
-</category>
-<category xml:id="tlaCQKHRIJSRVHAJOOQUM3YEFKWQA">
-<catDesc>Welshpool</catDesc>
-<category xml:id="tlaWIF25CFV4JFHFPM6YF5F2CEWLM">
-<catDesc>Powysland Museum and Montgomery Canal Centre</catDesc>
-</category>
-</category>
-<category xml:id="tlaDYZ64IGSYBABDCX5BZ7ZUJ4INE">
-<catDesc>Wakefield</catDesc>
-<category xml:id="tlaPQNQUIP3JBAHDIHKYUS5UARHDI">
-<catDesc>City Museum, Metropolitan District Council Art Galleries</catDesc>
-</category>
-</category>
-<category xml:id="tlaEJMFK7UPTBHQRN4JXCYIMTQUP4">
-<catDesc>Walsall</catDesc>
-<category xml:id="tlaCZDUVULZKZAWVCACO2EX2NNESI">
-<catDesc>Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaGETNONVCPJBVZGFNMRCMLZFKXU">
-<catDesc>York</catDesc>
-<category xml:id="tlaP5NCRXCV2NEKNCL3KDROYNNUJM">
-<catDesc>Yorkshire Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaJD4NAMK7MFGE3BXNRKJQCT7Y5U">
-<catDesc>Whitby</catDesc>
-<category xml:id="tlaB5I5BAUCG5GNBPOWXLOUNQ24NA">
-<catDesc>Whitby Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaJHCJE7ZAQJAQZC54HGC5QXJNHE">
-<catDesc>Truro</catDesc>
-<category xml:id="tlaIXA6W6JCUFBIJBQLJLRDH35CGM">
-<catDesc>The Royal Cornwall Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaKHEJFZ3KPZBUNGOB4FKHT6AGM4">
-<catDesc>Warwick</catDesc>
-<category xml:id="tla7SLCJVGJ75A2FNVOHFTVO4JRGQ">
-<catDesc>Warwickshire Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaKJ4SD4NJMVAARPEVSNFZ3PPZHA">
-<catDesc>Windsor</catDesc>
-<category xml:id="tla7FY6FSUEAVB7DMN4EJ3IEJRQWA">
-<catDesc>Myers Museum</catDesc>
-</category>
-<category xml:id="tlaZAGQKE6NSNFJXEDV6RAXFVYW74">
-<catDesc>Eton College</catDesc>
-</category>
-</category>
-<category xml:id="tlaLBTHCSWTJVABBM6CXJ3SWMXQNA">
-<catDesc>Wisbech</catDesc>
-<category xml:id="tlaLRBJSDY3LRCPJGWTR7Y6RW4GFU">
-<catDesc>Wisbech and Fenland Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaMOSI2DCY4VBOVMLZQUIK2LLIFI">
-<catDesc>Warrington</catDesc>
-<category xml:id="tla62UGNHDUYRAGHBZ55Y4UFHHP6Q">
-<catDesc>Ägyptische Sammlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaMRUF7VQHHZCCXDNILM5OTM5ZVM">
-<catDesc>Tunbridge Wells</catDesc>
-<category xml:id="tlaY3QIS7XB5NHXZFUSUAJPX36Q4E">
-<catDesc>Municipal Museum, Tunbridge Wells Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaQF6TZI6RSNGUPAGV2WIC5WP244">
-<catDesc>Wigan</catDesc>
-<category xml:id="tlaYXP7XEA6KVC6JNZVM76SR3XFPY">
-<catDesc>Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaR65UF7OCVNDN7KBB76UUHTJ7WI">
-<catDesc>Tamworth</catDesc>
-<category xml:id="tlaR6RIVALSP5F6NHLHBGQ5DF45GM">
-<catDesc>Tamworth Castle and Museum Service</catDesc>
-</category>
-</category>
-<category xml:id="tlaT2EVZGN2QFE5HLKB47FFC3GJAU">
-<catDesc>Torquay</catDesc>
-<category xml:id="tla4SMRWM7QZZHJXBPVE23EMDWC5M">
-<catDesc>Torquay Museum</catDesc>
-</category>
-<category xml:id="tlaVJDKPYQ2IBFWJLZBWHTLMPFCX4">
-<catDesc>Natural Hist. Society Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaTDENTTRPCVDMNNOUE6KS2RVCPA">
-<catDesc>Winchester</catDesc>
-<category xml:id="tlaB5LPMC2BYBERZF4UVWOS3656SU">
-<catDesc>Winchester City Museum</catDesc>
-</category>
-<category xml:id="tlaMEIMBMI6O5GOFDMC4NO54R6L4M">
-<catDesc>Winchester College Treasury</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaBUY467R3CVAKXKL7SYE222OYTA">
-<catDesc>(Städte A-C)</catDesc>
-<category xml:id="tla42AVITFYCBDI3OCAPKJVUNS2XE">
-<catDesc>Alton</catDesc>
-<category xml:id="tlaRJZKDSD7MBE6VLHW74U3TFXHUE">
-<catDesc>The Curtis Museum and Allen Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tla4JMFPSBKARG2TEJA5K7KUG75G4">
-<catDesc>Belfast</catDesc>
-<category xml:id="tla26TKRY4O5VGJVPNPMZK5NLSR2Q">
-<catDesc>Ulster Museum</catDesc>
-</category>
-</category>
-<category xml:id="tla67XSE7BISNEOJO7FYAHO4BVXBA">
-<catDesc>Blackburn</catDesc>
-<category xml:id="tlaLN46JGGGEFFRBBANSWJ6HEMMK4">
-<catDesc>Blackburn Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaBSFNVAN7BZCQDFCVLP46FX5UYA">
-<catDesc>Bolton</catDesc>
-<category xml:id="tlaIZEQ7UAZDZDVNGHGKSUJB3BHVU">
-<catDesc>Bolton Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaCDSYSRR2OFBFBA74HNQ4NXPM44">
-<catDesc>Brighton</catDesc>
-<category xml:id="tlaDCAEPZ74S5DTLJ45YBAVTQ4DCI">
-<catDesc>Art Gallery and Museum, North Gate House</catDesc>
-</category>
-</category>
-<category xml:id="tlaDP4NJTLYRNHONDNTJTE3WR5VXE">
-<catDesc>Bath</catDesc>
-<category xml:id="tla2TJ6VHHUANCTNOHJVBAWIZMNUE">
-<catDesc>Royal Literary and Scientific Institute</catDesc>
-</category>
-</category>
-<category xml:id="tlaDSVSDUZMENADRLR3ZAK4GSQ7GE">
-<catDesc>Croydon</catDesc>
-<category xml:id="tlaPV25V2OK6NCWNDHICYG4ZBTH7Q">
-<catDesc>Central Library</catDesc>
-</category>
-</category>
-<category xml:id="tlaG3VNZJCCL5BAPHAXFD4F5JGSME">
-<catDesc>Batley</catDesc>
-<category xml:id="tla6MUJKMB3WRBVLGUCGTZ5QSZVCY">
-<catDesc>Bagshaw Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaHUCDUJITPZFZNBO7KJ2ZSHVO64">
-<catDesc>Cheltenham</catDesc>
-</category>
-<category xml:id="tlaIT3QYO4N3JGFXPPVCQPBRTALJE">
-<catDesc>Birkenhead</catDesc>
-<category xml:id="tla7NQROYPFXVAKTK2S3OKLHQJSBA">
-<catDesc>Williamson Art Gallery and Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaIXX6ORFDRNHJBAUQAW5C6KPG6U">
-<catDesc>Aberdeen</catDesc>
-<category xml:id="tlaIZRUH7NIAZCJZDUAEJT265KH4Y">
-<catDesc>Anthropological Museum, University of Aberdeen</catDesc>
-</category>
-</category>
-<category xml:id="tlaKW6YT2QPBNCRJM7BHTUTEVEQWA">
-<catDesc>Chester</catDesc>
-<category xml:id="tlaKVEW4GNE2ZHU7HSGZOP6VP6NEQ">
-<catDesc>Grosvenor Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaLXKBND7HUZGUFJE4NHHYBHH6RY">
-<catDesc>Colchester</catDesc>
-<category xml:id="tla5VF7PZU3HRDCNJWMYRUFJ4NL2M">
-<catDesc>Museum</catDesc>
-</category>
-<category xml:id="tlaGHLL254DHNHGFHDJ742Z33MHQI">
-<catDesc>Castle Museum</catDesc>
-</category>
-<category xml:id="tlaYD47LDEI2NFOHCJV6EQZS3MQRU">
-<catDesc>The Hollytrees Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaM3VU3TDSS5FMHBMN7GQ4M62GJE">
-<catDesc>Caerleon</catDesc>
-<category xml:id="tlaWMMUP2CUJBEQXMEUQ33BIOWFZA">
-<catDesc>The Roman Legionary Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaMIEJZ36CLBFFJKZIM6YSN26LRE">
-<catDesc>Cardiff</catDesc>
-<category xml:id="tlaD3VF5NJ73NGAVNMOCSURNX46Q4">
-<catDesc>National Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaMM7GXB2E75FNVGSRG2CTHNM57U">
-<catDesc>Chelmsford</catDesc>
-<category xml:id="tlaK4NICS6F5RCFNOTZ3W4TVP6HVY">
-<catDesc>Chelmsford and Essex Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaPENH3LDTVNAK5AVBZYDLUER6QQ">
-<catDesc>Bristol</catDesc>
-<category xml:id="tlaTEPFXVCIWFEV5MUB5WEUUJAPSU">
-<catDesc>City of Bristol Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaPHJFJ6YSDZFF5ERIY4MPHTY4TA">
-<catDesc>Cambridge</catDesc>
-<category xml:id="tlaIXYNLNU7JJEWLA7MLMVNYB4TIU">
-<catDesc>Fitzwilliam Museum</catDesc>
-</category>
-<category xml:id="tlaJSGGBZO7C5BKPI577L3HOAF5XY">
-<catDesc>University Museum of Archaeology and Ethnology</catDesc>
-</category>
-<category xml:id="tlaXCP522QXOZCZTDTG4ULQS27M34">
-<catDesc>Faculty of Oriental Studies</catDesc>
-</category>
-</category>
-<category xml:id="tlaRVRDHS3Z2JC53JKUTZOVO2M234">
-<catDesc>Carmarthen</catDesc>
-<category xml:id="tlaOHU4MT5POVAU3P3WUXLQY7A2LU">
-<catDesc>Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaRWJMMZHEHRHT5IGG5ORMA43BSY">
-<catDesc>Canterbury</catDesc>
-<category xml:id="tlaITQZJW3V4FGDREFJGNQ3ZW5LFY">
-<catDesc>The Royal Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaVAH2NJQKAVHMFBHHLIDY4PB37E">
-<catDesc>Burnley</catDesc>
-<category xml:id="tlaDYIVY6YFANC4LMENMKDEZZ2FDY">
-<catDesc>Towneley Hall Art Gallery and Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaWN2NLYESVVEAJBPRWDGGME5V5Q">
-<catDesc>Bournemouth</catDesc>
-<category xml:id="tlaTE365A4USVBD5A6GKDGFT5V55I">
-<catDesc>Natural Science Society Museum</catDesc>
-</category>
-<category xml:id="tlaXRJ2QNBJGVFTTHXAF2RVTSMH24">
-<catDesc>Russell-Cotes Art Gallery and Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaX26CZWGT2ZFKFHTYQ63NMTZXPA">
-<catDesc>Birmingham</catDesc>
-<category xml:id="tlaEOQASVTOMNDELOEV2INULXYNH4">
-<catDesc>Barber Institute of Fine Arts</catDesc>
-</category>
-<category xml:id="tlaHS2YVTOGBZD47EH53KXMJMJ7JA">
-<catDesc>City Museum and Art Gallery</catDesc>
-</category>
-<category xml:id="tlaRNOADGWASZFPFHKBIKWTOAWN6I">
-<catDesc>The University of Birmingham, Dept. of Ancient History &amp; Archaeology</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaD4QRV6XXR5HBDOYZ5F3QNPSZ2U">
-<catDesc>(Städte K-N)</catDesc>
-<category xml:id="tla235O2Q6OKFGBNGI6RE6MMIOKGA">
-<catDesc>London</catDesc>
-<category xml:id="tla54J2LBSPDFEYNPDHB4255KWQGA">
-<catDesc>Petrie Museum of Egyptian Archaeology</catDesc>
-</category>
-<category xml:id="tla7R4DWJSS4VDOZNTYIRVXUZA7KE">
-<catDesc>St. Paul&#039;s School Museum</catDesc>
-</category>
-<category xml:id="tlaD2UE7L6FKBAE7ELORSK6HSYWFE">
-<catDesc>Central School of Arts and Crafts</catDesc>
-</category>
-<category xml:id="tlaDIONYIRZW5HCFBUV345KN2I554">
-<catDesc>Science Museum</catDesc>
-</category>
-<category xml:id="tlaDNGIODWZN5DLFHQOWPOUB2UJ6I">
-<catDesc>Victoria and Albert Museum</catDesc>
-</category>
-<category xml:id="tlaIASFUJ4OLZGHLGVHKKMMOTAFLM">
-<catDesc>Sir John Soane&#039;s Museum</catDesc>
-</category>
-<category xml:id="tlaJ63RJ2T7KBDTNA3T5464FRWGQI">
-<catDesc>Wellcome Historical Medical Museum</catDesc>
-</category>
-<category xml:id="tlaJDWCUPP66VA6PAUUEUAVFYHH5I">
-<catDesc>Royal College of Surgeons Museums</catDesc>
-</category>
-<category xml:id="tlaJMEAGLJDGJHLDJCXGLFGQ6FEFQ">
-<catDesc>British Museum</catDesc>
-</category>
-<category xml:id="tlaKULXLMADCRC4PJTMUKYTH5T5EA">
-<catDesc>Islington Museum</catDesc>
-</category>
-<category xml:id="tlaL7772UQX7ZBPTLMU647JL2772M">
-<catDesc>Royal Asiatic Society</catDesc>
-</category>
-<category xml:id="tlaMQ2UWWAUPZHJTM5YH6VMID5IDM">
-<catDesc>Royal College of Physicians</catDesc>
-</category>
-<category xml:id="tlaMYOFWWDOJBANVKG4JLPUA7ZWKI">
-<catDesc>Raleigh (NC)</catDesc>
-<category xml:id="tlaLL4GMMX2PFB27PZKSLERCDAHRA">
-<catDesc>North Carolina Museum of Art</catDesc>
-</category>
-</category>
-<category xml:id="tlaQG2Z3AIT2VENXOSERGHZN77MCU">
-<catDesc>United Services Museum</catDesc>
-</category>
-<category xml:id="tlaST2RDLTL7FDZLJGKPOLBWUZT3E">
-<catDesc>Cuming Museum</catDesc>
-</category>
-<category xml:id="tlaTJQAQ67ECZBERN2M3QKCAG47MU">
-<catDesc>Horniman Museum</catDesc>
-</category>
-<category xml:id="tlaU4LKJOTX6RH7BKCPPMIYEUYYVQ">
-<catDesc>British Library</catDesc>
-</category>
-</category>
-<category xml:id="tla44TYEJ5JKNFNLIVK6VM22JYINQ">
-<catDesc>Keighley</catDesc>
-<category xml:id="tlaV2SIFIDLLNBQLKT33WW6YQ7JQ4">
-<catDesc>Cliffe Castle</catDesc>
-</category>
-</category>
-<category xml:id="tla7752G3FTTRAY3JQUBK65KR3UQA">
-<catDesc>Leeds</catDesc>
-<category xml:id="tlaXGTMNELYBZCAHEBZG2C77SCVE4">
-<catDesc>City Museum</catDesc>
-</category>
-</category>
-<category xml:id="tla7AFEZ45E4FFN7EA3LWJEXMP3YI">
-<catDesc>Montrose</catDesc>
-<category xml:id="tlaYFR2T7G2SBHBLMI53YBPWL5A3E">
-<catDesc>Montrose Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaBWIYTYPE2RDSFFSXHBHT35NYJY">
-<catDesc>Northampton</catDesc>
-<category xml:id="tlaAULINLDBPJE3NCJPCEMQNHXSZI">
-<catDesc>Central Museum and Art Gallery</catDesc>
-</category>
-<category xml:id="tlaL3MUN3U4UVC3RL2XQLEXHAK64Q">
-<catDesc>Abington Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaEXUTKERJMBHHXIWD6CQSY53BVY">
-<catDesc>Kirkcudbright</catDesc>
-<category xml:id="tlaLHHFO4BMPRHRZBLMNNK5URDWVE">
-<catDesc>Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaGH5HXT2TXBD7LMFYWXVDR7FAAE">
-<catDesc>Lancing</catDesc>
-<category xml:id="tlaSJAXZZWZEFE7BFYXOFMSWMBFGI">
-<catDesc>Lancing College</catDesc>
-</category>
-</category>
-<category xml:id="tlaIG47JRKPLRD4ZIIQAJKBFHY47Y">
-<catDesc>Newcastle-upon-Tyne</catDesc>
-<category xml:id="tlaITS2VGPIYBFOXKBCS7Q5KSYH6U">
-<catDesc>Museum of Antiquities of the University and the Society of Antiquaries</catDesc>
-</category>
-<category xml:id="tlaZ5UUMVCXCZG3ZCFFC7YQWIVELY">
-<catDesc>Hancock Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaJQNJUQE4QNCG3J3G3JDSYXEBVE">
-<catDesc>Norwich</catDesc>
-<category xml:id="tla3REOK3OYRFBGPEGHNHVCA53EEM">
-<catDesc>Castle Museum</catDesc>
-</category>
-<category xml:id="tlaYEGNRNG7TVGLJHL57LYUKVKBJA">
-<catDesc>Sainsbury Centre for Visual Arts</catDesc>
-</category>
-</category>
-<category xml:id="tlaKDSWHXFVVJCIBGVDACGVMNO7EM">
-<catDesc>Macclesfield</catDesc>
-<category xml:id="tlaNSAJ2XACUZAUFFPPFLPACIJZUA">
-<catDesc>West Park Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaKJ2FFFNTH5HDRKZ5TB7TZ5KOZU">
-<catDesc>Littlehampton</catDesc>
-<category xml:id="tlaIMIVA3C5WRD3XJW3HNE2YLNNOU">
-<catDesc>Ägyptische Sammlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaP6MRQAVMNVGP5JCBOXLYNBP23A">
-<catDesc>King&#039;s Lynn</catDesc>
-<category xml:id="tlaOWQPGF6HKNEJ7JIGOZPPZ2COGA">
-<catDesc>Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaQ4WZYTCR55DENLFTRT3P7BDZXU">
-<catDesc>Leicester</catDesc>
-<category xml:id="tla5FJMDRBKQBHYJM7WTKZSLMWTOU">
-<catDesc>Leicestershire Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaQOMXP3ZDRFFUFPP3HDUI3BFWCA">
-<catDesc>Manchester</catDesc>
-<category xml:id="tla6577VYEY3JGELDEJBWEFCAJVPI">
-<catDesc>Manchester Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaSDKSUD5ICJE43N7DP3ZSBEGXGA">
-<catDesc>Middlesborough</catDesc>
-<category xml:id="tlaWY52CKFF4FAGVKNBC575T4FXDQ">
-<catDesc>Dorman Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaSVN2DR2FTNBXLCB57XJT5UIIJA">
-<catDesc>Lincoln</catDesc>
-<category xml:id="tla4BZWIOJGABB3ZAKDPSCCPGG3I4">
-<catDesc>City and County Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaTOZJ7UUDHND2PALFVUYXEANXNY">
-<catDesc>Liverpool</catDesc>
-<category xml:id="tlaDHUZEDCKTFEQDNY2YE7AXVCMPU">
-<catDesc>School of Archaeology and Oriental Studies</catDesc>
-</category>
-<category xml:id="tlaN6F2Q4EMWVFVHNCIH2ZHABJQKE">
-<catDesc>Liverpool Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaUIWXMEFEAFH75NKSY52EZVDRWQ">
-<catDesc>Leamington Spa</catDesc>
-<category xml:id="tlaWXGQ7D4N3FFVZHRZU4NO2VNGQ4">
-<catDesc>Warwick District Council Art Gallery and Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaVU4STYW2ZBGFLGIMMM4C2LFYC4">
-<catDesc>Newport</catDesc>
-<category xml:id="tlaV6Z6CUOQVJAEZEFD3GJMTHEIYA">
-<catDesc>Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaWITA5P3A4FBB3AEMHCZMXNXMC4">
-<catDesc>Kendal</catDesc>
-<category xml:id="tlaRZKHKUCLN5HYFH2PXB43UEOJYE">
-<catDesc>Ägyptische Sammlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaX3P7EJKJV5FBTMSSBJDC5U5WLI">
-<catDesc>Maidstone</catDesc>
-<category xml:id="tlaCPIE25V4X5HUFFTR4EWLJPZNJE">
-<catDesc>Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaXHXQF3PJTVGPLDRKVYAS674S2E">
-<catDesc>Nottingham</catDesc>
-<category xml:id="tla2KMO65F2EJEQXEBA32WT7GS6CY">
-<catDesc>Castle Museum, City Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaY5BZW3RCGNHJBHNFGEOGWTE67E">
-<catDesc>Newbury</catDesc>
-<category xml:id="tlaDQUJG64EONF6DIGARKZ2UHCEK4">
-<catDesc>District Museum</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaPJI7AYL67RF27K4ZXU3CTUWZ44">
-<catDesc>(Städte O-S)</catDesc>
-<category xml:id="tla2TLHF3CCENERRB44E7BKE5FTUU">
-<catDesc>Saffron Walden</catDesc>
-<category xml:id="tlaTS4XIQE2LBABZHA6NE5GRG554Y">
-<catDesc>Saffron Walden Museum</catDesc>
-</category>
-</category>
-<category xml:id="tla7KGDHE6BV5BDFBO54CJNOTY4GM">
-<catDesc>Port Sunlight</catDesc>
-<category xml:id="tlaFIAJVU32DZAJLK5OQ3PD4UTHYY">
-<catDesc>Lady Lever Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaA5POSSN2PZGUBEP2UVWF7D7KKY">
-<catDesc>Rotherham</catDesc>
-<category xml:id="tlaEUHVCMJYQRGLHH27LGXA5V4RN4">
-<catDesc>Rotherham Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaBDQGIII3MRDENFPMDPRVDOT624">
-<catDesc>Stockport</catDesc>
-<category xml:id="tla2NHW5NHZ4ZEN7AJXHRYOWXD75E">
-<catDesc>Stockport Museum</catDesc>
-</category>
-<category xml:id="tlaWWDTC5LN6VEMFMK5CZJUHBQYIQ">
-<catDesc>Vernon Park Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaBGKMKBIGLRDCVPYVLQBPKLPRI4">
-<catDesc>St. Helens</catDesc>
-<category xml:id="tlaMGWGOLG655A67OGBPJSLE46ZCQ">
-<catDesc>St. Helens Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaCMLLNHYETNBM7BXKZG3IP5DV7Y">
-<catDesc>Scarborough</catDesc>
-<category xml:id="tlaLXJZWFYWQZBYDDGOMJBGXQDQT4">
-<catDesc>Woodend Museum, King Richard II House</catDesc>
-</category>
-</category>
-<category xml:id="tlaDPTTPR6PVBCQBHDWXPKZTGQ67A">
-<catDesc>Stirling</catDesc>
-<category xml:id="tlaXMCXUB5ZIJE7VN3QBIXBXOUISQ">
-<catDesc>Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaDS4ILOU5CRBOFC4JFL7XEQ7TBY">
-<catDesc>Salford</catDesc>
-<category xml:id="tlaRPTEWV5WGNCEHNS57ASUNPH6MQ">
-<catDesc>Salford Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaEFGNXBLMBJDKPAJ6EXIBT5ELO4">
-<catDesc>St. Albans</catDesc>
-<category xml:id="tlaZCDE3ZUM2VDXLIUHBFT6X6OSF4">
-<catDesc>Museum of St. Albans</catDesc>
-</category>
-</category>
-<category xml:id="tlaF6TQNH5TQFGATBEPIZKDE6U3LA">
-<catDesc>Penzance</catDesc>
-<category xml:id="tlaSCPFKLXPMBHBRNRBIJFBYFFJLE">
-<catDesc>Penlee House Museum, Museum of Natural History and Antiquarian Society</catDesc>
-</category>
-</category>
-<category xml:id="tlaGGXCDWGDBZHUNISYW6FOTLCTLY">
-<catDesc>Rossendale</catDesc>
-<category xml:id="tlaHJW7NLU2JFAKLNDH6RBIL22FEE">
-<catDesc>Ägyptische Sammlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaJ65XJPPBTVBKHELFKQFBM6FNSM">
-<catDesc>Reading</catDesc>
-<category xml:id="tla7UCDZ75BS5FH7NYVCUKHJLL26Q">
-<catDesc>Museum and Art Gallery</catDesc>
-</category>
-<category xml:id="tlaFFNLXQ6S5ZEVNCJRXYM34KFHOI">
-<catDesc>The Ure Museum of Greek Archaeology</catDesc>
-</category>
-</category>
-<category xml:id="tlaKOKNYOM7TFHQ3E6QSL3PIVG63Q">
-<catDesc>Rochdale</catDesc>
-<category xml:id="tla4XX3ZT3QZJFGHNRHBY4WWRBVJ4">
-<catDesc>Rochdale Museum, Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaLXMXXB7LJBERVOXVLPUMYZYMNQ">
-<catDesc>Salisbury</catDesc>
-<category xml:id="tlaV6LFKTCS6ZB57FGTEIU4BET6G4">
-<catDesc>Salisbury and South Wiltshire Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaNQTTSL4NXBE2DOTKIGHJ7I3G6E">
-<catDesc>Stoke-on-Trent</catDesc>
-<category xml:id="tlaAIJRX6XMJRDGVJ3JAYEEQIMKCQ">
-<catDesc>City Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaPBWDEWSFSFGLTNPFHCZCQM5BMU">
-<catDesc>Rugby</catDesc>
-<category xml:id="tlaKIZHKN2P5BEUXGBNHFUWLGHKMQ">
-<catDesc>Rugby School, Art Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaSVFFOO4VWZCUBLUBK34VG46NDE">
-<catDesc>Plymouth</catDesc>
-<category xml:id="tla5K6XX3EJOJDBDNLRT6S5QS3AQU">
-<catDesc>City Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaSWRSNV4DXVCDDP244KLSJZY2PM">
-<catDesc>Oxford</catDesc>
-<category xml:id="tlaG3JB6H4CTBFB5JFWVB4TSJNNO4">
-<catDesc>Ashmolean Museum</catDesc>
-</category>
-<category xml:id="tlaJKU5XYFQCNB77ABOPVTNUWYTYQ">
-<catDesc>Bodleian Library</catDesc>
-</category>
-<category xml:id="tlaKELVMG6SERHCZG62UTQZWNSNOU">
-<catDesc>Queen&#039;s College</catDesc>
-</category>
-<category xml:id="tlaXWF3O3ZLHVEVRO6ZJOUYY67LC4">
-<catDesc>Pitt Rivers Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaVFV4M35B5BB4RF56FGL55BUZF4">
-<catDesc>Sunderland</catDesc>
-<category xml:id="tlaSKXNSUVPJJFV7E3WLAOJPZK3UY">
-<catDesc>Sunderland Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaVWC7LZBAB5DODEBY75ENDIEMJ4">
-<catDesc>Swansea</catDesc>
-<category xml:id="tla442QDMG43JDHBMW4HD2VAFDR5A">
-<catDesc>Wellcome Museum of Egyptian and Graeco-Roman Antiquities</catDesc>
-</category>
-<category xml:id="tlaVOYX55H74VHI5OHLEOCBDE2SBU">
-<catDesc>Royal Institution</catDesc>
-</category>
-</category>
-<category xml:id="tlaW7JZEN7ND5FYFCLT3J2ZPYSI7I">
-<catDesc>Swindon</catDesc>
-<category xml:id="tlaG4C7S6S6YZBKFBZK3X7MWM4D6Q">
-<catDesc>Swindon Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaWBMQXIEWG5AQPLB3MF2K6B4JRA">
-<catDesc>Sheffield</catDesc>
-<category xml:id="tla5PBUP7WIMFHZRECRBNBH3QQBFI">
-<catDesc>Sheffield City Museum</catDesc>
-</category>
-</category>
-</category>
-</category>
-<category xml:id="tlaTS6BPNNB7ZHGPEH22FVPDNC7K4">
-<catDesc>Finnland</catDesc>
-<category xml:id="tlaFSLEVDWBAJD7NLVAOYYHVWUMYQ">
-<catDesc>Helsinki</catDesc>
-<category xml:id="tlaB2C3TCUTHRCIVLU7GBPMEHW54A">
-<catDesc>Suomen Kansallismuseo, Ägyptische Sammlung</catDesc>
-</category>
-<category xml:id="tlaGWNQXGPZPRCUTLIMUKEWDO65R4">
-<catDesc>Didrichsenin Taidemuseo</catDesc>
-</category>
-<category xml:id="tlaRQWXHHKZPJDLJKJ7DMOB42GANQ">
-<catDesc>Ateneum</catDesc>
-</category>
-<category xml:id="tlaTTBQ47G7QVGRLCQLZLWTZXWOQY">
-<catDesc>Suomen Egypt. Seura</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaUT5VRBAZ4BDQLMMNNPJD3KWNVE">
-<catDesc>Litauen</catDesc>
-<category xml:id="tlaSF3RIRHEDBGUBNH54FC5BV5HUE">
-<catDesc>Vilnus</catDesc>
-<category xml:id="tla5OASW5AUHZEU7KD7TA4G6X4K6Y">
-<catDesc>Museum of History and Ethnography of Lithuania</catDesc>
-</category>
-<category xml:id="tla5QVSUJI43BB6VDCZV3SGCSWFQ4">
-<catDesc>Museum of Fine Arts of Lithuania</catDesc>
-</category>
-</category>
-<category xml:id="tlaUC5SMEY2UZGBBO5I4ISYS2QUNQ">
-<catDesc>Kaunas</catDesc>
-<category xml:id="tlaY42R4YUI7RAUHCYELHDPJFHGCI">
-<catDesc>Kaunas Ciurlionis Museum of Art</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaUXZQRO4ONZHN3MXM3LS552Q45U">
-<catDesc>Belgien</catDesc>
-<category xml:id="tla5D3NPPGWPFGAXF3PS46BKVVF4Y">
-<catDesc>Leuven</catDesc>
-<category xml:id="tlaKZPH6DYU5ZBEZAXPZPJANMYDF4">
-<catDesc>Musée de Louvain-la-Neuve</catDesc>
-</category>
-</category>
-<category xml:id="tlaAGMJAGAR3BDSFATXO427AHCRG4">
-<catDesc>Antwerpen</catDesc>
-<category xml:id="tlaMOGGUOQUJFEZFBZB6VSZHW64HI">
-<catDesc>Museum Vleeshuis</catDesc>
-</category>
-</category>
-<category xml:id="tlaALX7T23SIREOTCDITQM6Q5PEUI">
-<catDesc>Mariemont</catDesc>
-<category xml:id="tla2CMY3FB6NBAY7J2DBWL3MYANEA">
-<catDesc>Musée Royal et Domaine de Mariemont</catDesc>
-</category>
-</category>
-<category xml:id="tlaQXJ6XEVPJJENLEWXSZYNARSCWU">
-<catDesc>Brüssel</catDesc>
-<category xml:id="tla43UUYLI4Z5DRPDY4OZNXVJXE6Y">
-<catDesc>Fondation Égyptologique Reine Élisabeth</catDesc>
-</category>
-<category xml:id="tlaCFIJHEZAW5ELTGLIBBW3PZYGAQ">
-<catDesc>Archives et Musée de la Littérature, Bibliothèque Royale Albert</catDesc>
-</category>
-<category xml:id="tlaHCXUROQTOBFNDE4EDHPT6AQ4QA">
-<catDesc>Museum of Musical Instruments</catDesc>
-</category>
-<category xml:id="tlaM65RACJXWNEYRH7CRPDZLWOJ6E">
-<catDesc>Palais Royal</catDesc>
-</category>
-<category xml:id="tlaSG7YXFWZHVG75GTHDEME3KTCSM">
-<catDesc>Musées Royaux d&#039;Art et d&#039;Histoire</catDesc>
-</category>
-</category>
-<category xml:id="tlaV6UASPO3ZJBNZG6G7NUGZAXOOA">
-<catDesc>Liège</catDesc>
-<category xml:id="tlaMIU5QNBQWNFV7PZ5INPI6CCUYA">
-<catDesc>Musée Curtius</catDesc>
-</category>
-</category>
-<category xml:id="tlaWBI4D7P56FD4RN2SOJU4V4MUCU">
-<catDesc>Arlon</catDesc>
-<category xml:id="tlaHH6GHV4NW5DALINCKC33XRYTJM">
-<catDesc>Musée Luxembourgeois</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaVQ7YET4FMBDIBCCTXJW7KYCI3I">
-<catDesc>Niederlande</catDesc>
-<category xml:id="tla2N7B6I5R4JELRF7EZUDF2P3DS4">
-<catDesc>Bilthoven</catDesc>
-<category xml:id="tlaU3BUNYAVMNGANNDK5KBA5IEI4A">
-<catDesc>Werkplaats Kindergemeenschap</catDesc>
-</category>
-</category>
-<category xml:id="tla3LEYCONHJFEMDB3H2KJRLIPOFE">
-<catDesc>Amsterdam</catDesc>
-<category xml:id="tlaBLCE5ODUYBDUNOXSWGHLGPJK3A">
-<catDesc>Bijbels Museum</catDesc>
-</category>
-<category xml:id="tlaMHV6YRXZLVDFHN5547UQE7NWNU">
-<catDesc>NESARONE</catDesc>
-</category>
-<category xml:id="tlaMUCJFXIHABDCFHCANVXVKMSSVA">
-<catDesc>Allard Pierson Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaDD64Z6W6RNHLPBD5HUBHAY52JE">
-<catDesc>Leiden</catDesc>
-<category xml:id="tlaASJFDNBGLNHCZPUR7AAGPKVNJE">
-<catDesc>Rijksmuseum van Oudheden</catDesc>
-</category>
-<category xml:id="tlaWXJFLUH6SZFCNKNQTR6DMHC6Y4">
-<catDesc>Papyrologisch Instituut</catDesc>
-</category>
-</category>
-<category xml:id="tlaDJBXT7OKVBCXDMXRAKXXDLBQ34">
-<catDesc>Gravenhage / Den Haag</catDesc>
-<category xml:id="tla3XTIYHVKWFCSDH5D7ELXIDSYNI">
-<catDesc>Carnegie Museum</catDesc>
-</category>
-<category xml:id="tla7QGME3V2XZDN3IJKDWHZJWHEWU">
-<catDesc>Haags Gemeentemuseum</catDesc>
-</category>
-<category xml:id="tlaOWMHWBXVX5EZ7KK64ANKMKS3FE">
-<catDesc>Rijksmuseum Meermanno-Westreenianum</catDesc>
-</category>
-</category>
-<category xml:id="tlaI6SOPG64HBH4XLSXV5P4MLRPAY">
-<catDesc>Otterlo</catDesc>
-<category xml:id="tlaDSKEC62LBNCRPGQPUDPYKKV454">
-<catDesc>Rijksmuseum Kröller-Muller</catDesc>
-</category>
-</category>
-<category xml:id="tlaJWQQY4UUXRE2RHEFPTCHVHKQXU">
-<catDesc>Nijmegen</catDesc>
-<category xml:id="tla57T6UJPE3RFRTOUCVUQULFATGI">
-<catDesc>Instituut Jozef M.A. Janssen Katholieke Universiteit</catDesc>
-</category>
-<category xml:id="tlaSOVWHWBCNNGMXHUU5TY4TQ73O4">
-<catDesc>Rijksmuseum G.M. Kam</catDesc>
-</category>
-</category>
-<category xml:id="tlaLNZZ7LEYCRE37NJELL52YHZVHU">
-<catDesc>Utrecht</catDesc>
-<category xml:id="tlaJHYW3FEMANALRN625CZOJZO45Q">
-<catDesc>Rijksuniversiteit</catDesc>
-</category>
-</category>
-<category xml:id="tlaMEGRYNU5KZHE7PCKNDNKHOXIPY">
-<catDesc>Groningen</catDesc>
-<category xml:id="tlaNEXD4OGSDZFYDKSX4QTG3WBHA4">
-<catDesc>Groninger Museum, Naturrmuseum</catDesc>
-</category>
-<category xml:id="tlaPWVY65MJQJBMPOQ7DP3L6LRWAQ">
-<catDesc>Universiteit</catDesc>
-</category>
-</category>
-<category xml:id="tlaU4OQHCN3FFCA7HBUW3GUI2TWW4">
-<catDesc>Dordrecht</catDesc>
-<category xml:id="tlaGV342VZLHRCM5GHONFGZOSUZO4">
-<catDesc>Lips Slotenmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tlaZ5RFCVDSVJAGZH5DYKY3TNU45Y">
-<catDesc>Leeuwarden</catDesc>
-<category xml:id="tlaKB5BHCNKFZFGRNWOJ7BHVETRDE">
-<catDesc>Gemeentelijk Museum het Princessehof</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaWZ4MSUNHB5ARZA6Z7D6R64WPZ4">
-<catDesc>Spanien</catDesc>
-<category xml:id="tla357OIA72EZCWBLMAIVFPWAR3CQ">
-<catDesc>Malaga</catDesc>
-<category xml:id="tlaGOZM67X42FCSNIWIB6NSUTSTYQ">
-<catDesc>Museo Arqueológico Provincial</catDesc>
-</category>
-</category>
-<category xml:id="tla43M35ELXZZDGTK7OXTADRJBW3A">
-<catDesc>Montserrat</catDesc>
-<category xml:id="tlaNXVE3ZPFHZHWNHNEO3P4K5TVHA">
-<catDesc>Museo del Oriente Biblico</catDesc>
-</category>
-</category>
-<category xml:id="tla67GGDHWTKNGLBC2T2RXX2MRWD4">
-<catDesc>Mairena del Alcor</catDesc>
-<category xml:id="tlaS4RFTSP44NAAFERV5LQKBTGNTU">
-<catDesc>Casa de Bonsor</catDesc>
-</category>
-</category>
-<category xml:id="tla7N7RPAXATJHG3FQMFE72W3JBMI">
-<catDesc>Jaén</catDesc>
-<category xml:id="tlaDVKF7ZOK6ZBZDHESPPL23UAXW4">
-<catDesc>Museo Provincial</catDesc>
-</category>
-</category>
-<category xml:id="tla7TDL3BMQFZCWZH6WLHTEB6NRLY">
-<catDesc>Sitges</catDesc>
-<category xml:id="tlaIOBXESF5Y5HMFAGT76A44QKJRY">
-<catDesc>Museo Cau Ferrat</catDesc>
-</category>
-</category>
-<category xml:id="tlaCG5KOPUWIFHPVOONDMMAXIBBUI">
-<catDesc>El Vendrell</catDesc>
-<category xml:id="tlaKHVEA6EOJJBOPJSQHEWK7OY554">
-<catDesc>Museo Municipal, Museo Arqueológic</catDesc>
-</category>
-</category>
-<category xml:id="tlaEDNOKMAFEBBYBCWGBBH4GH5LV4">
-<catDesc>Palma</catDesc>
-<category xml:id="tlaTSG6F5BJKZFNZAMXV6XFDRTJPM">
-<catDesc>Museo Biblico del Seminario Diocesano</catDesc>
-</category>
-</category>
-<category xml:id="tlaENKGNRLVBBCZLFH7KJWP3IL7GQ">
-<catDesc>Vich</catDesc>
-<category xml:id="tla7XLQJ2L5M5CM7PQBNE2YNNOB7Q">
-<catDesc>Museo Arqueológico Artistic Episcopal</catDesc>
-</category>
-</category>
-<category xml:id="tlaEXAEQZCG2FDDRHZXSTNK3B3V4M">
-<catDesc>Ibiza</catDesc>
-<category xml:id="tlaQLO6KABF6VCWRE7SAECEHZXMPQ">
-<catDesc>Museo Arqueológico</catDesc>
-</category>
-</category>
-<category xml:id="tlaEYMDDKQE3BCANJE3Q6FAQNJXM4">
-<catDesc>Sevilla</catDesc>
-<category xml:id="tlaQCZZTOVGNFDITHRJKHNC24XINQ">
-<catDesc>Museo Arqueológico</catDesc>
-</category>
-</category>
-<category xml:id="tlaHFD2O2WTBNCZBBWVTFAAV3EERY">
-<catDesc>Almeria</catDesc>
-<category xml:id="tlaMDFSIIPMENH4DBIXFG25YX7N7Y">
-<catDesc>Museo Arqueológico</catDesc>
-</category>
-</category>
-<category xml:id="tlaHNYJWWTCGNBXNGVJWIDNT7I7PA">
-<catDesc>Badajoz</catDesc>
-<category xml:id="tlaW3TUFXFTVJBE7NGQL7HION3FUQ">
-<catDesc>Museo Arqueológico</catDesc>
-</category>
-</category>
-<category xml:id="tlaI56AA4MP2FCG7JRKEALFSGTIFA">
-<catDesc>Girona</catDesc>
-<category xml:id="tlaTZHWBCPB6BCIVOCALNG2O2MMME">
-<catDesc>Museo Arqueológico</catDesc>
-</category>
-</category>
-<category xml:id="tlaJCLQSZ4GCNA2PJYETU5RDNQUNE">
-<catDesc>Cádiz</catDesc>
-<category xml:id="tla6YULXXKSUBCBZEBDWE3L2ZO5MY">
-<catDesc>Museo Arqueológico</catDesc>
-</category>
-</category>
-<category xml:id="tlaJVFG5FYQNFH4BHFV5XEAB2GFGY">
-<catDesc>Valencia</catDesc>
-<category xml:id="tlaCVKTJRUOGJCJLGAO6BFBNY5M7Y">
-<catDesc>Museo de Prehistoria</catDesc>
-</category>
-</category>
-<category xml:id="tlaKUEMPDDO6BD3TIZKJGOVFBN2BQ">
-<catDesc>Alicante</catDesc>
-<category xml:id="tla3SQSCSQUU5E6PHSLQRXAT2VTSU">
-<catDesc>Museo Arqueológico</catDesc>
-</category>
-</category>
-<category xml:id="tlaKVR4MTA2XJHAFAYBSRPPBAGOP4">
-<catDesc>Huelva</catDesc>
-<category xml:id="tlaNBJS7ZSEVRAAPMMO3C2LEPIYXE">
-<catDesc>Museo Provincial</catDesc>
-</category>
-</category>
-<category xml:id="tlaN5WSMVOQWBFKTMWEN6SQE3FN3I">
-<catDesc>Madrid</catDesc>
-<category xml:id="tlaAOSSV3CNFFDPJOZZOXPMJGD4M4">
-<catDesc>Museo Arqueológico Nacional del Prado</catDesc>
-</category>
-<category xml:id="tlaNPLLLD2IONGPBLJOQ6JH5JUVQQ">
-<catDesc>Inst. de Valencia</catDesc>
-</category>
-</category>
-<category xml:id="tlaNBLTDPTA3NGNZNP2Z7ABD3VFGE">
-<catDesc>Puerto Real</catDesc>
-<category xml:id="tlaPU5FGQ6BNVBY7GKUHKRGVHYBGA">
-<catDesc>Museo Municipal</catDesc>
-</category>
-</category>
-<category xml:id="tlaRFRGSJTTP5G4RCTCVX45NK63GE">
-<catDesc>Vilanova i la Geltru</catDesc>
-<category xml:id="tlaTFYSYWBES5ERJDLQEJQHDWVWOU">
-<catDesc>Museo Biblioteca Victor Balaguer</catDesc>
-</category>
-</category>
-<category xml:id="tlaRQNAX7PIRNF5TIVZWTRHTCMGWU">
-<catDesc>Murcia</catDesc>
-<category xml:id="tlaYCI4CC3QDBH25FF6Q6CARUK5CQ">
-<catDesc>Sección Arqueologia</catDesc>
-</category>
-</category>
-<category xml:id="tlaTWUPIAH7RJC5PN3Q3UQT7Z2Y2A">
-<catDesc>Amposta</catDesc>
-<category xml:id="tlaDVO6IU2UUJBQ5JKCP4VWXFXSAE">
-<catDesc>Museo Municipal</catDesc>
-</category>
-</category>
-<category xml:id="tlaW5HSSKJV4ZCLTKSIROJJEHVUFQ">
-<catDesc>Granada</catDesc>
-<category xml:id="tla4F2TEZLNH5A4POI5IE7CWM2PCQ">
-<catDesc>Museo Arqueológico Provincial</catDesc>
-</category>
-</category>
-<category xml:id="tlaXQIWEV3DM5DJ5OXFGTMDPVUQIM">
-<catDesc>Barcelona</catDesc>
-<category xml:id="tla4BMT7XTA6FAR3BCT3YDLLMPVVU">
-<catDesc>Museo Arqueológico</catDesc>
-</category>
-<category xml:id="tla7A2KUGI6EJGD7OMW43N7GNSSD4">
-<catDesc>Museo de Artes Decorativas in Palacaio Virreina</catDesc>
-</category>
-<category xml:id="tlaOWKPW5NCMNAR5NYH6W5IKPWF5M">
-<catDesc>Instituto Amatller</catDesc>
-</category>
-<category xml:id="tlaPUBS46CS25DJ5OMVAJHP2AEVBQ">
-<catDesc>Institute of Archaeology and Prehistory in the University of Barcelona</catDesc>
-</category>
-<category xml:id="tlaYLYOZGVOOFFANFS6NTZS7GY3BI">
-<catDesc>Fundació Arqueològica Clos</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaYF2UJCO2XVEM3GUI5UMFHA7GUY">
-<catDesc>Norwegen</catDesc>
-<category xml:id="tlaCP5MLH5QHBGOLBINQ6H6SEO7RM">
-<catDesc>Oslo</catDesc>
-<category xml:id="tlaCDHRWRCGLNGKNNLMCJVALBZWPI">
-<catDesc>Ethnographical Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaGJBWPQHJNNARJDIHQIY37HWDUE">
-<catDesc>Elverum</catDesc>
-<category xml:id="tlaTJZXOMEJHRFTPBKRJJF2EKSDAI">
-<catDesc>Glomdalsmuseet</catDesc>
-</category>
-</category>
-<category xml:id="tlaZQIZXRY5LVD7PPNESZJUVQ7KQA">
-<catDesc>Bergen</catDesc>
-<category xml:id="tlaRBMKN6PQH5CM7LHG4W3535RLLA">
-<catDesc>Historisk Museum, Ägyptische Sammlung</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaYZQDJLLFXRE6HFGT5P5FF55OMU">
-<catDesc>Deutschland</catDesc>
-<category xml:id="tla6BRPTNYBRNHIPM4OOUMPFMXUCA">
-<catDesc>(Städte N-Z)</catDesc>
-<category xml:id="tla5BVEDTRESZEH3HN46PUHRL4JO4">
-<catDesc>Pforzheim</catDesc>
-<category xml:id="tla7QVFZXSTYJHORITNC6LFLL6JNU">
-<catDesc>Schmuckmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tla7HR324GMORCTJEXMGT2YSYZGCM">
-<catDesc>Werl</catDesc>
-<category xml:id="tlaG467T4ENJFDWPJQR4RN25CZQQM">
-<catDesc>Forum der Völker. Völkerkundemuseum der Franziskaner</catDesc>
-</category>
-</category>
-<category xml:id="tlaA623H7XSHRB5NFKPBAGLHFZD5E">
-<catDesc>Würzburg</catDesc>
-<category xml:id="tla4EYCPNDXCBBNHF7PYOCS75IHRA">
-<catDesc>Martin-von-Wagner-Museum, Antikensammlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaDOCQXKB5FFBZBIJJMQ2QIL5ZS4">
-<catDesc>Trier</catDesc>
-<category xml:id="tla4YMWL6C3IRCWHBFNPBNXHPWVRA">
-<catDesc>Simeonstift</catDesc>
-</category>
-<category xml:id="tlaKCU77MSS2NAMRDT4RS5LSODJJI">
-<catDesc>Rheinisches Landesmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tlaE7ZMMU5GFZBFFDHMDI4RLOVLFE">
-<catDesc>Recklinghausen</catDesc>
-<category xml:id="tlaCTYN62YJTNET7KU5GVTFE62IVA">
-<catDesc>Ikonenmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tlaGENNNEBKLVBOFEXQEPPW2KJOPE">
-<catDesc>Offenbach</catDesc>
-<category xml:id="tlaWMH4PJ6BUFHOFNMQMUCZL5WLHE">
-<catDesc>Deutsches Ledermuseum mit Deutschem Schuhmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tlaI6KCBJPXSJG3HJ26JMZ4DPDOTM">
-<catDesc>Osnabrück</catDesc>
-<category xml:id="tlaM6R2QMF6RVFG3FNOEDRGKWD6JA">
-<catDesc>Kulturgeschichtliches Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaKD54XVCJQZG2DKZ6AIPBYHTQUM">
-<catDesc>Wiesbaden</catDesc>
-<category xml:id="tlaOOI3E7NCXVBTZFQSXXR3V56BGI">
-<catDesc>Museum Wiesbaden, Sammlung Nassauischer Altertümer</catDesc>
-</category>
-</category>
-<category xml:id="tlaM26VL2ZQQREVVASQNL2KQTJLOQ">
-<catDesc>Nürnberg</catDesc>
-<category xml:id="tla7RKIPNUZL5AKVJ56HZR2SWL52U">
-<catDesc>Gewerbemuseum</catDesc>
-</category>
-</category>
-<category xml:id="tlaN5MPTMSO6JB4DLW332IR6NZ3VY">
-<catDesc>Solingen</catDesc>
-<category xml:id="tlaFLLEPFU7MBEUREITXONNTJXPQU">
-<catDesc>Klingenmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tlaNRRDOUJHNZDG5GJ4RW7GASQTXI">
-<catDesc>Ulm</catDesc>
-<category xml:id="tlaVRVXPTWRPJAYDK5HLNAPV45H3U">
-<catDesc>Das Deutsche Brotmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tlaOB2NPZTBDFA2DEFEAASCGCRBXM">
-<catDesc>Stuttgart</catDesc>
-<category xml:id="tlaWUQA5WWJIJE6JFETH62K74QUG4">
-<catDesc>Württembergisches Landesmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tlaOOJEZSFYEVC3DJQUOYVEAHDML4">
-<catDesc>Tübingen</catDesc>
-<category xml:id="tlaASI4YFJLRNDJDOEHRYH3FVGNCA">
-<catDesc>Sammlung des Ägyptologischen Instituts der Universität</catDesc>
-</category>
-</category>
-<category xml:id="tlaQSZW2XICXNACVEW6CHXQZY7VIE">
-<catDesc>Römhild</catDesc>
-<category xml:id="tlaLTNGSXYM55EAHO4J6ZIGL3ONFU">
-<catDesc>Steinsburg Museum, Ägyptische Sammlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaR5U2TTKKCFCW5KZX3A23EC4ICE">
-<catDesc>Weimar</catDesc>
-<category xml:id="tlaUK5FZPAQWNHNVGN3V2V2EQAFPE">
-<catDesc>Goethe-Nationalmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tlaRR3ULLDWPVGTTGO3442X6PUXG4">
-<catDesc>Oldenburg</catDesc>
-<category xml:id="tla6ZYSLKPE5JAWNHV5IRUHFLI5LY">
-<catDesc>Landesmuseum für Kunst und Kulturgeschichte</catDesc>
-</category>
-</category>
-<category xml:id="tlaSPWFAPZYGRBHRB76PCR2HRASZU">
-<catDesc>Rostock</catDesc>
-<category xml:id="tlaPVABCEUI25GQRIC7JIVXMLMIR4">
-<catDesc>Museum der Stadt Rostock</catDesc>
-</category>
-</category>
-<category xml:id="tlaUB4GJB4S3NBZ7O2HXA5RC6S4VA">
-<catDesc>Wuppertal</catDesc>
-<category xml:id="tlaOCGTVN24SVDWXKLMXJW6LMSFOM">
-<catDesc>Von der Heydt-Museum</catDesc>
-</category>
-<category xml:id="tlaQXX2K3ZSQRGJJJJQOEBIOPPLHE">
-<catDesc>Wuppertaler Uhrenmuseum K. Abel</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaDZE367XTXJCS7AY7HGEMQ3GZBY">
-<catDesc>(Städte H-M)</catDesc>
-<category xml:id="tla23GZ56GUGZFQLKZPHZZPLUG4SE">
-<catDesc>Heidelberg</catDesc>
-<category xml:id="tlaUJC4V7EVX5B5NEEM6JE3GDDM2Q">
-<catDesc>Sammlung des Ägyptologischen Instituts der Universität Heidelberg</catDesc>
-</category>
-</category>
-<category xml:id="tla3VS4WHPBNJECREEVDJYDCHZNR4">
-<catDesc>Kassel</catDesc>
-<category xml:id="tla2M365MPSSFGYZEXCZDPGXAGTC4">
-<catDesc>Staatliche Kunstsammlungen Schloss Wilhelmshöhe</catDesc>
-</category>
-</category>
-<category xml:id="tla52DUGWSNJVEDNLRLMBYHJ2WD2I">
-<catDesc>Mainz</catDesc>
-<category xml:id="tla4ZCR6UZCEJCGFAGCPIVNDLWRVM">
-<catDesc>Landesmuseum Mainz</catDesc>
-</category>
-<category xml:id="tlaFXQ72RGNIFA5FG2T53OWOVSNKE">
-<catDesc>Prinz-Johann-Georg-Sammlung</catDesc>
-</category>
-<category xml:id="tlaPXTVOZ7D35H4JFZUCVJDLCHEEI">
-<catDesc>Römisch-Germanisches Zentralmuseum</catDesc>
-</category>
-<category xml:id="tlaZA5IHW6DIBE6VNOUP2VIAAE7AU">
-<catDesc>Gutenberg-Museum</catDesc>
-</category>
-</category>
-<category xml:id="tla5IKOLHCGXFAWFPL2F464TXOBDU">
-<catDesc>Leipzig</catDesc>
-<category xml:id="tlaSH4JZCUG6RC67ISNT5JY54F3JA">
-<catDesc>Ägyptisches Museum</catDesc>
-</category>
-</category>
-<category xml:id="tla5TGRMEGTNVD77A5RGPX7GTJBJY">
-<catDesc>Marburg</catDesc>
-<category xml:id="tlaMXFOEAFEDZAQVBSPHQELMN6GYI">
-<catDesc>Religionskundliche Sammlung</catDesc>
-</category>
-</category>
-<category xml:id="tla6M34N6GZ7RDBFP2JKAZ7A6WV6I">
-<catDesc>Kaiserswerth</catDesc>
-<category xml:id="tlaHRN2EHJUWRF2BKH3PFCRG6V2RU">
-<catDesc>Diakonie-Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaBMX6BBCNB5AA7PHI3B4DTNKYDM">
-<catDesc>Lübeck</catDesc>
-<category xml:id="tlaDMOVL22LQZHFFOUDN7VJVPURRU">
-<catDesc>St. Annen-Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaDLEOHKWRTRDG5CSKE45KN2F2A4">
-<catDesc>Mühlheim</catDesc>
-<category xml:id="tlaV367GLK4SNELRLSNDXBV6GHOCA">
-<catDesc>Konrad-Ziegler-Schule</catDesc>
-</category>
-</category>
-<category xml:id="tlaG4WPLJNNIZDZBPJF3OLD3TB7SY">
-<catDesc>Karlsruhe</catDesc>
-<category xml:id="tlaIUIA3EESGFHBLFCE34TUDFNBDA">
-<catDesc>Badisches Landesmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tlaIWXCGYF3MJDIFDNI2AAJS7WLLM">
-<catDesc>Hildesheim</catDesc>
-<category xml:id="tlaNM3QUYNOMVDOBD2JX4WCD76QY4">
-<catDesc>Pelizaeus-Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaLK7FEY3N4BHVHB2YRC2ZJBSRAE">
-<catDesc>Halle</catDesc>
-<category xml:id="tla77AFQGNNIRESBMOLM7IVZFIQS4">
-<catDesc>Moritzburg</catDesc>
-</category>
-<category xml:id="tlaDACZ7EZ35BB5BFRK2TZ74HCU54">
-<catDesc>Landesmuseum für Vorgeschichte</catDesc>
-</category>
-<category xml:id="tlaDFIT5MSMKJFB7JTP4ZFDMKANRU">
-<catDesc>Archäologisches Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaLRIATOLCTBHYPAN2OIS5JM2XAU">
-<catDesc>Hamburg</catDesc>
-<category xml:id="tlaGQUFHNFL3REO7FUE7RBTXP2OPI">
-<catDesc>Museum für Kunst und Gewerbe</catDesc>
-</category>
-<category xml:id="tlaIAVPF4XRCFD6FDDO6X4MITLUDE">
-<catDesc>Hamburgisches Museum für Völkerkunde</catDesc>
-</category>
-</category>
-<category xml:id="tlaO3N32QI6NFGU3LPK466ER5W7N4">
-<catDesc>Münster</catDesc>
-<category xml:id="tlaLAMGPIDR4RGYBGAK3CLVTE6ZFY">
-<catDesc>Archäologisches Museum der Universität</catDesc>
-</category>
-</category>
-<category xml:id="tlaOWCO7KEXAZEFZCU56I45MROJOI">
-<catDesc>Mönchengladbach</catDesc>
-<category xml:id="tlaPFJ473TPABACDABOV2T2KX2YHE">
-<catDesc>Schloß Rheydt</catDesc>
-</category>
-</category>
-<category xml:id="tlaRQ4EZXMWENFN3L5TFTAFMCXBVY">
-<catDesc>Köln</catDesc>
-<category xml:id="tla3P4J4LHZ7NBZXKTE5KSMH2Z4RM">
-<catDesc>Rautenstrauch-Jost-Museum</catDesc>
-</category>
-<category xml:id="tlaK42CSR3EQ5BLTNK4A6M76AMH74">
-<catDesc>Seminar für Ägyptologie der Universität zu Köln</catDesc>
-</category>
-</category>
-<category xml:id="tlaUMPX6PFLRJC6PEGONWS4FA3AAQ">
-<catDesc>Hamm</catDesc>
-<category xml:id="tla6VYBY2TGXNG4HK7PX67FYW3XDA">
-<catDesc>Gustav-Lübcke-Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaVI75P3AEMVFOVFIVG4VYPJ37YM">
-<catDesc>Hannover</catDesc>
-<category xml:id="tlaGQRQZDDBJ5G7LNRJBS5FJX5TCM">
-<catDesc>Kestner-Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaYSZQPS5XLNAHHLHEWCBVXFYQX4">
-<catDesc>München</catDesc>
-<category xml:id="tlaGCVEOGEZLFGH5D6UPBWNXZCUMQ">
-<catDesc>Prähistorische Staatssammlung, Museum für Vor- und Frühgeschichte</catDesc>
-</category>
-<category xml:id="tlaPVYF5IRKY5GQXFHDUG3SWP5M2U">
-<catDesc>Nationalmuseum</catDesc>
-</category>
-<category xml:id="tlaZHJRWTBLB5GHLKVDW5XEVKUAKY">
-<catDesc>Staatliche Antikensammlung und Glyptothek</catDesc>
-</category>
-<category xml:id="tlaZN4QSMUSP5FVJBCD6TECD35MCE">
-<catDesc>Staatliche Sammlung Ägyptischer Kunst</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaTIC7Y3F6HVABVKXMYHPBMIZINM">
-<catDesc>(Städte A-G)</catDesc>
-<category xml:id="tla2MJMMGFLINASXN4CG7X4X6QYZY">
-<catDesc>Gotha</catDesc>
-<category xml:id="tlaGYQI5IYO3BGP3DN2KCEPDWWVMQ">
-<catDesc>Schloßmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tla33EA2OCMHNGOXDMK4GLPP4ERRA">
-<catDesc>Banz</catDesc>
-<category xml:id="tlaIRUS4ZB4GRGE7P2PHPOZIDGLNQ">
-<catDesc>Petrefakten- und Orientalische Sammlung Banz</catDesc>
-</category>
-</category>
-<category xml:id="tla4JELCY42ZNDLBISRS6O5RSH7JI">
-<catDesc>Gießen</catDesc>
-<category xml:id="tlaBNPKT4DI7VDAPFUSSES7JDWNYQ">
-<catDesc>Oberhessisches Museum</catDesc>
-</category>
-<category xml:id="tlaOWQZPI6XCNFJ7OHNMUPSGWGUUQ">
-<catDesc>Universitätsbibliothek</catDesc>
-</category>
-</category>
-<category xml:id="tla5O73ZODJMJDH5ETRHZQR2QJTNE">
-<catDesc>Bonn</catDesc>
-<category xml:id="tla35Z27YQHENBUZMSKLWQAOLREOU">
-<catDesc>Ägyptologisches Seminar der Universität</catDesc>
-</category>
-<category xml:id="tla5ZQL6AHS7NGY5JBGLPJN6LNATQ">
-<catDesc>Archäologische Sammlung des Lyceum Hosianum</catDesc>
-</category>
-<category xml:id="tlaXZDLM7WKRJDFLKHTVBHX36F7RY">
-<catDesc>Akademisches Kunstmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tla7W7AKXWCRNCMFHGLI4LOHTIWU4">
-<catDesc>Greifswald</catDesc>
-<category xml:id="tlaRLWRUKLOMBE7TPLIMHF6BXBHVM">
-<catDesc>Archäologische Sammlung der Universität</catDesc>
-</category>
-</category>
-<category xml:id="tlaBBVF7WEX3VBNPOVL325XZOVZ6Q">
-<catDesc>Aachen</catDesc>
-<category xml:id="tlaHAYG7WDAFRH5NFRAO4UC66R3WY">
-<catDesc>Suermondt-Ludwig-Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaIWPSCDLU6NGI7KDL6CNSWXF3LQ">
-<catDesc>Essen</catDesc>
-<category xml:id="tla4ISE4KXQ5RFBHKFH5Q7HKVIH6U">
-<catDesc>Folkwang Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaJ4ACS5PS45BKRCVEI243KE7ONM">
-<catDesc>Braunschweig</catDesc>
-<category xml:id="tlaN7FBZXDYBVAKJLLGUZPHTIPLQQ">
-<catDesc>Herzog Anton Ulrich Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaJ6KBPK4DORFTXJR3QEKM4SAQ24">
-<catDesc>Dresden</catDesc>
-<category xml:id="tlaAPWIPVDEM5EYBBU3TLGIKQIZ6M">
-<catDesc>Albertinum</catDesc>
-</category>
-</category>
-<category xml:id="tlaK2UDH3BCGZDKZNNHP4FRNJYIFE">
-<catDesc>Düsseldorf</catDesc>
-<category xml:id="tlaR2AOJUK7RVDCPFBWW5N7VFLAWY">
-<catDesc>Hetjens-Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaKHYOWHNSJFCODFUVCEM4C3BDO4">
-<catDesc>Bielefeld</catDesc>
-<category xml:id="tlaSR5SXDHNOFGTLBYR4ORZOQKIDE">
-<catDesc>Kulturhistorisches Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaO24H7CHJRVDRDFCVUNZM5NVQEU">
-<catDesc>Detmold</catDesc>
-<category xml:id="tlaHWHDLZO3GNAEVINBFS5VCCILVM">
-<catDesc>Lippisches Landesmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tlaPO3DLRWC2BBZFGHQT6STIUHJYY">
-<catDesc>Augsburg</catDesc>
-<category xml:id="tlaF5KWMYXKKZGK7IA7S3EFORRBD4">
-<catDesc>Römisches Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaRH4XITZOPBBG3DA3E7U6MBMIGI">
-<catDesc>Freiburg im Breisgau</catDesc>
-<category xml:id="tla54DWWWZMPFCYTID76WL2AMAPGQ">
-<catDesc>Museum für Völkerkunde</catDesc>
-</category>
-<category xml:id="tlaWCC44EJOY5D6DG6NJYRO4KQ3DY">
-<catDesc>Archäologische Sammlung der Universität</catDesc>
-</category>
-</category>
-<category xml:id="tlaS2JXZIV3ENBWVNQKUC3NSBVRQY">
-<catDesc>Frankfurt am Main</catDesc>
-<category xml:id="tla3R7UCEDFF5D77I5656LC4GZ2CI">
-<catDesc>Senckenberg Museum</catDesc>
-</category>
-<category xml:id="tla5V2DYXNOGVAFBJFU72MOXOXWUA">
-<catDesc>Kunsthandwerk</catDesc>
-</category>
-<category xml:id="tlaLQUHNEUXRRES7JEMCM6YALFT2U">
-<catDesc>Liebieghaus, Museum Alter Plastik</catDesc>
-</category>
-</category>
-<category xml:id="tlaTFGFHY6MWFEWPF2UTDXJRPIGLA">
-<catDesc>Erlangen</catDesc>
-<category xml:id="tla7DRY6GXQFFEK7F3IHEBR2PME4M">
-<catDesc>Kunstsammlung (Archäologische Sammlung) der Universität</catDesc>
-</category>
-</category>
-<category xml:id="tlaV7PROYGBXZH57PKYK7BGR6E2EA">
-<catDesc>Berlin</catDesc>
-<category xml:id="tlaGOUD7BQ5DBCENBWBR4KFWDW5SI">
-<catDesc>Ägyptisches Museum und Papyrussammlung</catDesc>
-</category>
-<category xml:id="tlaUVQQXLR3O5BGZAXXRJTQHEUTVU">
-<catDesc>Museum für Kommunikation</catDesc>
-</category>
-</category>
-<category xml:id="tlaWLKLYSXCLJBX3CSZGGTMUAXEVY">
-<catDesc>Darmstadt</catDesc>
-<category xml:id="tlaTZMNSDK3XFAQ7BFG6A4BSFH6B4">
-<catDesc>Hessisches Landesmuseum</catDesc>
-</category>
-</category>
-<category xml:id="tlaXG7GB2EBNFHNDCVQWNYI5N74KU">
-<catDesc>Cottbus</catDesc>
-<category xml:id="tla4D3M7K4TNVH5VDFOJXFYLRFLCI">
-<catDesc>Pückler Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaXPVERXNUQBGFZMNHJTESYPEZSY">
-<catDesc>Bochum</catDesc>
-<category xml:id="tlaGZEGJN3TTVGB5F6GG2F3AK6AS4">
-<catDesc>Antikenmuseum Kunstsammlungen der Ruhr-Universität Bochum</catDesc>
-</category>
-</category>
-<category xml:id="tlaZC4P5FN5JJFDTKL3ESA2V2ZS6Q">
-<catDesc>Bremen</catDesc>
-<category xml:id="tlaUZ4NYSJFB5CG7KDHNLLOXZATQI">
-<catDesc>Überseemuseum</catDesc>
-</category>
-</category>
-<category xml:id="tlaZHYNNO267BE5LLL23X46GWAAXI">
-<catDesc>Göttingen</catDesc>
-<category xml:id="tla2U7DNWSYZBC37LVZSIAE7CSSBY">
-<catDesc>Sammlung des Archäologischen Instituts der Universität</catDesc>
-</category>
-</category>
-</category>
-</category>
-<category xml:id="tlaYZZ4RR3EXZAN3PKCQF2NRYVDWY">
-<catDesc>Tschechien</catDesc>
-<category xml:id="tla564FDBDANRECJHT23EFPXBMRC4">
-<catDesc>Prag</catDesc>
-<category xml:id="tla6AMDAG3E7NGEXEOKZWPWU7ZVKU">
-<catDesc>Náprstkovo Muzeum</catDesc>
-</category>
-<category xml:id="tlaCKGY7QSWBZB37EQX4JD35LDQKQ">
-<catDesc>Národní Galerie</catDesc>
-</category>
-<category xml:id="tlaKNEZ4I4ABBAF7PH2MRJSIIYCTA">
-<catDesc>Národní Muzeum</catDesc>
-</category>
-</category>
-<category xml:id="tla5IA4UHWUNBCWFAHNDRKNSHQ7FM">
-<catDesc>Zleby</catDesc>
-<category xml:id="tlaVKKMXWGLSNEWHEJ37446PKYZOU">
-<catDesc>Státní Zámek</catDesc>
-</category>
-</category>
-<category xml:id="tlaIYGQG3OKJZF3HMI7KWEA6XIWDA">
-<catDesc>Olomouc</catDesc>
-<category xml:id="tlaOMOBNSQHFJHVTPQS3UKS3ALFVI">
-<catDesc>Oblastní Galerie</catDesc>
-</category>
-</category>
-<category xml:id="tlaU6CVG63WMFDZBPAY57TNJJL6DQ">
-<catDesc>Lázne Kynzwart</catDesc>
-<category xml:id="tla7T3GVMUIAZDOBANO2BBRWSCZ6M">
-<catDesc>Státní Zámek</catDesc>
-</category>
-</category>
-<category xml:id="tlaW6W25WNBAVF3XEFUYBHRLHQGFQ">
-<catDesc>Moravská Trebová</catDesc>
-<category xml:id="tlaLA3COPTLNJHS3MTGHLA2MPFDVM">
-<catDesc>Mestské Muzeum</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaZSVAEOLGMFHAXH4OGCCJRX4OWM">
-<catDesc>Dänemark</catDesc>
-<category xml:id="tlaARKYG2YELNGCXHV5AJAHSRB6MQ">
-<catDesc>Klampenborg</catDesc>
-<category xml:id="tlaWRMJB4S6S5DQRPIE5XXEZ4UY4M">
-<catDesc>Ordrupgaard Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaO3I6QT6FJFET3JFA5GIDBPIXP4">
-<catDesc>Kopenhagen</catDesc>
-<category xml:id="tla73Z6YQ3VWRH3BJIOTAMO3KHMEU">
-<catDesc>Thorvaldsen Museum</catDesc>
-</category>
-<category xml:id="tlaGWDDUG7C3VEX3LTZSNW6ZYNPBI">
-<catDesc>Ny Carlsberg Glyptotek</catDesc>
-</category>
-<category xml:id="tlaOC4FXKDV6BAQ5D2FXSTT7RRKVY">
-<catDesc>Nationalmuseet</catDesc>
-</category>
-<category xml:id="tlaZXOO62EMLZFBNLSWR5RREZS4UQ">
-<catDesc>C. Niebuhr Instituttet</catDesc>
-</category>
-</category>
-</category>
-</category>
-<category xml:id="tlaHRTGFPJGPVAYTNSJFKRJQTBNPQ">
-<catDesc>Mittelamerika</catDesc>
-<category xml:id="tla33TBKRCHYJCMDKL5QLQS52RPSU">
-<catDesc>Kuba</catDesc>
-<category xml:id="tla4TI2MW6UCVDJHA3BBXIWZQOAKE">
-<catDesc>Havana</catDesc>
-<category xml:id="tlaGJTJOWF4TBHDHGY2NKE2SRHQYI">
-<catDesc>Museo Nacional, Palacio de Bellas Artes, Inst. Nacional de Cultura</catDesc>
-</category>
-</category>
-<category xml:id="tlaILXEZHTDKRH2HMZG3I4JVYZXJM">
-<catDesc>Santiago de Cuba</catDesc>
-<category xml:id="tlaDUJ47VYQUBBUVDWHUW22HVX3HA">
-<catDesc>Museo Emilio Bacardi Moreau</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaBUA3DJAWIFAHDDUCJFLAEVSWJY">
-<catDesc>Mexiko</catDesc>
-<category xml:id="tlaHIRAQGSLSFGKLFMBP5RVCAGNR4">
-<catDesc>Mexico Stadt</catDesc>
-<category xml:id="tla2NFAFRGYSJFIPAAFGTUMOBLMAE">
-<catDesc>Museo Nacional de Antropologia</catDesc>
-</category>
-</category>
-</category>
-</category>
-<category xml:id="tlaNKKY5E7SXVBNLNYKVOZVHAT3VM">
-<catDesc>Asien</catDesc>
-<category xml:id="tla3TSH7T3TFRCEJAWITWOPKVVK7U">
-<catDesc>Indien</catDesc>
-<category xml:id="tla6LGFFUH3AJBOLGXKVCAISJHB2U">
-<catDesc>Kalkutta</catDesc>
-<category xml:id="tla5FHRRLNRX5GIPG6PXKHWGODEYU">
-<catDesc>Indian Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaKBMI3GLUMNFPDEY2XR7MXSVPQQ">
-<catDesc>Baroda</catDesc>
-<category xml:id="tlaJSP4GEMEFJFVVANOPV4ABTBD2A">
-<catDesc>Museum and Picture Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaPB5GX7LNW5EEPL3AEIHGYXPSSQ">
-<catDesc>Bombay</catDesc>
-<category xml:id="tlaLOCR2PIMHNCBVG7OLDCMCTVMUE">
-<catDesc>Prince of Wales Museum of Western India</catDesc>
-</category>
-</category>
-<category xml:id="tlaQ4HWL7H4HBBWND4FXBLDU67ZWQ">
-<catDesc>Lucknow</catDesc>
-<category xml:id="tlaSDKPKHELJJBSNESEYAHJLBXAHA">
-<catDesc>State Museum</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tla4IF3RAYNBND5LCI4RZQUAVOPEM">
-<catDesc>Georgien</catDesc>
-<category xml:id="tlaFDLF3P5HTNDU3PBSSL25532YMQ">
-<catDesc>Sotschni</catDesc>
-<category xml:id="tlaPHI7TVXYPZH75MZRGSWNYV2ZUE">
-<catDesc>Museum of History of Socni</catDesc>
-</category>
-</category>
-<category xml:id="tlaITFVBGDHWZHFBAP2KT5G3IZO7Y">
-<catDesc>Tiflis</catDesc>
-<category xml:id="tla6YZFYKSTTFFCHO5SLYC3SBNG7Q">
-<catDesc>Art Museum of Georgia</catDesc>
-</category>
-<category xml:id="tlaZFU5OB2MYNHOVATOWE3AMHMZ6I">
-<catDesc>State Museum of History of Georgia</catDesc>
-</category>
-</category>
-<category xml:id="tlaJVJ6R5EZ2ZGITEKUZJ3FD3ELLY">
-<catDesc>Suchumi</catDesc>
-<category xml:id="tlaTP2XXEU2MVGSXAIFWGVNSZFUY4">
-<catDesc>State Museum of Abkhazia</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tla62CXDP4W6JAMHPWUW2FZSBITEA">
-<catDesc>Japan</catDesc>
-<category xml:id="tla4ZEQB5RG7JAV3BS33W5JI3JZIQ">
-<catDesc>Kioto</catDesc>
-<category xml:id="tlaDKPLZXWNYNBXNESZZ5XWQSX24Q">
-<catDesc>The Museum of the Faculty of Letters, Kyoto University</catDesc>
-</category>
-</category>
-<category xml:id="tlaECKSZ5IW7FGF3OPXELEDI2S7KU">
-<catDesc>Nariwa</catDesc>
-<category xml:id="tlaHT2BPZH3NJGB3P7CD76RLLR54Q">
-<catDesc>The Nariwa Culture Centre Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaSTSLE4JD4ZF6JOVGBOAMQITKQQ">
-<catDesc>Tokio</catDesc>
-<category xml:id="tla3ZQZ7GJG3JAGRL42KOQQA6JOFU">
-<catDesc>Matsuoka Museum of Art</catDesc>
-</category>
-<category xml:id="tla7CPTMPC4IBEE3PQAXMCZMYJXSY">
-<catDesc>Idemitsu Art Gallery</catDesc>
-</category>
-<category xml:id="tlaCTYQ7PYSANFPVCZKHD7LWUDM2I">
-<catDesc>University Museum, Waseda University, School of Literature</catDesc>
-</category>
-<category xml:id="tlaLN2UOWDQT5EO3KWN2V66DVPFQU">
-<catDesc>Bridgestone Museum of Art, Ishibashi Foundation</catDesc>
-</category>
-<category xml:id="tlaSARNLQNSBVCFRBP5XEOJ3ZSI7Y">
-<catDesc>Geijutsu Daigaku Shiryokon</catDesc>
-</category>
-</category>
-<category xml:id="tlaW2RCCBNU7NHH5NIQSLXVTWJSZM">
-<catDesc>Tenri</catDesc>
-<category xml:id="tlaGP5SNWXMANFNPL7JQERQTB7EMQ">
-<catDesc>Tenri Sankokan Museum</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaARZVMG6BFFEPDKPK32JZPRRXAA">
-<catDesc>Jemen</catDesc>
-<category xml:id="tla4FOLMU4W6JDGLFKA6RVZMBFLZM">
-<catDesc>Aden</catDesc>
-<category xml:id="tlaLNF4KOUOWRERZPUYVTRB3SDCDU">
-<catDesc>Ägyptische Sammlung</catDesc>
-</category>
-<category xml:id="tlaPSP2RUOWEZH6ZME3YLMWHH6YAY">
-<catDesc>National Museum, Department of Antiquities and Museums</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaB4BGAYEEQJFIDDDEEQJYFRCNII">
-<catDesc>Turkmenistan</catDesc>
-<category xml:id="tlaQ6FKCYFC6RBCTKBJWUOHPQEOXA">
-<catDesc>Aschchabad</catDesc>
-<category xml:id="tlaMWOWVZ5NB5GTFC6SO6LYSTEYDU">
-<catDesc>Institute of History of the Academy of Sciences</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaDPVV7MMSGRD5LGNLGPVCOXO6W4">
-<catDesc>Irak</catDesc>
-<category xml:id="tlaBYDLODHJWRGEFORPRA267VW3C4">
-<catDesc>Mossul</catDesc>
-<category xml:id="tla3K6MEABQIZFQ5B752J6HQRQU2Y">
-<catDesc>Ägyptische Sammlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaP2K7VYKEPBA3LHBKKERKO62EDQ">
-<catDesc>Bagdad</catDesc>
-<category xml:id="tla72ZTEBR4SFD2TDYAZZIRUUZ464">
-<catDesc>State Organisation of Antiquities and Heritage, Iraq Museum</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaGNXVXK244RAI5OWHNY5PZ6V6Y4">
-<catDesc>Libanon</catDesc>
-<category xml:id="tlaABNMPZELBVELNMWBVJRBIP26WE">
-<catDesc>Beirut</catDesc>
-<category xml:id="tlaIJWDGL2N5VFXFJD6UEKDT6JBMU">
-<catDesc>National Museum</catDesc>
-</category>
-<category xml:id="tlaK42GQGD2A5BEBPT6MLWIBNC7TA">
-<catDesc>Archaeology Museum, American University of Beirut</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaH4QDFSZ7KRDZPJYTBDJF2WCX7A">
-<catDesc>Aserbaidschan</catDesc>
-<category xml:id="tlaSVDB4LC3YVDA5IBIPU2QS2JWXM">
-<catDesc>Baku</catDesc>
-<category xml:id="tla5DNTPKNEDVGH5JLA4MXKU2OEZA">
-<catDesc>Museum of History of Azerbaijan</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaJ2FDR35S6VE3FFDBORGPY5ISLI">
-<catDesc>Türkei</catDesc>
-<category xml:id="tla6SAVLXUSSBCSRAZ6UGDSUEEIJM">
-<catDesc>Selçuk</catDesc>
-<category xml:id="tlaBDZCBMMDP5BUVPAATNZ3G2N22U">
-<catDesc>Efes Müzesi</catDesc>
-</category>
-</category>
-<category xml:id="tlaA3SKL4PQVRFIFM3PJOAEFHKE6A">
-<catDesc>Ankara</catDesc>
-<category xml:id="tlaFRHN5MPCVNGQLJKKLQI766XIII">
-<catDesc>Museum of Anatolian Civilisations</catDesc>
-</category>
-</category>
-<category xml:id="tlaZND4XMSSC5B7HEZM7OS2S2NGKY">
-<catDesc>Istanbul</catDesc>
-<category xml:id="tla2OUMXLBPRZB25MIEIPKMFKZ6F4">
-<catDesc>Ancient Oriental Museum</catDesc>
-</category>
-<category xml:id="tlaYCATUS2HYFGJPOSLHXC4M6N6TU">
-<catDesc>Arkeoloji Müzesi</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaJLARKESMRZC2TOKWBKY5ORH3AI">
-<catDesc>Iran</catDesc>
-<category xml:id="tlaMML2HZZPLNF6XJQB4LK3S3TNH4">
-<catDesc>Teheran</catDesc>
-<category xml:id="tlaB2JDA7GRKZG4BNU4TGEHZZLL4Q">
-<catDesc>Museum Iran Bastan</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaJLJDEBUSVRHWBHD7H7XK2UCWUM">
-<catDesc>Sri Lanka</catDesc>
-<category xml:id="tla5OBTHX3GCZDA5EYM7HE4UA5FFM">
-<catDesc>Colombo</catDesc>
-<category xml:id="tlaCTCFFYJ4BRDP5A7DWKMTODA4CU">
-<catDesc>National Museum</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaODTUL6WZRRFYXIL5Q4B6IHP364">
-<catDesc>Israel</catDesc>
-<category xml:id="tla2O64C2SVEFDAPPOMXLWU6LAR3Y">
-<catDesc>Tel Aviv</catDesc>
-<category xml:id="tlaD4PCJLJWABFIBHGGPEFZNV3RRY">
-<catDesc>Museum of Antiquities of Tel Aviv-Yafo (Haaretz Museum)</catDesc>
-</category>
-<category xml:id="tlaHQ47VQOFQBFC5I75SCNLITRIPE">
-<catDesc>Nehusthan Pavilion</catDesc>
-</category>
-<category xml:id="tlaTUX6AHOCYNGZLCVC4AMAYCHVCY">
-<catDesc>Institute of Archaeology</catDesc>
-</category>
-</category>
-<category xml:id="tla46YBKCNWEVBY3BMKQGXFMGFNV4">
-<catDesc>Beit Shean</catDesc>
-<category xml:id="tla6MVBKPZRUNH2ZPMHPSILWFR2UI">
-<catDesc>Municipal Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaHZR2J5B3C5AQHEMCK5EHOOKHKE">
-<catDesc>Eyn Hashophet</catDesc>
-<category xml:id="tlaCMIWPIY25FHZJHWRSBZEPRJHKQ">
-<catDesc>Ägyptische Sammlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaL7KZALOCUZDZHFKJT3367CBFYY">
-<catDesc>Deganya Aleph</catDesc>
-<category xml:id="tlaHS4DTWVDUFCIRJ24ADHOPD7V4U">
-<catDesc>Bet Gordon</catDesc>
-</category>
-</category>
-<category xml:id="tlaO4TRKZB54BDKXJURYNPZONVMCI">
-<catDesc>Kibbutz Kfar Menahem</catDesc>
-<category xml:id="tlaKG26QLIWGVCUPFHKY52FJ5UUN4">
-<catDesc>Shephela Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaOFFTXEE44ZCT3LHNKHAW4FR4NU">
-<catDesc>Jerusalem</catDesc>
-<category xml:id="tlaAZSS3AA2Y5FPHGH6EBST4B55ME">
-<catDesc>Museum of Assumptionist Fathers</catDesc>
-</category>
-<category xml:id="tlaELDUISRRQZFJZGDUA4W7MT7K5M">
-<catDesc>Flagellation Museum, Museum of the Studium Biblicum Franciscanum</catDesc>
-</category>
-<category xml:id="tlaFYM4NCYWAREFTIPEVC4RCUI44Y">
-<catDesc>The Bible Lands Museum</catDesc>
-</category>
-<category xml:id="tlaGACMONL5SVF3XKJSBIW3NG6XEM">
-<catDesc>L. A. Mayer Museum</catDesc>
-</category>
-<category xml:id="tlaKSF6PLNZZFCPFNHANYIZZMSCQI">
-<catDesc>Pontifical Biblical Institute Museum</catDesc>
-</category>
-<category xml:id="tlaR3HJSETHDZEOJOVE6GHVUYUYWU">
-<catDesc>Bezalel National Art Museum (The Israel Museum)</catDesc>
-</category>
-<category xml:id="tlaRAHSJKEBFFDSTLMYHYVURRAFUM">
-<catDesc>H. E. Clark Collection</catDesc>
-</category>
-<category xml:id="tlaRK4ZTTSJTFFRTC32LYTRIXGVRQ">
-<catDesc>Russian Monastery on the Mount of Olives</catDesc>
-</category>
-<category xml:id="tlaW77NR7CEE5GFPEV6P4EMT6PH2Q">
-<catDesc>Rockefeller Archaeological Museum</catDesc>
-</category>
-<category xml:id="tlaXB7X32CZTBE37I5FBM4ZOV56UI">
-<catDesc>Israel Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaQLNXWR37KRDVLNK5MNWQRUBQ4E">
-<catDesc>Ramat Hashofet</catDesc>
-<category xml:id="tlaY7XYUHRTH5ELFDFQLABGZCNENQ">
-<catDesc>Archaeological Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaR5O3CDKD6JC23OPC3UN6LGI5G4">
-<catDesc>Nir David</catDesc>
-<category xml:id="tlaYBCCYMKUAJBUPBXMBWGPF3TNUM">
-<catDesc>Museum of Mediterr. Archaeology</catDesc>
-</category>
-</category>
-<category xml:id="tlaS3EDH3V5AFHHBHC6TTUMNVWQDU">
-<catDesc>Haifa</catDesc>
-<category xml:id="tlaJUDVCPUBBZGR5HYDKXTRZYJK2Q">
-<catDesc>Dagon Collection</catDesc>
-</category>
-<category xml:id="tlaMDXWKUWFLNB67LRW6SMQNAQN2M">
-<catDesc>National Maritime Museum</catDesc>
-</category>
-<category xml:id="tlaNJMGSP5URNH3TKZ2NXXAWKHKHE">
-<catDesc>Museum of Ancient Art</catDesc>
-</category>
-<category xml:id="tlaV6ZTNTCZAVBWNKJ57WOS6QROXM">
-<catDesc>Music Museum</catDesc>
-</category>
-<category xml:id="tlaVUFOGFREH5GPRKGHSOMLA7I6CQ">
-<catDesc>R. and E. Hecht Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaV27WPJWHPRH57GT7WIHO6XENLA">
-<catDesc>Kibbutz Hazorea</catDesc>
-<category xml:id="tlaS5Y34A3UD5EHDIAAUE43NPMY24">
-<catDesc>Wilfred Israel House for Art and Oriental Studies</catDesc>
-</category>
-</category>
-<category xml:id="tlaXDPO5W62GZDA7AULLU2JAS4G2E">
-<catDesc>Akkon</catDesc>
-<category xml:id="tlaYBQC6TEVPZEJHCSSTPW72FJNWI">
-<catDesc>Municipal Museum</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaTSD2YCQLQFE7VBL6NTTU6VQYZY">
-<catDesc>Armenien</catDesc>
-<category xml:id="tlaMVSM3M2UQZGUJOUSRNKR2VILHY">
-<catDesc>Eriwan</catDesc>
-<category xml:id="tlaDK55FGARIZDUNKVZBRWQMFIKC4">
-<catDesc>State Museum of History of Armenia</catDesc>
-</category>
-<category xml:id="tlaJXQP2WJTHNFC5KLIZYZLC2CAIM">
-<catDesc>State Picture Gallery of Armenia</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaW2R272TFG5GBNGGAR2BNNAJJUE">
-<catDesc>Zypern</catDesc>
-<category xml:id="tla734GWEXPKZBYHKRETJMZQP65IY">
-<catDesc>Nikosia</catDesc>
-<category xml:id="tlaAUP7RP3OAVGPNPLKBYZ22WNHVA">
-<catDesc>The Cyprus Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaXYCOEXETMJAKLEG7JJZBZN556M">
-<catDesc>Limassol</catDesc>
-<category xml:id="tlaY67S6XNFUJF4TMECUUKL5GKZWU">
-<catDesc>Limassol District Museum</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaZ46G5LOM55D4NPMFM4RJ6PAZ7M">
-<catDesc>Jordanien</catDesc>
-<category xml:id="tlaT5MA2ABDWVAN7A5J7NJ44CMTQE">
-<catDesc>Amman</catDesc>
-<category xml:id="tlaJZFD5WRWUNGNHNAYALHRSTR2LM">
-<catDesc>Jordan Archaeological Museum, Department of Antiquities</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaZBP5TCODHBHPJDKSA7ATWUIMDQ">
-<catDesc>Syrien</catDesc>
-<category xml:id="tlaCQP72RV7SNGWTCJNCL5GD4YSSY">
-<catDesc>Lattakia</catDesc>
-<category xml:id="tla64KYRG4UYJCYZO26OCN3D2KARA">
-<catDesc>Ras Shamra Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaD3IDW5CAPVBKTIYSD52VNEWNPY">
-<catDesc>Damaskus</catDesc>
-<category xml:id="tlaDBQ4IG2ZAZHWFHOX6T4S5CEPOA">
-<catDesc>National Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaLAPH6WYSQJA3RBDMEYANWWXK4A">
-<catDesc>Aleppo</catDesc>
-<category xml:id="tlaN6WSO2PU7ZBOZBCCEKJBGFVQ54">
-<catDesc>Aleppo National Museum</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaZZDWN4HT2BAVTBUP5ZHKX6J7CY">
-<catDesc>Tadschikistan</catDesc>
-<category xml:id="tlaTLHJBTCCQFEIHFHV7CFC7QEUVM">
-<catDesc>Duschanbe</catDesc>
-<category xml:id="tlaQY3RXJKZPZAZTAO3FRVV5TGWNI">
-<catDesc>Institute of History, Archaeology and Ethnography of the Academy of Sciences of Tadschikistan</catDesc>
-</category>
-</category>
-</category>
-</category>
-<category xml:id="tlaPRXVLUJ7ENA4PH6XIPENAXFNZI">
-<catDesc>Australien und Neuseeland</catDesc>
-<category xml:id="tlaDUWGYNLAMRCYZD47WDAUQNIFPU">
-<catDesc>Neuseeland</catDesc>
-<category xml:id="tlaHXKXKSWVKJCL7O7B2JJ5UXLGII">
-<catDesc>Wellington</catDesc>
-<category xml:id="tlaZDEXVOY7P5E4NJEA2Z5OFGN7YU">
-<catDesc>Dominion Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaI2GRNFP75RAUZAFXA5XIHFDXGU">
-<catDesc>Palmerston North</catDesc>
-<category xml:id="tlaMV5FYY7K2BF7ZCX6RFYKYEK4EM">
-<catDesc>Public Library</catDesc>
-</category>
-</category>
-<category xml:id="tlaPF3EHNY22RBVLHZMO37ZIH2DHQ">
-<catDesc>Auckland</catDesc>
-<category xml:id="tlaBJXIVRMG7JEH5MIVCL5XBDOGRU">
-<catDesc>Museum, Ägyptische Sammlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaPHN3MY63FNGMVCAHTD3BGWNKVI">
-<catDesc>Dunedin</catDesc>
-<category xml:id="tlaLJ73RLGAQFH45K5RS3R6SBZXIM">
-<catDesc>Otago Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaXVFT3MFVENDQDKHDL656YLLL6M">
-<catDesc>Christchurch</catDesc>
-<category xml:id="tlaJSIHVVBRCJHTRKOFD6VBIOAZT4">
-<catDesc>Ägyptische Sammlung</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaOS5UQ6XEGNFKDGN5DCZHZULJ2I">
-<catDesc>Australien</catDesc>
-<category xml:id="tlaA5VEBLTROJBBLN2O2THGVUGU6E">
-<catDesc>Adelaide</catDesc>
-<category xml:id="tla26Z23C5OB5CKPM2IFVQ77RIFX4">
-<catDesc>University Museum of Classical Archaeology</catDesc>
-</category>
-<category xml:id="tlaXAYZQGKLQRA3LMQDH4CPQZ6IXQ">
-<catDesc>South Australian Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaN2ZFMA2LU5C4ZIGTHPZQUJILXY">
-<catDesc>St. Lucia (Queensland)</catDesc>
-<category xml:id="tlaAWGNDDRHYZBKPGWWTM75IG2PKM">
-<catDesc>University of Queensland Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaPYQBOAZZT5BXPOVPLD3DOY6QBA">
-<catDesc>Hobart</catDesc>
-<category xml:id="tlaJ62ZBSON25EQBK7TE55SZWSSOQ">
-<catDesc>Tasmanian Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaWZAS3PCOCVATTGSOSMORROVVOE">
-<catDesc>Melbourne</catDesc>
-<category xml:id="tla6POILMR5PBGM5KZZHF22NNEFGU">
-<catDesc>Victoria Arts Center</catDesc>
-</category>
-<category xml:id="tlaPFH2J4FLJBH5XLTDTZE54Y6KLQ">
-<catDesc>National Museum of Victoria</catDesc>
-</category>
-<category xml:id="tlaULBOLLKJB5F3XA2NP7BEHGAK7M">
-<catDesc>Australian Institute of Archaeology</catDesc>
-</category>
-<category xml:id="tlaZSAHGINTIVCJBBIMFWSAB6K6YQ">
-<catDesc>National Gallery of Victoria</catDesc>
-</category>
-</category>
-<category xml:id="tlaZPAJPPRVMRD77PT4BJNHHVNGPI">
-<catDesc>Sydney</catDesc>
-<category xml:id="tlaHQ7LEIHVXRCQDKKIXJDJF7JUAY">
-<catDesc>Australian Museum</catDesc>
-</category>
-<category xml:id="tlaPBYPXOGCXJAIVG755F625PDPHA">
-<catDesc>Macquarie University, School of History, Philosophy and Politics</catDesc>
-</category>
-<category xml:id="tlaVBO4IXJ2NRHSLBYIGW2I35LBYE">
-<catDesc>Nicholson Museum of Antiquities</catDesc>
-</category>
-</category>
-</category>
-</category>
-<category xml:id="tlaVEI3KVRNMJEOLF4EWOBXCV4XWM">
-<catDesc>Südamerika</catDesc>
-<category xml:id="tla6AU4NQFB7RCYHEYMZFZ4PNBGG4">
-<catDesc>Venezuela</catDesc>
-<category xml:id="tlaU6T6MBT5ONG6LKG5SJJPOJY2NM">
-<catDesc>Caracas</catDesc>
-<category xml:id="tlaITLHGDCOIZGFPF46BRLTY3ZOSI">
-<catDesc>Museo de Bellas Artes</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaASGQILDAMBBWDIJQDBIDRLGUCU">
-<catDesc>Kolumbien</catDesc>
-<category xml:id="tlaIHC3BF6M5BFLZHF6R4RWLP7DMA">
-<catDesc>Bogota</catDesc>
-<category xml:id="tlaDCATFYQY2ZDGZEGFVCRAGZ5U2M">
-<catDesc>Inst. de Ciencias Naturales, Museo de Historia Natural, Univ. Nac.</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaBK3Z2HN47JCWHCA3ITSLAN7MKI">
-<catDesc>Argentinien</catDesc>
-<category xml:id="tla2R2XC7WQJVBNRNPAMWMXCPBN4U">
-<catDesc>Buenos Aires</catDesc>
-<category xml:id="tla3I2C7E4KY5DQZFPNHITYTTIMBM">
-<catDesc>Museo Nacional de Arte Oriental</catDesc>
-</category>
-<category xml:id="tla6BHDJGQG6FCWJAM73VVYG66RTE">
-<catDesc>Museo Etnográfico de la Facultad de Filosofia y Letras</catDesc>
-</category>
-</category>
-<category xml:id="tlaIKO5UG7Y4FG65LQBZEMRLVHLMI">
-<catDesc>La Plata</catDesc>
-<category xml:id="tla44SOM5H5CBCKLFLUM44M5PQ3K4">
-<catDesc>Museo de Ciencias Naturales de la Plata</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaHBALTY4BFVEX7JF3BR7MTYP3FU">
-<catDesc>Uruguay</catDesc>
-<category xml:id="tlaD7YO2DMCJRER7EANIW4JCRFFTA">
-<catDesc>Montevideo</catDesc>
-<category xml:id="tlaGXQXT3BDT5HYDGEJUEC5W4HO5Q">
-<catDesc>Sociedad Urug. de Egiptologia</catDesc>
-</category>
-<category xml:id="tlaHN3BJZU3MZHPVEMLA7ADLAHQEA">
-<catDesc>Museo Nacional de Historia Natural</catDesc>
-</category>
-<category xml:id="tlaN2PE6WQQHRA3XH5JF5AUVUAYEA">
-<catDesc>Museo de Historia del Arte</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaX4P253DSYJE3PIS2MGBIVDAWM4">
-<catDesc>Brasilien</catDesc>
-<category xml:id="tla6DSFU6TGVNGGVPVKBK34MGDXNU">
-<catDesc>Sao Paulo</catDesc>
-<category xml:id="tlaHTVKMMVCZ5BHPCBVM3TZ7CUFAQ">
-<catDesc>Museu de Arqueologia e Etnologia da Universidade de Sao Paulo</catDesc>
-</category>
-</category>
-<category xml:id="tlaC3GW6CTRE5BN3GTLA2FHEPBYJU">
-<catDesc>Rio de Janeiro</catDesc>
-<category xml:id="tlaEW6GB7VDQ5ERVKGRPFEEOCUXWI">
-<catDesc>Museu Nacional</catDesc>
-</category>
-<category xml:id="tlaYKBM2I5PZ5BYPI5WAVSNHRVNWY">
-<catDesc>Museu Nacional de Belas Artes</catDesc>
-</category>
-</category>
-</category>
-</category>
-<category xml:id="tlaW2NJGUEPWZGO7MMOJ6EANCRT7Y">
-<catDesc>(in situ)</catDesc>
-</category>
-<category xml:id="tlaWYXAL6F6XRH4VOZFX4MY7E63UM">
-<catDesc>(Grabungsmagazin)</catDesc>
-<category xml:id="tla4PXSC254BNHSDKRNHUFTNZZNXE">
-<catDesc>IFAO / Balat</catDesc>
-</category>
-<category xml:id="tlaPXOB5NUUGFFXDFRWVQCURFBNLQ">
-<catDesc>IFAO / Deir el-Medine</catDesc>
-</category>
-<category xml:id="tlaT4MI6A2RKBAF7LTB7XMV37IIUQ">
-<catDesc>SCA / Edfu</catDesc>
-</category>
-</category>
-<category xml:id="tlaZBOIYJ5VIJC6RIX6XKP2JVYCQQ">
-<catDesc>Afrika</catDesc>
-<category xml:id="tlaKKWN4OPL3JHQ7JROLGJN2SF2DU">
-<catDesc>Libyen</catDesc>
-<category xml:id="tlaPPK2CCGIBNDWVO4N7D2GFBD3KY">
-<catDesc>Kyrene</catDesc>
-<category xml:id="tlaC422FCIA2BGRXH4RY4GLSFZW7A">
-<catDesc>Museum of Sculpture</catDesc>
-</category>
-</category>
-<category xml:id="tlaZMOBLLCNNJENXJVI5HARRKZRVA">
-<catDesc>Marsa Susa</catDesc>
-<category xml:id="tlaH7MHTR5QC5EBNG4JV4U34FHVJA">
-<catDesc>Apollonia Museum</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaKKZRW2AAZVDVZPMGEB7MYOLE7U">
-<catDesc>Ägypten</catDesc>
-<category xml:id="tla2N5F6U34VRH77MOCMXIMWFH5RI">
-<catDesc>Mit Rahina</catDesc>
-<category xml:id="tla73V43UBBHBHRDITBHEWBNEJM7M">
-<catDesc>Mit Rahina Museum</catDesc>
-</category>
-</category>
-<category xml:id="tla4ZSAUJUBXNBJZFGBEAOVAZBJR4">
-<catDesc>Miniya</catDesc>
-<category xml:id="tlaSFHATSIQ7JF7PE2SDIAP7PYH2I">
-<catDesc>Minia Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaBDNNGM4DQJG3RBIFDPV2SIBWSQ">
-<catDesc>Gisa</catDesc>
-<category xml:id="tlaJMDQOBFRHBAY7OEQDETSCVL7NA">
-<catDesc>Solar Boat Museum (Cheops Boat Museum)</catDesc>
-</category>
-</category>
-<category xml:id="tlaBYYUJ7HO3ZHRZBXCQGSBDUAYAU">
-<catDesc>Aschmunein</catDesc>
-<category xml:id="tlaNGADXQ3ESJDVDBPVJAONUF22II">
-<catDesc>Aschmunein Open Air Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaCRVKATGHKRFVPDBMEAS3JOGC4A">
-<catDesc>Suez</catDesc>
-<category xml:id="tla6NMGPCALOFB7HOADWCPCQEH7MU">
-<catDesc>Suez Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaDBHDNJ6RCFDPNA55JWWL2FNQBQ">
-<catDesc>Assuan</catDesc>
-<category xml:id="tlaHDFJH4PFKZGOHP56GY33AKWUNA">
-<catDesc>Nubia Museum</catDesc>
-</category>
-<category xml:id="tlaT745TE3455CMRNS4P6CWP7SJNI">
-<catDesc>Aswan Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaEU6PE7DH6ND3HB47RZKZJLPT5M">
-<catDesc>Ismailia</catDesc>
-<category xml:id="tlaILFJIZTXUVFNLPB5X6QNLBGNIE">
-<catDesc>Ismailia Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaFX2GFRKAINAEZATKEN73AHNWXU">
-<catDesc>Tanta</catDesc>
-<category xml:id="tlaX3ECQYUH3ZEXLIWDCSFXGNHDKQ">
-<catDesc>Tanta Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaGBA6NM4VHJBPNPYA4NJRWL5GLA">
-<catDesc>Kom Ushim</catDesc>
-<category xml:id="tlaNETL5EWR2VEGVLQ5T4XC75FV24">
-<catDesc>Kom Ushim Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaKQHATHCJQRHNNKEYUY3X2BDHXE">
-<catDesc>Zaqaziq</catDesc>
-<category xml:id="tla55TJTPTPYRDRFDDOWF77YYUB7M">
-<catDesc>Tell Basta Site Museum</catDesc>
-</category>
-<category xml:id="tlaKVXK7WJ5HVBT3ETQWF37QP7M3I">
-<catDesc>University of Zagazig Museum</catDesc>
-</category>
-<category xml:id="tlaLLYTPT7Q5RFGDKGRJ3VBMACFCM">
-<catDesc>Heriyet Rezan Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaLEDUZK7TSBBLXODTUQHW32CDZ4">
-<catDesc>Kafr el Sheikh</catDesc>
-<category xml:id="tlaPPKLJBCLRFBA5GDOOLQMH6EVEA">
-<catDesc>Kafr el Sheikh Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaMYHP23AZPNEDTJJ2NYEUXCFYYU">
-<catDesc>Kharga</catDesc>
-<category xml:id="tlaLQYVEUWWKVABVBDMK2MEJVLVXA">
-<catDesc>Wadi el-Gedid Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaNGDSOENKOZEJVENPFKPHYAE7PE">
-<catDesc>Mallawi</catDesc>
-<category xml:id="tlaXVHJ64ITNZCIBOW5W7TAS5ZCQQ">
-<catDesc>Antiquities Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaSPF5BCZGVRHXVKOXSY766QA5Q4">
-<catDesc>Alexandrien</catDesc>
-<category xml:id="tlaAH2QWPACOVAFVLPNIS7RFSHRHI">
-<catDesc>Museum of the Faculty of Arts, University of Alexandria</catDesc>
-</category>
-<category xml:id="tlaTP365PO46JHC7P53USYDPVXD2A">
-<catDesc>Graeco-Roman Museum</catDesc>
-</category>
-<category xml:id="tlaV2JRHODWCVALDF2CNVYBOHNI6A">
-<catDesc>Jewellery Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaUSF6WYKVRRFHTLDM2OFI4XOD5A">
-<catDesc>Port Said</catDesc>
-<category xml:id="tlaVYEMC5AU2FC4TLDGHZQRSNQIOI">
-<catDesc>Port Said National Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaWLRFN3FJ4RBC5NQMV2YL546FLA">
-<catDesc>Assiut</catDesc>
-<category xml:id="tlaTHQ2QZHLBVD65A6JWVHMJKX27I">
-<catDesc>Beni Suef Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaX4BF5GAM7RCRJPXDA4PBUJGRWA">
-<catDesc>Sohag</catDesc>
-<category xml:id="tlaJH3DVVIUI5BMPLADOSYP3IYWLQ">
-<catDesc>Sohag Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaXDYKAWWYWBHFPP7MVKZA2MRZYA">
-<catDesc>Karnak</catDesc>
-<category xml:id="tlaB4XRRILT75HU5ET2FGGCPETHNE">
-<catDesc>Open-Air Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaYAK5GHWPNNHBPLSBJRU6I6FMR4">
-<catDesc>Kairo</catDesc>
-<category xml:id="tla2E4T57M7NZCC7EYM5U3IDHE5XE">
-<catDesc>Mohammed-Mahmoud-Khalil Museum</catDesc>
-</category>
-<category xml:id="tla2I2LDPDNQFFGNNMNDWAADCPQGE">
-<catDesc>Gezira Public Gardens</catDesc>
-</category>
-<category xml:id="tla2SMNTZV4W5GBFKJHK3T7EIL2PA">
-<catDesc>Cairo University - Faculty of Archaeology Museum</catDesc>
-</category>
-<category xml:id="tla3KQI62T3HJBFRPEQU6BD4CGSUU">
-<catDesc>Madbotat el-Athar Museum (confiscated Antiquities Museum) (Citadel of Salah el-Din)</catDesc>
-</category>
-<category xml:id="tla3QYRRW4V2FCATFOEGXFFU2EZ4M">
-<catDesc>Lycée Liberté (Lycée Français)</catDesc>
-</category>
-<category xml:id="tla5V4LG32PKVAPVEMXZSWTV2ZXEY">
-<catDesc>Coptic Museum</catDesc>
-</category>
-<category xml:id="tla7GIJHHMIE5C3VNVOTQFKMOUXEE">
-<catDesc>Military Museum (Citadel of Salah el-Din)</catDesc>
-</category>
-<category xml:id="tlaAY7SHCZNRNCDRMXCQKNBIRLXTY">
-<catDesc>College of the Holy Family</catDesc>
-</category>
-<category xml:id="tlaDZQ3HGHMKFGM3GZRVAZNQLX76E">
-<catDesc>St. George&#039;s Monastery</catDesc>
-</category>
-<category xml:id="tlaIUDG3ARYZFFNTDWLVUWQ5FAJPE">
-<catDesc>Police Museum (Citadel of Salah el-Din)</catDesc>
-</category>
-<category xml:id="tlaJ473G3GFQVGFVHFF3B3AB5SKNM">
-<catDesc>Heliopolis Open Air Museum</catDesc>
-</category>
-<category xml:id="tlaLFXQK5IVQBGZPICA3WNBIEATZI">
-<catDesc>Institut Français d&#039;Archéologie Orientale</catDesc>
-</category>
-<category xml:id="tlaQNUUX2SQTRCN7OZE22UOADOM6Q">
-<catDesc>Cairo University - Faculty of Medicin</catDesc>
-</category>
-<category xml:id="tlaQVHPZOLDRJCAPDFIMOGCLRC73Q">
-<catDesc>Bibliothèque Bonaparte</catDesc>
-</category>
-<category xml:id="tlaRJR6FHP26FBPVMGXDXHLLZIG2Y">
-<catDesc>Egyptian Museum</catDesc>
-</category>
-<category xml:id="tlaSHEYFEYFERBDRM6UX3MCGXMEFY">
-<catDesc>Collège St. Joseph des Frères des Écoles Chrétiennes</catDesc>
-</category>
-<category xml:id="tlaTXBFVDBDQZCE3NBAM6UYSMCSMA">
-<catDesc>El-Matar Museum (Cairo Airport)</catDesc>
-</category>
-</category>
-<category xml:id="tlaYUWN7GZG5VBTPHKGFONPBFB4DE">
-<catDesc>San el-Hagar</catDesc>
-<category xml:id="tlaZUJ7OMV66FAABCP3CDW2XQNRSU">
-<catDesc>San el-Hagar Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaZDOAPZWZHRC2VA2WOQAQVXOSNE">
-<catDesc>Luxor</catDesc>
-<category xml:id="tlaAOFQLOVTBBBFZCSAKOF5D5HCTE">
-<catDesc>Magazin des Antiquities Department</catDesc>
-</category>
-<category xml:id="tlaJDTW3SSLXVHWHPQXQKQNHLIATA">
-<catDesc>Mummification Museum</catDesc>
-</category>
-<category xml:id="tlaKWOO3IEZNJDG5BJNVWKW4ZQJJQ">
-<catDesc>Luxor Museum of Egyptian Art</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaO7RD3MGUNVEMVNC6QWNR67476E">
-<catDesc>Ghana</catDesc>
-<category xml:id="tlaT4UYNMHBZ5GUZHU53A7OZGUHTI">
-<catDesc>Accra</catDesc>
-<category xml:id="tlaWFAO76QHQJHGBPNYBAMAF6O7KA">
-<catDesc>National Museum</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaRAKJHF37SZHT5AYGVGEL5OPNXQ">
-<catDesc>Südafrika</catDesc>
-<category xml:id="tlaAJ2N3VXYKVDNVEM5FGVZHZHNN4">
-<catDesc>Kapstadt</catDesc>
-<category xml:id="tlaRXYDSJKS6ZGZTOEBANKC2X4JAE">
-<catDesc>South African Cultural History Museum</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaS5CPQOIHNBG7LAJ5XZL53O4BJ4">
-<catDesc>Äthiopien</catDesc>
-<category xml:id="tlaJH2O2R2MDZCRPN2526I5ELALLM">
-<catDesc>Addis Abeba</catDesc>
-<category xml:id="tlaSMA4AW3V5RED5AZFFQAM2R4JMM">
-<catDesc>Archaeological Museum</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaWUS7ZZ6SV5CLND4COTL3GJHF3U">
-<catDesc>Sudan</catDesc>
-<category xml:id="tla3U42AI6ZXRAFDB5LCAIOVGIZ2Y">
-<catDesc>Wadi Halfa</catDesc>
-<category xml:id="tlaUZZL4BIZABF73GECYEL6WKJZFM">
-<catDesc>Halfa Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaKUQJPMOY2NFX3NVHVL5SKACWSY">
-<catDesc>Merowe</catDesc>
-<category xml:id="tlaDNYCKCFHNBGIZA7TOKXWVF4SC4">
-<catDesc>Merowe Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaMFH6J5IO2ZG45BRUXOH6JVMWZY">
-<catDesc>Khartum</catDesc>
-<category xml:id="tlaFQN7XMJQABG43LWRHYNXRJW7OQ">
-<catDesc>Sudan National Museum</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaXULZVECEUNDAHKYWHJONSMR7WE">
-<catDesc>Tunesien</catDesc>
-<category xml:id="tla32Q36BQHKRGYZEIJ7D2KJWVYRA">
-<catDesc>Karthago</catDesc>
-<category xml:id="tlaWM7ULSQ4SBE7LIX653QIGMO5LY">
-<catDesc>Musée la Vigerie de St. Louis</catDesc>
-</category>
-</category>
-<category xml:id="tlaLAYL7F3Y35FRBKI2TS77GXFWXE">
-<catDesc>Tunis</catDesc>
-<category xml:id="tlaRXV7FZ3RCZBKXNWO6K6CEHIEG4">
-<catDesc>Musée National du Bardo</catDesc>
-</category>
-</category>
-</category>
-</category>
-<category xml:id="tlaZBSNWPNKRZH2FLOH76RV5BFZ6I">
-<catDesc>(unbekannt)</catDesc>
-</category>
-<category xml:id="tlaZQHEZY7AUZF6BM54XPO3Z3LOJU">
-<catDesc>Nordamerika</catDesc>
-<category xml:id="tlaL7ODVKNVFBCB3CU332IKL2SHDU">
-<catDesc>Kanada</catDesc>
-<category xml:id="tla4SV2RJH7ZNERZFDKTYY5Z643UQ">
-<catDesc>Regina (Saskatchewan)</catDesc>
-<category xml:id="tlaFRUFGWNGJBE2XBO3BIGL6JS3EA">
-<catDesc>Norman Mackenzie Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tla5I5KYSEDVNGJDMKXCJGKWLLDCY">
-<catDesc>Montréal</catDesc>
-<category xml:id="tla4YKLCAWUMNDG3JRCHWL7AG2BM4">
-<catDesc>McGill University Ethnological Museum</catDesc>
-</category>
-<category xml:id="tla54ELZYSVPFGYVKXYATU5OYIISM">
-<catDesc>Redpath Museum</catDesc>
-</category>
-<category xml:id="tlaXYTIDZJQHBC5JOVYFW77OXOF3Y">
-<catDesc>Musée des Beaux-Arts de Montréal</catDesc>
-</category>
-</category>
-<category xml:id="tlaHQRGBBEL7BAVHJY2CKJQ6WK5TM">
-<catDesc>Québec</catDesc>
-<category xml:id="tlaZDBK422JOZCD3OAVJP2QGEE2QY">
-<catDesc>Laval University Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaMP6VK5IW6FC55IRLVFCF3F3IHY">
-<catDesc>Niagara Falls</catDesc>
-<category xml:id="tlaWD5MKSBLXFC2TP522W2O44FOBQ">
-<catDesc>Niagara Falls Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaUAFFUFPXKFGFREB2U5ZDOKKNYA">
-<catDesc>Vancouver</catDesc>
-<category xml:id="tlaIDWTL7YCYVE5TOYKYJEBBYLHNA">
-<catDesc>Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaWKBSYZB3A5CDXFO4TPKPVS6ESI">
-<catDesc>Toronto</catDesc>
-<category xml:id="tla7ZQHHK4EHFBCFORGV3GR4IPYQE">
-<catDesc>Royal Ontario Museum</catDesc>
-</category>
-<category xml:id="tlaSTNXUHWLJRCEHKXI3DOXYOYVO4">
-<catDesc>The Lands of the Bible Archaeology Foundation</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaM4BPIWR72JDLPKZN5QWVSTOUQ4">
-<catDesc>U.S.A.</catDesc>
-<category xml:id="tla4NDQCI4YLZCTNJK7677STRJCHA">
-<catDesc>(Städte A-Ch)</catDesc>
-<category xml:id="tla2THRI7PEDVAXXJB6AASISJHM6A">
-<catDesc>Chicago (IL)</catDesc>
-<category xml:id="tlaAVAF4KFOSBG33LWXVBB7EDGFPM">
-<catDesc>Art Institute</catDesc>
-</category>
-<category xml:id="tlaI6LLY3EJVRAWDAR4GCRBLA425Y">
-<catDesc>Oriental Institute Museum</catDesc>
-</category>
-<category xml:id="tlaXTEPN27SWNFXDJY6EVCDGGLL4M">
-<catDesc>George F. Harding Museum</catDesc>
-</category>
-<category xml:id="tlaXVNNL7M5VZCP5JAGY4V5FWZCCM">
-<catDesc>Field Museum of Natural History</catDesc>
-</category>
-</category>
-<category xml:id="tla3NG3AQ5NTNCUHDRD3MAEWIJZOI">
-<catDesc>Berkeley (CA)</catDesc>
-<category xml:id="tlaBZDESZAD7RELZJMBJ76ZMLSSUU">
-<catDesc>Phoebe Apperson Hearst Museum of Anthropology</catDesc>
-</category>
-<category xml:id="tlaG2YJGIBHIJH45I5N4BKHEE5TBM">
-<catDesc>University Art Museum</catDesc>
-</category>
-<category xml:id="tlaGQMG3N4LJZHWVJSEGGAB3ILKWE">
-<catDesc>Bade Institute</catDesc>
-</category>
-</category>
-<category xml:id="tla4CGUOSXVTBBBFLEPJJGSOXIVEM">
-<catDesc>Boston (MA)</catDesc>
-<category xml:id="tlaW5RFGYEN5JDHJHT4BQF3E7K2YI">
-<catDesc>Museum of Fine Arts</catDesc>
-</category>
-</category>
-<category xml:id="tla6RPXUC5CYVF3HP6MK57QCHQCK4">
-<catDesc>Bryn Athyn (PA)</catDesc>
-<category xml:id="tlaMLNXGDF4GBCEDEXOGBZZXG3B5Y">
-<catDesc>Museum of the Academy of the New Church</catDesc>
-</category>
-</category>
-<category xml:id="tla6WQ6Y6VKM5BALJZ6WEWI6KCJCU">
-<catDesc>Aurora (NY)</catDesc>
-<category xml:id="tlaB3BIZOJD25CEZILCLZ3K6B6ATI">
-<catDesc>Wells College Art Collection</catDesc>
-</category>
-</category>
-<category xml:id="tlaBLJZOGYKDVAGHACHVMIJ4QAQ4Y">
-<catDesc>Ann Arbor (MI)</catDesc>
-<category xml:id="tlaEEQD4QSF2BDKVOEKMWINAZNPQM">
-<catDesc>University of Michigan, Kelsey Museum of Ancient and Mediaeval Archaeology</catDesc>
-</category>
-<category xml:id="tlaR36M3CRJVREKRBML2U56BGWUYE">
-<catDesc>University of Michigan, Museum of Art</catDesc>
-</category>
-</category>
-<category xml:id="tlaDMPJEDYKYJAOTO5QU3ODGP3LZY">
-<catDesc>Brunswick (ME)</catDesc>
-<category xml:id="tlaCXA5F22EURCL7NV2ANKLWTBHWM">
-<catDesc>Bowdoin College Museum of Art</catDesc>
-</category>
-</category>
-<category xml:id="tlaEGNJQ6TK5VGHPNLTCWZ2DNDTH4">
-<catDesc>Amherst (MA)</catDesc>
-<category xml:id="tlaB72OLQBHB5DR7HBNNPE6SC2JJY">
-<catDesc>Mead Art Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaF757L764TBCFDK74DEJFKI7TOQ">
-<catDesc>Cambridge (MA)</catDesc>
-<category xml:id="tla654VFI6HJNDLTFMBUBGF26TVGY">
-<catDesc>Fogg Art Museum, Harvard University</catDesc>
-</category>
-<category xml:id="tlaVQ34KHQM3FGMNPHUWQUP66H5CM">
-<catDesc>Semitic Museum</catDesc>
-</category>
-<category xml:id="tlaYTXHPMTNXBD27JNJNMJ7N3EG7M">
-<catDesc>Peabody Museum of Archaeology and Ethnology</catDesc>
-</category>
-</category>
-<category xml:id="tlaFHW2TEX42VAHVPSX6PP5O6XJW4">
-<catDesc>Atlanta (GA)</catDesc>
-<category xml:id="tlaHLNE6EAFNVDF5P33XWAPSFD6SY">
-<catDesc>M.C. Carlos Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaHNMIPUNAYRBNLCCLF6EDN733VM">
-<catDesc>Charleston (SC)</catDesc>
-<category xml:id="tlaAGTRNBKWMNEXTG76LBQHB6RE54">
-<catDesc>The Charleston Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaMER3NPX6YBE5PNAKPEAVGGJCR4">
-<catDesc>Birmingham (AL)</catDesc>
-<category xml:id="tlaDYBDMT5PGREK7EDCRVG5GODUSY">
-<catDesc>Museum of Art</catDesc>
-</category>
-</category>
-<category xml:id="tlaOYI53U532ZC6ZHLQ2SKR4HDPJI">
-<catDesc>Champaign-Urbana (IL)</catDesc>
-<category xml:id="tla6DMO7AMVTNGWRKJTDI67TXASM4">
-<catDesc>Krannert Art Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaPH2GPB47DVFF7JC46GZSC7V4LU">
-<catDesc>Baltimore (MD)</catDesc>
-<category xml:id="tla2MKZIGHBVJFLVFBCP7X5EOF3FE">
-<catDesc>Museum of Art</catDesc>
-</category>
-<category xml:id="tlaN3DGPVGG45GCTBP4RNVWEABZNQ">
-<catDesc>Johns Hopkins University Museum</catDesc>
-</category>
-<category xml:id="tlaSEIZV3OYQVDRVPMUU3N4WEQHJU">
-<catDesc>Goucher College</catDesc>
-</category>
-<category xml:id="tlaW22REGKPU5GFDGJEAATSJKMNZU">
-<catDesc>Walters Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaRVIRCXMS4BA5JNF2IMGAX5H7NE">
-<catDesc>Buffalo (NY)</catDesc>
-<category xml:id="tlaCLCXBQKIEJCNHJ47N4QDRWKQLA">
-<catDesc>Albright-Knox Art Gallery, The Buffalo Fine Arts Academy</catDesc>
-</category>
-<category xml:id="tlaHCXM4GPCURBUTBZC44CC2XKPJQ">
-<catDesc>Buffalo and Erie County Historical Society Museum</catDesc>
-</category>
-<category xml:id="tlaUM5YDBWGLZBDDJA4HYCIOLIS2Q">
-<catDesc>Museum of Science</catDesc>
-</category>
-</category>
-<category xml:id="tlaS3BKM2MHUNEIXE2ZMJKA6ABDZM">
-<catDesc>Bloomfield Hills (MI)</catDesc>
-<category xml:id="tlaYM65UNMBMNCPDPZUAMCNWZEK4M">
-<catDesc>Cranbrook Institute of Science</catDesc>
-</category>
-</category>
-<category xml:id="tlaWGJZSKRLHFDVDHY7TGKABWEBZY">
-<catDesc>Bloomington (IN)</catDesc>
-<category xml:id="tlaMI3BQKW5KZEYHALYCMYTJZITGY">
-<catDesc>Indiana University Art Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaXVMYXHROWFATZLXQ5AWFSWS3SA">
-<catDesc>Chapel Hill (NC)</catDesc>
-<category xml:id="tlaISME5675TRBJZFULK7JSGGIB4Q">
-<catDesc>Ackland Art Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaY35IFY5B7NBNFF4GGIT6RHMQOE">
-<catDesc>Berrien Springs (MI)</catDesc>
-<category xml:id="tlaIA57WHFUQJFBBKXO3NHXJ5EIIU">
-<catDesc>Andrews University</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tla5RLAQ4BRQZFVNO3AHFYUXXXD44">
-<catDesc>(Städte L-P)</catDesc>
-<category xml:id="tla3MHGFID5KRCNHEPVNU7V3TO3L4">
-<catDesc>Providence (RI)</catDesc>
-<category xml:id="tlaS72FJQL4URFDPKDTLZUAO2RQR4">
-<catDesc>Museum of Art, Rhode Island School of Design</catDesc>
-</category>
-</category>
-<category xml:id="tla474LZS2SPJHCJO6LU75MVNWEWE">
-<catDesc>Newark (DE)</catDesc>
-<category xml:id="tlaPU4ZP6RIDFEZXKXON6DJA67Y5I">
-<catDesc>University of Delaware</catDesc>
-</category>
-</category>
-<category xml:id="tla4LUSOAXTANEH7LJB67JNXWGWEQ">
-<catDesc>New Brunswick (NJ)</catDesc>
-<category xml:id="tlaNYMEEHWB4JHEBKZUFTOT3CH27Q">
-<catDesc>Rutgers University Library</catDesc>
-</category>
-</category>
-<category xml:id="tla6KSXIEUKNNDPTIKACUYBFO4QJA">
-<catDesc>Los Angeles (CA)</catDesc>
-<category xml:id="tlaOIDKYEVKZNBIZB3STFTNRPOQSY">
-<catDesc>County Museum of Art</catDesc>
-</category>
-</category>
-<category xml:id="tla6RCR5GUOURAIDKHIPVIKNDJYIQ">
-<catDesc>Portland (ME)</catDesc>
-<category xml:id="tla5D4QJTJDQRACVBIVGTJZD5ULX4">
-<catDesc>Museum of Art</catDesc>
-</category>
-</category>
-<category xml:id="tla74TOAD2KVRH53LBDYY6M2EVF34">
-<catDesc>Philadelphia (PA)</catDesc>
-<category xml:id="tlaDOJS33X3DVEKNOCWZYYKTC2TCU">
-<catDesc>Commercial Museum</catDesc>
-</category>
-<category xml:id="tlaF6FYQMG2H5CDBHARW3CUB3IWSU">
-<catDesc>The Rosenbach Museum and Library</catDesc>
-</category>
-<category xml:id="tlaH4426FAAMJC6TDL76MHZKBMKIQ">
-<catDesc>The University Museum</catDesc>
-</category>
-<category xml:id="tlaNYX5NTLQRNHLRMWEQNADWDH2NA">
-<catDesc>Philadelphia Museum of Art</catDesc>
-</category>
-</category>
-<category xml:id="tlaAWEIXZCUAFB55DJ6OHMOKTRPZ4">
-<catDesc>Memphis (TN)</catDesc>
-<category xml:id="tla4ABJPIO43VHUBCSQ2C6R7QCJ3Y">
-<catDesc>Memphis State University</catDesc>
-</category>
-<category xml:id="tlaJDPJTV2NYJBYFMO35YMGARQFMQ">
-<catDesc>Institute of Egyptian Art</catDesc>
-</category>
-<category xml:id="tlaMOCORKV2MFALPGJC7NFZT7CMXY">
-<catDesc>Zoological Garden</catDesc>
-</category>
-</category>
-<category xml:id="tlaCCQ2R5HCSNHFNFQGJ3MVOHVHXM">
-<catDesc>Omaha (NE)</catDesc>
-<category xml:id="tlaCKH7ZOERCNHL3ML2IU6P7A7IFQ">
-<catDesc>Joslyn Art Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaJ5VRTTCJUZEH5FPYN7P7DUIU6Q">
-<catDesc>Little Rock (AR)</catDesc>
-<category xml:id="tlaS4UHUREKAZHCFIDHXZPXEQ5LMU">
-<catDesc>Science and History</catDesc>
-</category>
-</category>
-<category xml:id="tlaK4XHMT7ZAFG5JAY6Y2WJVA62OY">
-<catDesc>New York City (NY)</catDesc>
-<category xml:id="tlaCXBVV3IB2JDNTJRJTWJL2V7XCM">
-<catDesc>Brooklyn (NY)</catDesc>
-<category xml:id="tlaZGC73O5WYBC4ZDS3NGTA34NZ3A">
-<catDesc>The Brooklyn Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaCXUA5GP3EFEVFJJB5B2UVHVJDI">
-<catDesc>Cooper-Hewitt Museum</catDesc>
-</category>
-<category xml:id="tlaH6JSFIW5CBGO7KIFGHIADHOWEI">
-<catDesc>Academy of Medicine</catDesc>
-</category>
-<category xml:id="tlaIL4SGUWMRFHHXFTXNS6CFPBBKY">
-<catDesc>Metropolitan Museum of Art</catDesc>
-</category>
-<category xml:id="tlaNJEHI6AWZRD3NCN4Z7S7RSWBFQ">
-<catDesc>Alfred University, Allen Steinheim Museum</catDesc>
-</category>
-<category xml:id="tlaQBJ6ZBUYCFA2VMW3GKKHRTUC74">
-<catDesc>American Museum of Natural History</catDesc>
-</category>
-<category xml:id="tlaRCEYW5JSXRFX5JBGOMGGGNFV6E">
-<catDesc>Pierpont Morgan Library</catDesc>
-</category>
-<category xml:id="tlaS2N5YQLFF5BB3O3NPK7SD6K65A">
-<catDesc>Columbia University Museum</catDesc>
-</category>
-<category xml:id="tlaTD5TBOLYRNBPLM7ICPFETRISSQ">
-<catDesc>Institute of Art and Archaeology</catDesc>
-</category>
-<category xml:id="tlaTK5SQOMPGRFTXBU2KM4BGCERQA">
-<catDesc>Hispanic Society</catDesc>
-</category>
-<category xml:id="tlaYLRJCC4SWFHOBMOQTRKORMC7GU">
-<catDesc>Queens College Art Collection</catDesc>
-</category>
-</category>
-<category xml:id="tlaKAB7I7O5MBD6TCUAAUT76672NU">
-<catDesc>Princeton (NJ)</catDesc>
-<category xml:id="tla6KXQVIB52RHQ7D42H5SLUPFC6Y">
-<catDesc>Art Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaLBKP5EPQOJHVJO3YYJEMUOFUHM">
-<catDesc>Nevada City (CA)</catDesc>
-<category xml:id="tlaKFRZZMDM3FFEVBWLRN2H26UAVM">
-<catDesc>Lands of the Bible Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaLOBQZUUUH5CIPPQVKBURU67NEA">
-<catDesc>Oberlin (OH)</catDesc>
-<category xml:id="tlaR4SLWLNJXZG6RLO6RYM4VVDFAQ">
-<catDesc>Allen Memorial Art Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaMKVJ7XTYFND6FEHF5T5M5UGILE">
-<catDesc>Northampton (MA)</catDesc>
-<category xml:id="tlaFUGYVNFNCFENNKIBW3W3EUYMQI">
-<catDesc>Smith College Museum of Art</catDesc>
-</category>
-</category>
-<category xml:id="tlaMNRTV5T6RBHV3K3Z4FBZOFL7XM">
-<catDesc>Milwaukee (WI)</catDesc>
-<category xml:id="tlaPJBOSVWL6FEBBG3PQELQQI5OMY">
-<catDesc>Milwaukee Public Museum</catDesc>
-</category>
-<category xml:id="tlaRVRCNRQVYRCIPIZCRUEIQCSQPY">
-<catDesc>Art Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaO76WDV3D65FNVLYNBAPZ2B3GLU">
-<catDesc>Newark (NJ)</catDesc>
-<category xml:id="tlaVBRAWBDZX5BU5G7Z2CB3YWXTFE">
-<catDesc>Newark Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaPCZJPBIUXFDZXBJVEN5ENTI3UA">
-<catDesc>New Haven (CY)</catDesc>
-<category xml:id="tla4QU72FX2AJFKVPNZ5GG5HW7L5Y">
-<catDesc>Yale University Art Gallery</catDesc>
-</category>
-<category xml:id="tlaJWDZ7UA7L5A5LNY37XPSPAJYCY">
-<catDesc>Peabody Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaPH2MGSG2CBGEPDX3BXJZNUAHFU">
-<catDesc>Minneapolis (MI)</catDesc>
-<category xml:id="tlaEGLD7EX63NH6VEUMTG47JKEVXI">
-<catDesc>Public Library</catDesc>
-</category>
-<category xml:id="tlaEWGL55C5EZEGXOPF7UQKB2BUK4">
-<catDesc>The Minneapolis Institute of Arts</catDesc>
-</category>
-<category xml:id="tlaFGRJBOJXFRE5BDVAOVFIS6APKM">
-<catDesc>Walker Art Center</catDesc>
-</category>
-</category>
-<category xml:id="tlaSYKOPSYJMVCFLBFGFHQWAY3ZII">
-<catDesc>Miami (FL)</catDesc>
-<category xml:id="tlaUXJB27JGC5CI3D6DCXBP7KS5HU">
-<catDesc>Lowe Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaTQTOTKGQHFFB7IIFH2ARGEHA2I">
-<catDesc>Pittsburgh (PA)</catDesc>
-<category xml:id="tlaNAH2TU5TOFHUNPIYLR3WZG2EL4">
-<catDesc>The Carnegie Museum of Natural History</catDesc>
-</category>
-<category xml:id="tlaTOFNHESUU5AAPLY4JKRGAZGU2M">
-<catDesc>Carnegie Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaUEBOFGLADJGITKNMOOQ34DMR3U">
-<catDesc>Phoenix (AZ)</catDesc>
-<category xml:id="tlaGQGAUMI3XZHGFGRUNMG5RNHEPI">
-<catDesc>Art Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaZTKIABHZPNHCFM6GVIR23DSBLQ">
-<catDesc>Manheim (PE)</catDesc>
-<category xml:id="tla4GMLAJXUGZAQ3PPFU4OEYAJHPI">
-<catDesc>Catholic University</catDesc>
-</category>
-</category>
-<category xml:id="tlaZX5CUSABARF4NHGOEXP3O7MCHA">
-<catDesc>Louisville (KY)</catDesc>
-<category xml:id="tla4O36Y346KJBE5CBSCWVRHACOYU">
-<catDesc>The J.B. Speed Art Museum</catDesc>
-</category>
-<category xml:id="tlaNW6WUIHIJZD5LNDDNVUL5LXJFU">
-<catDesc>The Southern Baptist Theological Seminary, Eisenberg Museum</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tla6HFVTW7K3NCQFFRH4QCMJPIZ6U">
-<catDesc>(Städte R-Z)</catDesc>
-<category xml:id="tla3UD2KDJRTRHBFD7IKOKUTNWXFY">
-<catDesc>Salem (MA)</catDesc>
-<category xml:id="tla2M6HT7PVLBEZNLGIB2DOCEOSII">
-<catDesc>Peabody Museum</catDesc>
-</category>
-</category>
-<category xml:id="tla422HRCSJ35FKDI6URKODYWX3YU">
-<catDesc>San Jose (CA)</catDesc>
-<category xml:id="tlaKJSOFMVGTNFCLOEIR3F7GL4MSA">
-<catDesc>Rosicrucian Egyptian Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tla5UL5UB4QWZFDPJDCYBUN4QQFJI">
-<catDesc>Urbana Champaign (IL)</catDesc>
-<category xml:id="tla77XJ7AZEUNBIJCY3FA4PX72KQA">
-<catDesc>Krannert Art Museum (University of Illinois)</catDesc>
-</category>
-</category>
-<category xml:id="tlaBIAK4R2YXRCNJHJWWNVV76NYJA">
-<catDesc>Wellesley (MA)</catDesc>
-<category xml:id="tlaM6Z5BE3G35E67CE53BWROR2HDI">
-<catDesc>Jewett Arts Center</catDesc>
-</category>
-</category>
-<category xml:id="tlaDFZ7DIKP6FAIJCR7HTL33VHWQY">
-<catDesc>San Francisco (CA)</catDesc>
-<category xml:id="tla64VOVWUBZRFBVDWIPDUHYPX2V4">
-<catDesc>M.H. de Young Memorial Museum</catDesc>
-</category>
-<category xml:id="tlaOLZXRRX7IVGHPDCGZQGQIYICQ4">
-<catDesc>Fine Arts / Legion of Honor</catDesc>
-</category>
-<category xml:id="tlaQHPM3I7SFNCVLCSSK4WCYORMW4">
-<catDesc>State University</catDesc>
-</category>
-<category xml:id="tlaU2NOID4QIZC53ESFHSDE4KO3HI">
-<catDesc>Fine Arts / Young Mem. Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaDYUR2F7K2BF35OZAMLK4BUEVEQ">
-<catDesc>San Diego (CA)</catDesc>
-<category xml:id="tlaIZUEFGS2Q5EL5GNKHVMIQ4C4NY">
-<catDesc>San Diego Museum of Art</catDesc>
-</category>
-<category xml:id="tlaSWPKOE5BKFGZXIEKO7ALRVXU7Y">
-<catDesc>Museum of Man</catDesc>
-</category>
-</category>
-<category xml:id="tlaECTWMZOLABBNJPLTD5FHBB5CJI">
-<catDesc>Shawnee (OK)</catDesc>
-<category xml:id="tlaKSCDC6P3SVDHPIAFVZLA7XOZG4">
-<catDesc>Mabee-Gerrer Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaETV5AKZ77FAZJM6DZMDEHGSMN4">
-<catDesc>Springfield (MA)</catDesc>
-<category xml:id="tlaQS52MQZ2QRFMTGHBBDJYQN6NRA">
-<catDesc>Smith Art Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaEVDQY3MFRBECVJ5RMZMUFSGV4Q">
-<catDesc>Toledo (OH)</catDesc>
-<category xml:id="tlaO6SYX2HGTJCETIOECKYO6OZEA4">
-<catDesc>Museum of Art</catDesc>
-</category>
-</category>
-<category xml:id="tlaI7TFOJZQANETHI35GBCLHUQLAI">
-<catDesc>Santa Barbara (CA)</catDesc>
-<category xml:id="tlaJ7MGC7WQUJFYBNL6ZL4S5LC53E">
-<catDesc>Museum of Art</catDesc>
-</category>
-</category>
-<category xml:id="tlaJYQZ3CFE25HQ7NQGBUCUO4W5ZI">
-<catDesc>Stanford (CA)</catDesc>
-<category xml:id="tlaKZXFA7VOQJEO5F5BUV2SQC7YLU">
-<catDesc>University Museum and Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaLJSYXJJCUJDY3IXWFSNB2SNDFM">
-<catDesc>Worcester (MA)</catDesc>
-<category xml:id="tla5JDHXRXQKFC6NBMC3Q4EWPWEQY">
-<catDesc>Art Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaLZJ5QCDYJVHFRFDZU5BI6J6B44">
-<catDesc>Rochester (NY)</catDesc>
-<category xml:id="tlaA4K62MH4EFHLDGWDZHSWOKOHWI">
-<catDesc>Rochester University</catDesc>
-</category>
-<category xml:id="tlaNJNDGWXBHVBX5DRR3V5MHXK7VI">
-<catDesc>Memorial Art Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaMLJ4LO4BWZGHTPURTVPDHSN5T4">
-<catDesc>St. Louis (MO)</catDesc>
-<category xml:id="tla7YYPKUMTLVFJHO3VUVE2CDNJCQ">
-<catDesc>Washington University Gallery of Art, Steinberg Hall</catDesc>
-</category>
-<category xml:id="tlaDHHM65LILFDEXE2K37SYOWTPEU">
-<catDesc>Art Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaNU6MOQQGOVHSHAPH7VGEVPKCEE">
-<catDesc>St. Paul (MN)</catDesc>
-<category xml:id="tlaJ5BKMGRMKFA25LMHOWTQGFW2VY">
-<catDesc>The Science Museum of Minnesota</catDesc>
-</category>
-</category>
-<category xml:id="tlaOTPY6NHC3VAI5OGBGRKFFZ53T4">
-<catDesc>Salt Lake City (UT)</catDesc>
-<category xml:id="tlaJJKIDINW5BC4RIOGZ5TVQIEIUU">
-<catDesc>Museum of Fine Arts</catDesc>
-</category>
-</category>
-<category xml:id="tlaR5VRT5VYRRCNXA6UP6CKPCH6CQ">
-<catDesc>Washington (DC)</catDesc>
-<category xml:id="tla3MUSWV7QURA2NOM575K52MIUBQ">
-<catDesc>Catholic University, Georgetown University Art Collection</catDesc>
-</category>
-<category xml:id="tlaEE6LIRT2K5GNDNQABNTD6JKO7I">
-<catDesc>Washington University</catDesc>
-</category>
-<category xml:id="tlaF6Q3CFZFYVHOFLRVLWLXGTEAWE">
-<catDesc>Smithsonian Institute</catDesc>
-</category>
-<category xml:id="tlaIKPE6UUMB5GE5NAIEWUQST5RTM">
-<catDesc>United States National Museum</catDesc>
-</category>
-<category xml:id="tlaNHFDJDTRTBFENG2NOMOYRFWAHQ">
-<catDesc>Hirshhorn Museum and Sculpture Gallery</catDesc>
-</category>
-<category xml:id="tlaR3A23P44TJAVHKUFDAP3HXGUOU">
-<catDesc>Textile Museum</catDesc>
-</category>
-<category xml:id="tlaXAES67H6RJDORKDZ7W7BILM3BE">
-<catDesc>Dumbarton Oaks Research Library and Collection</catDesc>
-</category>
-<category xml:id="tlaZG455I7CQZA7LN6CRCVENPJ5H4">
-<catDesc>Freer Gallery of Art</catDesc>
-</category>
-<category xml:id="tlaZWJG6EN2RJHN7F4J22FRJW4SN4">
-<catDesc>The Phillips Collection</catDesc>
-</category>
-</category>
-<category xml:id="tlaRPOXUEJUVFEY7DM6M3Q7DZQMMQ">
-<catDesc>Richmond (VA)</catDesc>
-<category xml:id="tlaEAEC7JZVAJBNBGQS4L3ZA6PRCI">
-<catDesc>Virginia Museum of Fine Arts</catDesc>
-</category>
-</category>
-<category xml:id="tlaRR7VJDX5F5APJMXND4OB3G27OQ">
-<catDesc>South Hadley (MA)</catDesc>
-<category xml:id="tlaIBTKN65LWNBW7GQGCICR2ZHGKI">
-<catDesc>Mount Holyoke College</catDesc>
-</category>
-</category>
-<category xml:id="tlaUYRKORRG6VBVXL24JOD5W6JWSI">
-<catDesc>Wilmington (NC)</catDesc>
-<category xml:id="tlaAWECVN4CFFADLGVKMRMZF34ZVY">
-<catDesc>New-Hannover Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaVHVIOV2IHVDMZMRY7AO5UL6LG4">
-<catDesc>San Antonio (TX)</catDesc>
-<category xml:id="tla42BOS4YUGZH3ZEIFQDALEX2GPA">
-<catDesc>San Antonio Museum Association</catDesc>
-</category>
-</category>
-<category xml:id="tlaZLJI7EBECJH3JEW5BQTGND5LH4">
-<catDesc>Seattle (WA)</catDesc>
-<category xml:id="tla5LSGAOOJKJFB7OEEOMDJ2KV3XQ">
-<catDesc>Art Museum</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaF4L3TGIVYZH6FCQT25LUX37BKY">
-<catDesc>(Städte Ci-K)</catDesc>
-<category xml:id="tla3MZKR3KW7VFIBCV4KOY2Y7ZJHQ">
-<catDesc>Kansas City (MO)</catDesc>
-<category xml:id="tlaKRP5QRWPORHAFFKCG6WSE4Y3KM">
-<catDesc>University of Kansas, The Spencer Museum of Art</catDesc>
-</category>
-<category xml:id="tlaOHILO7DXONGM5NC6JCOOWYQO3U">
-<catDesc>Nelson-Atkins Museum of Art</catDesc>
-</category>
-</category>
-<category xml:id="tla4F7CXWXNN5ED5JJTY6F6M2BXWI">
-<catDesc>Kearney (NE)</catDesc>
-<category xml:id="tlaX6XRYJAZ3ZHMNMNL3FKUKLIJ34">
-<catDesc>Fort Kearny Museum</catDesc>
-</category>
-</category>
-<category xml:id="tla4QWOERCQTJHR5B2TYJ53JDWGV4">
-<catDesc>Honolulu (HI)</catDesc>
-<category xml:id="tlaFUKB7UV47ZGDLO7D6QDV3KS3P4">
-<catDesc>Honolulu Academy of Arts</catDesc>
-</category>
-</category>
-<category xml:id="tla565XPF4ORJFIBEKH6FETG3A5NU">
-<catDesc>Columbia (MO)</catDesc>
-<category xml:id="tlaDNHY5JDHGNDFDHRXO5HU4XN4DU">
-<catDesc>Museum of Art and Archaeology</catDesc>
-</category>
-</category>
-<category xml:id="tla5YADI45R4VHBFIQJEJMXWH3V6Q">
-<catDesc>Hartford (CT)</catDesc>
-<category xml:id="tlaVD7SJ7PT3BB4PP73VRTFZIGUG4">
-<catDesc>Wadsworth Atheneum</catDesc>
-</category>
-</category>
-<category xml:id="tla6XHJKGKLEFANNC4EBMX6ACTTOY">
-<catDesc>Corning (NY)</catDesc>
-<category xml:id="tlaSEKALXYYMJE3PAZP4LQXRVEOKI">
-<catDesc>Glas Center</catDesc>
-</category>
-</category>
-<category xml:id="tla7I7FFMSKQRDP5KESGYXOUFDGAY">
-<catDesc>Ithaca (NY)</catDesc>
-<category xml:id="tlaNXBK62CNGVCTPHPJSMLG32FZUY">
-<catDesc>Cornell University, Museum of Archaeology</catDesc>
-</category>
-</category>
-<category xml:id="tlaB3W5UV57LVGUJNCFW6KMGMGU74">
-<catDesc>Houston (TX)</catDesc>
-<category xml:id="tla45TS7XDBDFEB3JISFWBSQITMPI">
-<catDesc>University of St. Thomas</catDesc>
-</category>
-<category xml:id="tla4HK56XCQBNEVBKREUDIPQKJ6JQ">
-<catDesc>Museum of Fine Arts</catDesc>
-</category>
-<category xml:id="tlaQNHH3776LZDRPKUSZNJXGZGJTQ">
-<catDesc>Museum of Natural Science</catDesc>
-</category>
-</category>
-<category xml:id="tlaBIMYZZU4DZEFJE67XLILJORD4Y">
-<catDesc>Hanover (NH)</catDesc>
-<category xml:id="tla2J4REMUR5RCITE6NMMK5AYY7BU">
-<catDesc>Dartmouth College Museum and Galleries</catDesc>
-</category>
-</category>
-<category xml:id="tlaFNPZJVE6RJCLLCFBEUO2FDMOC4">
-<catDesc>Dayton (OH)</catDesc>
-<category xml:id="tlaIC6OSIFACJF4XHZAK5FFBTRVUY">
-<catDesc>Art Institute</catDesc>
-</category>
-</category>
-<category xml:id="tlaITVBJFU6WJB6TG7CCG7OJPCMNQ">
-<catDesc>Clinton (NY)</catDesc>
-<category xml:id="tlaFGKY4YEYNRHWXK2473ER7BYZMY">
-<catDesc>Hamilton College</catDesc>
-</category>
-</category>
-<category xml:id="tlaLIE7MSEDIVEF3NUDCU2DOAMP6M">
-<catDesc>Cincinnati (OH)</catDesc>
-<category xml:id="tlaZGELJ4TBLBBT5FEFBYD5CKQEEY">
-<catDesc>Cincinnati Art Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaMGSALFW2IJEWBE4TCNZN2IPMNY">
-<catDesc>East Lansing (MI)</catDesc>
-<category xml:id="tlaYC3OMJ5E7BEKLOKZHU47EUKBSA">
-<catDesc>Michigan State University, Kresge Art Center Gallery</catDesc>
-</category>
-</category>
-<category xml:id="tlaO33RER7CZZCD7HCE622DHEBL34">
-<catDesc>Columbus (MS)</catDesc>
-<category xml:id="tlaKIYWK4SPJJEUZMKHS33T7RFQ7M">
-<catDesc>Gallery of Fine Arts</catDesc>
-</category>
-</category>
-<category xml:id="tlaPABEOPBE2VEGDMSLIUO5XHAY6M">
-<catDesc>Denver (CO)</catDesc>
-<category xml:id="tlaMZBCGVPMNFDOPO54Q6WHOFYSWE">
-<catDesc>Denver Art Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaRJM2MARG7RCLRPTHNFGK5IO4MA">
-<catDesc>Jacksonville (FL)</catDesc>
-<category xml:id="tlaHZM3HDWIVFGCXCVTO44QVNNA44">
-<catDesc>Cummer Gallery of Art</catDesc>
-</category>
-</category>
-<category xml:id="tlaSBCXF53GC5GL5FBBV4CNILGXLU">
-<catDesc>Grand Forks (ND)</catDesc>
-<category xml:id="tlaJA3WVVPSYVB2ZJISDF63EJAFQI">
-<catDesc>University Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaSLN3DCNJU5HJ5B6N5CND5VTJKE">
-<catDesc>Columbus (OH)</catDesc>
-<category xml:id="tlaIHGEKI6QKJDYBHTIKQPVPBTCVQ">
-<catDesc>Museum of the Ohio State Archaeological and Historical Society</catDesc>
-</category>
-</category>
-<category xml:id="tlaSQQP77TCR5BYREPRCEBYGCYTVM">
-<catDesc>Durham (NC)</catDesc>
-<category xml:id="tla7RUXEZBMWRFZ5IEHRWTE52QWZU">
-<catDesc>Duke University</catDesc>
-</category>
-</category>
-<category xml:id="tlaVS72EU4CQFEVRFM5UQD5XGKOUM">
-<catDesc>Cleveland (OH)</catDesc>
-<category xml:id="tlaEZENPHRF4FBDXNIZVNBYZSTTGU">
-<catDesc>Museum of the Western Reserve Historical Society</catDesc>
-</category>
-<category xml:id="tlaNE42GOEKQ5E37LMHTOGMNHP7HY">
-<catDesc>Museum of Art</catDesc>
-</category>
-</category>
-<category xml:id="tlaWNGE524MQZFJJPBCKV36SGBFUY">
-<catDesc>Dallas (TX)</catDesc>
-<category xml:id="tlaH5GLN2ELFJASDJHHL2NTJVTJSA">
-<catDesc>Museum of Fine Arts</catDesc>
-</category>
-</category>
-<category xml:id="tlaWYCDWDHVC5HCNNHF5XFZ3LON4E">
-<catDesc>Indianapolis (IN)</catDesc>
-<category xml:id="tlaF56RPIGMDJD27KDEDOXK2OFIQE">
-<catDesc>John Herron Art Institute</catDesc>
-</category>
-</category>
-<category xml:id="tlaWYK46CYEBBGSLI2YNZKY47ULEE">
-<catDesc>Huntington (NY)</catDesc>
-<category xml:id="tlaBSFLQHVFDRFUJGZKQAOYIVKIPI">
-<catDesc>Heckscher Museum</catDesc>
-</category>
-</category>
-<category xml:id="tlaYBAVLG657JCQVIH5Y6HUPEN6AU">
-<catDesc>Detroit (MI)</catDesc>
-<category xml:id="tlaDHTBI44MMZHEPMUU6HVCXNH2JQ">
-<catDesc>Institute of Arts</catDesc>
-</category>
-<category xml:id="tlaMTYJFNORFVDLJAQ4NV72TNLZR4">
-<catDesc>Clark Museum</catDesc>
-</category>
-</category>
-</category>
-</category>
-</category>
-</category>
-<category xml:id="tla2WTMWILFXFCFHIIN6JATL47IG4">
-<catDesc>23 = Akteur</catDesc>
-<category xml:id="tlaGT4HRUBG55AE5IB7RM2ZMJOQ6M">
-<catDesc>Privatmann</catDesc>
-</category>
-<category xml:id="tlaKHC5ZCKCHJDG7J3PGYCUHGLR5E">
-<catDesc>König</catDesc>
-</category>
-<category xml:id="tlaVBXHCUXMVFA5VBBSUX53ZW6Y5U">
-<catDesc>Gott</catDesc>
-</category>
-</category>
-<category xml:id="tlaP33RJ7RXYRHW7FU4BA2BULCCCI">
-<catDesc>21 = Objekttyp</catDesc>
-<category xml:id="tlaB22H5ZYF6NBTJEEIIQ3DWYXXEI">
-<catDesc>Überreste</catDesc>
-<category xml:id="tlaPTD6RR5YEZFRNCSMZAKPUJTV4M">
-<catDesc>Knochen</catDesc>
-</category>
-<category xml:id="tlaZJGHMMLU6JGC7BH4S545JYIGPI">
-<catDesc>Mumie</catDesc>
-</category>
-<category xml:id="tlaZLB5GOHSGNGWZAP2RJ5EVQYUEI">
-<catDesc>Muschel</catDesc>
-</category>
-</category>
-<category xml:id="tlaKIVHUYHHIBDNJDYK4HEVFBS2EI">
-<catDesc>unbekannt</catDesc>
-</category>
-<category xml:id="tlaLY2FDYZWRVGKHK4FYAL3EVZW6U">
-<catDesc>Architektur</catDesc>
-<category xml:id="tlaVDJICLKKQJCY5DEUPRRGVDT3JA">
-<catDesc>Gebäude &amp; Konstruktionen</catDesc>
-<category xml:id="tla2KUBMS2CEJEI7DTTKCIK4JWQ7A">
-<catDesc>Talbezirk</catDesc>
-</category>
-<category xml:id="tla3OMHAO4VSFFGPCJ3YCYVOAPY4I">
-<catDesc>Brücke</catDesc>
-</category>
-<category xml:id="tla6GCJHSUTOFHEDPYNYSB6ODCLSQ">
-<catDesc>Turm</catDesc>
-</category>
-<category xml:id="tla7WQOKULE5JFPPAZ4DPJJBDANX4">
-<catDesc>Wirtschaftsgebäde</catDesc>
-<category xml:id="tla2F76RMDCIFGM5FMZASB5WZLA3Y">
-<catDesc>Werkstatt</catDesc>
-</category>
-<category xml:id="tlaI5UCR2NQDBE6BHB6CSZQRBFSJE">
-<catDesc>Kornspeicher</catDesc>
-</category>
-<category xml:id="tlaIYQ7LVNJGBEU3HD5ZZXRGPVOU4">
-<catDesc>Tierzuchtgebäude</catDesc>
-</category>
-<category xml:id="tlaXHRNFM3DERDHZIEM262OEZA3GI">
-<catDesc>Schatzhaus</catDesc>
-</category>
-<category xml:id="tlaYKSSZQO7YREZTPNIVYNBQ4HA5M">
-<catDesc>Verwaltungsgebäude</catDesc>
-</category>
-</category>
-<category xml:id="tlaG2IECCH4XFGNNMPYXHKEONAS54">
-<catDesc>Kloster</catDesc>
-</category>
-<category xml:id="tlaGMZLAOCDP5B7NOVKBD543U4K7I">
-<catDesc>Fortifikation</catDesc>
-<category xml:id="tla6R2QNT4FJJEIXKWYN2WWJKYXCU">
-<catDesc>Grenzmauer</catDesc>
-</category>
-<category xml:id="tlaY4NUGV7AQ5D33KJRRZ4BWJKEL4">
-<catDesc>Festung</catDesc>
-</category>
-</category>
-<category xml:id="tlaHV3JFDDE4NDJ5HTBR7F2QWPHFE">
-<catDesc>Grab</catDesc>
-<category xml:id="tla3CR6KBQ3UBDZLFDWKNTT4R3ARY">
-<catDesc>Galleriegrab</catDesc>
-</category>
-<category xml:id="tla3IZSQL4XPVEJBIJWYMAWG3XS6M">
-<catDesc>Cachette</catDesc>
-</category>
-<category xml:id="tlaCCBP62XK5ZFTDNWQK5MORJ4HNQ">
-<catDesc>Kenotaph / Scheingrab</catDesc>
-</category>
-<category xml:id="tlaDME3FXTGUBB2BNWGFCOV55XSUA">
-<catDesc>Pyramidengrab</catDesc>
-</category>
-<category xml:id="tlaFEO6RBKYTBCYNHD4IWIVAZI7V4">
-<catDesc>Felsgrab</catDesc>
-</category>
-<category xml:id="tlaGENSOWZN5FEGBJJ4IDSRSXJWPA">
-<catDesc>Südgrab</catDesc>
-</category>
-<category xml:id="tlaOUWV7WEJZNEIXCNNRH4SVXDN5A">
-<catDesc>Mastabagrab</catDesc>
-</category>
-<category xml:id="tlaRSPTCY2K3REO7BLYIU2MQSZYGU">
-<catDesc>Schachtgrab</catDesc>
-</category>
-<category xml:id="tlaSAIVAGWRSVCXNDUJCCFWD7EH4Y">
-<catDesc>Grubengrab</catDesc>
-</category>
-<category xml:id="tlaSESOISO52FBE5ESNI2EHQZLQVM">
-<catDesc>Schiffsgrab</catDesc>
-</category>
-<category xml:id="tlaUPPKQEOZHNCUHJDABY5KXO3BJY">
-<catDesc>Tumulusgrab</catDesc>
-</category>
-<category xml:id="tlaVJWAWBRE6NFJXIAQ5XKXHA3XO4">
-<catDesc>Tempelgrab</catDesc>
-</category>
-<category xml:id="tlaYOWN36PA7VGW3BABXERPB2XXBQ">
-<catDesc>Hypogaeum</catDesc>
-</category>
-</category>
-<category xml:id="tlaJLN43XXHXRDAZHUOYB3BM3WWF4">
-<catDesc>Straße / Weg</catDesc>
-<category xml:id="tlaC72T2BEZSBBVLEM65DJRKKCOFQ">
-<catDesc>Militärstraße</catDesc>
-</category>
-<category xml:id="tlaGHNMLDH6TBATJEEH35OXQUNUDI">
-<catDesc>Prozessionsstraße</catDesc>
-</category>
-</category>
-<category xml:id="tlaKDCR3NQLWFEDNL5BZVX2QCDMKQ">
-<catDesc>Stadt</catDesc>
-<category xml:id="tla6CVIMG3OTZGFTDJD2AZIJMEVKU">
-<catDesc>Arbeiterstadt</catDesc>
-</category>
-<category xml:id="tlaWTY5GLZGMNDTTPIHXTYQJUVIJM">
-<catDesc>Pyramidenstadt</catDesc>
-</category>
-</category>
-<category xml:id="tlaM6LHBERYQZBZVEGKKTLCZ7FMXY">
-<catDesc>Wasserbauwerk</catDesc>
-<category xml:id="tla4DD7XP7NQFD2NMWQ5K2TXXJT54">
-<catDesc>Heiliger See</catDesc>
-</category>
-<category xml:id="tlaM62477XJ5ZECDDDAAWKPUEPBJA">
-<catDesc>Kaitribüne / Schiffsanlage</catDesc>
-</category>
-<category xml:id="tlaS75RBGP6RBDYFOVLSAN4VGEKYY">
-<catDesc>Brunnen / Nilometer</catDesc>
-</category>
-<category xml:id="tlaU4W5YGKPI5FL5G57TJW2NTPAYI">
-<catDesc>Hafen</catDesc>
-</category>
-<category xml:id="tlaWW35L6N7H5GDZP4KLF3MK444RI">
-<catDesc>Kanal</catDesc>
-</category>
-</category>
-<category xml:id="tlaPX3PGTPSQVAIHHSIUSSEYVBUEI">
-<catDesc>Kirche</catDesc>
-</category>
-<category xml:id="tlaRRMC7LFARVDDPCSQOK4ROBRPWU">
-<catDesc>Moschee</catDesc>
-</category>
-<category xml:id="tlaUAH3A6TU3FB6HF7NNFYRHXNNKU">
-<catDesc>Kapellen</catDesc>
-<category xml:id="tla2Y73DZC2P5CLZOJAJQKDSKL3YA">
-<catDesc>Kiosk</catDesc>
-</category>
-<category xml:id="tlaCMGTMCFON5CIRM5AVVGBBDCFAE">
-<catDesc>Dachkapelle</catDesc>
-</category>
-<category xml:id="tlaJOURNPAMUBEMNNXRI4AMNLCUF4">
-<catDesc>Ka-Haus</catDesc>
-</category>
-<category xml:id="tlaO7JMJQFTO5CRPM5QK3I4PEFLNM">
-<catDesc>Gedächtniskapelle</catDesc>
-</category>
-<category xml:id="tlaPQSWNT7SINDD5CLLWIBEJQZ7TI">
-<catDesc>Wabet</catDesc>
-</category>
-<category xml:id="tlaY3ICYUIXTFDGRHZAQ53Z65K24E">
-<catDesc>Barkenstationskapelle</catDesc>
-</category>
-</category>
-<category xml:id="tlaURCTTU5GIZC2TJNA6YQJE4WIC4">
-<catDesc>Tempel</catDesc>
-<category xml:id="tlaA3CREZPMNNFKDPPNP6DPNPETKA">
-<catDesc>Taltempel</catDesc>
-</category>
-<category xml:id="tlaAQDS45BQ6BFRPCG7LQVKC54GJM">
-<catDesc>Meret-Heiligtum</catDesc>
-</category>
-<category xml:id="tlaC2FEUF7SXFGJ5F6CIDXBGCUWQU">
-<catDesc>Barkenstationstempel</catDesc>
-</category>
-<category xml:id="tlaIBXR5HJO55AJ3I2YIAOM7ATCII">
-<catDesc>Sonnenheiligtum</catDesc>
-</category>
-<category xml:id="tlaIMSQEDD4UBETXCTCQ3VGDST4AQ">
-<catDesc>Mammisi</catDesc>
-</category>
-<category xml:id="tlaKF3YBBDH2FDQ5LPMGIINDW6QDI">
-<catDesc>Pyramidentempel</catDesc>
-</category>
-<category xml:id="tlaMB2A2GCHTFC4VDDDMDBBNX3NIA">
-<catDesc>Höhlentempel / Speos</catDesc>
-</category>
-<category xml:id="tlaS2SMVDKDFBCSBPQ24Q67UNC45A">
-<catDesc>Gegentempel</catDesc>
-</category>
-<category xml:id="tlaUQFTBQLPUNFD7BYUJ3QBKKWYHY">
-<catDesc>Terrassentempel</catDesc>
-</category>
-<category xml:id="tlaZ6GZDXE5NRGTDE3IL5CKVU2Z3E">
-<catDesc>Totentempel</catDesc>
-</category>
-</category>
-<category xml:id="tlaUUXHEUGSKFHOLKMRQQPCG3QHA4">
-<catDesc>Synagoge</catDesc>
-</category>
-<category xml:id="tlaXBLYB2AT4VHJDJRSOOGMAQVIME">
-<catDesc>Haus</catDesc>
-<category xml:id="tla6EMYESTXTVCVFCS25LO445AKSU">
-<catDesc>Wohnhaus</catDesc>
-<category xml:id="tlaB5N6INHOVVEGFP65LRQGWODH7Y">
-<catDesc>Turmhaus</catDesc>
-</category>
-</category>
-<category xml:id="tlaXHSWXYHW2VGNPF5MI7RREKLG7I">
-<catDesc>Palast</catDesc>
-</category>
-</category>
-</category>
-</category>
-<category xml:id="tlaNWXI27WQTVAMLFBD5HNFNJLFPE">
-<catDesc>Artefakt</catDesc>
-<category xml:id="tla2JK45TRNWVF67CVWL76SID5S4Q">
-<catDesc>Behälter</catDesc>
-<category xml:id="tlaBZQQMFDB4VBZJH3R66Y3XK64XI">
-<catDesc>Gefäß</catDesc>
-<category xml:id="tlaDRWEIUJUCJFEPEMM4L64NP3MWY">
-<catDesc>Vorrats- &amp; Transportgefäße</catDesc>
-<category xml:id="tlaUYFSMRJKXZAKJPE6V7NT2TBZBU">
-<catDesc>Amphore</catDesc>
-</category>
-</category>
-<category xml:id="tlaEWHGDMVTHNDRJJBWGDSCORNF6A">
-<catDesc>Becher</catDesc>
-<category xml:id="tlaBRTSNASDPRHBDBHUPUYK3VJXVM">
-<catDesc>Kelche</catDesc>
-</category>
-</category>
-<category xml:id="tlaI6L3KNNYJFGSNIG2BPXEYEYYYY">
-<catDesc>Schalen &amp; Teller</catDesc>
-<category xml:id="tla2PT5JHAN55BEJCRTB6N772WNW4">
-<catDesc>Waagschale</catDesc>
-</category>
-<category xml:id="tlaFOAP5JBU2FFBJO4D7KPYB3JDYI">
-<catDesc>Waschschüssel</catDesc>
-</category>
-<category xml:id="tlaKVSEXZBTO5HVPEKALT6UEI2K2E">
-<catDesc>Schminkschale</catDesc>
-</category>
-<category xml:id="tlaXZVB3LYEEZA2FPPKXLHFMQ6DJY">
-<catDesc>Nun-Schale</catDesc>
-</category>
-</category>
-<category xml:id="tlaSY2OHZ3XGRBN5BSKAWAGGRDNNY">
-<catDesc>Krüge &amp; Flaschen</catDesc>
-<category xml:id="tla2E5WMIXOWNEGXJJJAUS7P54K2A">
-<catDesc>Situla</catDesc>
-</category>
-<category xml:id="tla3PGC2ASLQJH6NDQ3XI5ETTYOPU">
-<catDesc>Kanopenkrug</catDesc>
-</category>
-<category xml:id="tla3TMXZJJSYJEXBIHU4OQG5UQOOA">
-<catDesc>Alabastron</catDesc>
-</category>
-<category xml:id="tla5YGOPAVCNFGTZDVTEUXIXQVIV4">
-<catDesc>Waschkrug</catDesc>
-</category>
-<category xml:id="tlaGC2DVFWJS5B5LKYQPJ4PKKMVJM">
-<catDesc>Neujahrsflasche</catDesc>
-</category>
-<category xml:id="tlaL7AX7OFTKZFS5NACFLZBPJPVNM">
-<catDesc>Uschebtikrug</catDesc>
-</category>
-</category>
-<category xml:id="tlaTMZFASVFGND77AYDORYJI3QLDU">
-<catDesc>Tiegel</catDesc>
-<category xml:id="tlaFP35KSSZTFCFHKPHSE3CNZANWI">
-<catDesc>Schmelztiegel</catDesc>
-</category>
-<category xml:id="tlaSQV35W4MSNAG7DK37GHWV53MLI">
-<catDesc>Kosmetiktiegel</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaEOH26S2KCJC5JHPL35OJ42T5N4">
-<catDesc>Sarg</catDesc>
-<category xml:id="tlaCKI3UAVKUBAE5JBVC2KXXZSXKE">
-<catDesc>Kastensarg</catDesc>
-</category>
-<category xml:id="tlaJYMQTYYXXBAHXG5GPYB2J6LME4">
-<catDesc>anthropoider Sarg</catDesc>
-</category>
-<category xml:id="tlaQTUQJB6RVZHQ5N6F6WVRMECFDE">
-<catDesc>Tiersarg</catDesc>
-</category>
-<category xml:id="tlaXJ4WDB7EV5CI5LCWN245DTAPZI">
-<catDesc>Uschebtisarg</catDesc>
-</category>
-</category>
-<category xml:id="tlaF7E3PVPVEBHPNMADEIYW5RORPA">
-<catDesc>Körbe</catDesc>
-<category xml:id="tlaVWB3DFC6IZBRXNMA73RZBYQVTQ">
-<catDesc>Lebensmittelkörbe</catDesc>
-</category>
-</category>
-<category xml:id="tlaHVHBYDV7EBB2TIF5VPLWL6INRI">
-<catDesc>Osirisziegel</catDesc>
-</category>
-<category xml:id="tlaPAZQJR6JKZEQDDKX4SCYZSIJNM">
-<catDesc>Leichenumhüllung</catDesc>
-<category xml:id="tla2P2OU5FWNZBP3HF5A46NDRXJVA">
-<catDesc>Penishülle</catDesc>
-</category>
-<category xml:id="tlaFUN2YX6Z5VDUXIPIFCSW7LP7X4">
-<catDesc>Ganzkörperkartonage</catDesc>
-</category>
-<category xml:id="tlaGAWMAZS6HZCFDF5KBZBCSRPPKQ">
-<catDesc>Fußhülle</catDesc>
-</category>
-<category xml:id="tlaH3CBZIIOSREGJP5SH4JRMWHRRM">
-<catDesc>Mumienmaske / Maske</catDesc>
-<category xml:id="tla5O2UEYQXSVFM7GJ2Z42JFFLDNA">
-<catDesc>Gesichtsmaske</catDesc>
-</category>
-<category xml:id="tlaKUVXG4QQ65AQPKJO5HCKH6CTCU">
-<catDesc>Stülpmaske</catDesc>
-</category>
-</category>
-<category xml:id="tlaL6MBS55VRVAQ5JB72DFUPGPLR4">
-<catDesc>Leichentuch</catDesc>
-</category>
-<category xml:id="tlaMP737HZGCZEGZORTCE7JR6EWNE">
-<catDesc>Fingerhülle</catDesc>
-</category>
-<category xml:id="tlaPN5YIWK5AVGUDPUIIUO32C7DCQ">
-<catDesc>Fellumhüllung</catDesc>
-</category>
-<category xml:id="tlaXSPKIMG62NBEDNZFAK6ONEGVV4">
-<catDesc>Mattenumhüllung</catDesc>
-</category>
-<category xml:id="tlaYBCRSZ3FBRG7HN6QI4LRPZ25CY">
-<catDesc>Mumienbindenumwicklung</catDesc>
-</category>
-</category>
-<category xml:id="tlaRJQSBIRGHJD6HFCQS55BQ3CRHA">
-<catDesc>Kasten</catDesc>
-<category xml:id="tla3QUUX5LA2ZBDHE75NTXIOPASRA">
-<catDesc>Kanopenkasten</catDesc>
-</category>
-<category xml:id="tlaCNIJ3DT72BFBTKASKSBCB45OKY">
-<catDesc>Toilettenkästchen</catDesc>
-</category>
-<category xml:id="tlaKOMNR2MCIJBZBOYUUALVMV2RHE">
-<catDesc>Naos</catDesc>
-</category>
-<category xml:id="tlaPOLRZULC45B65ODEC7YFAIC6CI">
-<catDesc>Perückenbehälter</catDesc>
-</category>
-<category xml:id="tlaSIESSHVLFRCBJF5XWN64G3ZYHA">
-<catDesc>Kleidertruhe</catDesc>
-</category>
-</category>
-<category xml:id="tlaT3EF3WQ7GNAF3FRHP6QDKZVU4Q">
-<catDesc>Gehäuse / Hülle</catDesc>
-<category xml:id="tlaA73ZD5A2MNCKXH353YNRO5U2WE">
-<catDesc>Lebensmittelgehäuse</catDesc>
-</category>
-<category xml:id="tlaDLJFK7AEBFEP7CWAQKNSRQWAL4">
-<catDesc>Köcher</catDesc>
-</category>
-<category xml:id="tlaFHSO6EJNAJH4ZD6P4UEXEXEQRI">
-<catDesc>Amuletthülse</catDesc>
-</category>
-<category xml:id="tlaISHSECSFWVBJ7GGWHJKU3NWFPE">
-<catDesc>Handwaagengehäuse</catDesc>
-</category>
-<category xml:id="tlaO6TMJXNM6ZF5BBD4P7OLZCOGMI">
-<catDesc>Schriftrollengehäuse</catDesc>
-<category xml:id="tla7ABBTB23CBDVZMTMNQXLURQ44Y">
-<catDesc>Ptah-Sokar-Osiris-Figur</catDesc>
-</category>
-<category xml:id="tlaGSCEQRGOKND2VMPLCM74QQBT4A">
-<catDesc>Papyrusschatulle</catDesc>
-</category>
-</category>
-<category xml:id="tlaPR2MB7627RH7BGTIQ2EEFB6JYU">
-<catDesc>Musikinstrumentengehäuse</catDesc>
-</category>
-<category xml:id="tlaU4SRRI5FIJE5XAI6PVUBY2F3CA">
-<catDesc>Schreibbinsengehäuse</catDesc>
-</category>
-</category>
-<category xml:id="tlaULZGCBDMGBHLJHINAPD5D77OLM">
-<catDesc>Sarkophag</catDesc>
-<category xml:id="tlaDANO34XQS5APLJKVBO75DNYRRA">
-<catDesc>rock-cut pit sarcophagus</catDesc>
-</category>
-<category xml:id="tlaJFOEHWNDQJAFVA2TMGURELNXVM">
-<catDesc>Uschebtisarkophag</catDesc>
-</category>
-<category xml:id="tlaSUJOPO4IA5GY3H7S5A5PPMEJ44">
-<catDesc>Kastensarkophag</catDesc>
-</category>
-<category xml:id="tlaZEXUVHMWU5GUNGG6FGOF3TXFVU">
-<catDesc>anthropoider Sarkophag</catDesc>
-</category>
-</category>
-<category xml:id="tlaYZROY7L4KNGQNHDBNQKNLK3XWE">
-<catDesc>Kornosiris</catDesc>
-</category>
-</category>
-<category xml:id="tla46EEHPJHQJFQ7ICDCBFA4WNR7Q">
-<catDesc>Skulptur</catDesc>
-<category xml:id="tla6ZDTVZOWOFD3RAKWUZTPZZRFNY">
-<catDesc>Statue / Figur</catDesc>
-<category xml:id="tlaJOPRB4FLUVEO3LBMALUJKOZMXU">
-<catDesc>Dienerfigur</catDesc>
-</category>
-<category xml:id="tlaTEIKTAAVEFBNTLQFZ2OPWWRH5I">
-<catDesc>Ächtungsfigur</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tla64Y2SM2JZ5AIPMQGOLBC36323Q">
-<catDesc>Schriftmedien</catDesc>
-<category xml:id="tla5QIW3ZRHQFGINHBP4GI2GI4LFA">
-<catDesc>Schriftrolle</catDesc>
-</category>
-<category xml:id="tla5Z4BBZUQ3JBTVEJSKXNCA7LKUQ">
-<catDesc>Schreibtafel</catDesc>
-</category>
-<category xml:id="tlaEP7XNRXU4ZAU7BKOHF5H2PYC34">
-<catDesc>Stele</catDesc>
-<category xml:id="tla2QJQDZOOOBARDOTA6BLKAT5EPE">
-<catDesc>Slab stela</catDesc>
-</category>
-<category xml:id="tla7OQNLVAE2FB5HIHUYLRMMIWJYU">
-<catDesc>Stele mit Scheintürfassung</catDesc>
-</category>
-<category xml:id="tlaCUNICVTWNNF6VN2RUTXZNNN444">
-<catDesc>rechteckige Stele</catDesc>
-</category>
-<category xml:id="tlaG3RHFFZZ5VGMXPLIK23T5VPX2E">
-<catDesc>Grenzstele</catDesc>
-<category xml:id="tlaNCFHNFDVFRBTXEABFZKKEJON7I">
-<catDesc>Schenkungsstele</catDesc>
-</category>
-</category>
-<category xml:id="tlaJ7IA6TR4HFDZVFJLMQ4ZKOXUMY">
-<catDesc>Altarstele (Amarna)</catDesc>
-</category>
-<category xml:id="tlaLCPWQCZ2HVFBVFJHVYSQ2UJHIY">
-<catDesc>rundbogige Stele</catDesc>
-</category>
-<category xml:id="tlaNLZJDZX7VVCCPHEYK5NKR75654">
-<catDesc>Horusstele / Horuscippus</catDesc>
-</category>
-<category xml:id="tlaNYY3IYP3XZDOBFNZUGI7RV52IY">
-<catDesc>Wandstele</catDesc>
-</category>
-<category xml:id="tlaXKMFQ6O4IVAQVEVHNLR3TMS6QA">
-<catDesc>Felsstele</catDesc>
-</category>
-</category>
-<category xml:id="tlaLKQP7D6XGBGV5K52MIEFX2NWNI">
-<catDesc>Ostrakon</catDesc>
-</category>
-<category xml:id="tlaM2UOQEMSJRD3JEZW5ZJSY7P3TI">
-<catDesc>Schreibblatt</catDesc>
-</category>
-<category xml:id="tlaOPJINUAIVNEFLJTHV5WTMHHHII">
-<catDesc>Etikett</catDesc>
-<category xml:id="tlaALBHSJGZ5JA6VMMRPTA6KVMUDI">
-<catDesc>Mumienetikett</catDesc>
-</category>
-<category xml:id="tlaDQBSH25355EPTNBFSHUAOPFJDQ">
-<catDesc>Gefäßetikett</catDesc>
-</category>
-</category>
-<category xml:id="tlaTR7VBJP3LBFKXHCPVKPX6G7QFE">
-<catDesc>Codex / Buch</catDesc>
-</category>
-</category>
-<category xml:id="tlaB33RP4MSDZBQFDKY4EIN66J644">
-<catDesc>Mobiliar</catDesc>
-<category xml:id="tla4OUGU4JB5ZCFVNJZNXW66GTGTE">
-<catDesc>Kopfstütze</catDesc>
-</category>
-<category xml:id="tla4TZC3EJ6YNB67B3QLA7RRFKBFU">
-<catDesc>Sitzmöbel</catDesc>
-<category xml:id="tla6QNNOQJL5JBQNGFSVL5XQ7Q54E">
-<catDesc>Hocker</catDesc>
-<category xml:id="tlaEW5K62T3IZAFFNL7RUAL5BW2DM">
-<catDesc>Klapphocker</catDesc>
-</category>
-</category>
-<category xml:id="tla7VPYHV5J3RADZPYZK7IT7MAUGY">
-<catDesc>Schemel</catDesc>
-<category xml:id="tlaXQIRGGIEQ5E2PFCOE5LFTYGXBE">
-<catDesc>Fußschemel</catDesc>
-</category>
-</category>
-<category xml:id="tlaDLRVSAQHNJEENHRAUZ4DTTZ7HM">
-<catDesc>Stuhl</catDesc>
-<category xml:id="tlaA7RSUKHALJHBNBR2PMQTJL52F4">
-<catDesc>Stuhl mit Armlehne</catDesc>
-</category>
-<category xml:id="tlaJMPPH73FLFANPDXX7NOSO22NFA">
-<catDesc>Tragestuhl</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaIREAP7P2WZERBP7HKUC3YG53SU">
-<catDesc>Liegemöbel</catDesc>
-<category xml:id="tlaH2O5SPNJOJGGNIWHRFPJF4TRKI">
-<catDesc>Bett</catDesc>
-</category>
-</category>
-<category xml:id="tlaRQIXQ4ON2NDETGLHUL7OX2HAFE">
-<catDesc>Geburtsziegel</catDesc>
-</category>
-<category xml:id="tlaVIPFZSQ4DBBWPOBZXODCMHLEWI">
-<catDesc>Baldachin</catDesc>
-</category>
-<category xml:id="tlaWDFPDGEHKFCBRA7MRLLCL3EDM4">
-<catDesc>Tischmöbel</catDesc>
-<category xml:id="tlaLNLWNNXOLBGO7PPALV6WU647II">
-<catDesc>Opfertafel</catDesc>
-</category>
-<category xml:id="tlaNQ2GHQK3OJCNRPIPKLK5M4R5OE">
-<catDesc>Opferplatte / Seelenhaus</catDesc>
-</category>
-<category xml:id="tlaRMZLPW7BXVETFD2DTU36FJCYFI">
-<catDesc>Opfertisch</catDesc>
-</category>
-<category xml:id="tlaYDHSECVKFVG3BHUXVG4EJEG4G4">
-<catDesc>Opferbecken</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaWS2SDAG4N5CDRNCBYS3CBU62II">
-<catDesc>Geräte &amp; Instrumente</catDesc>
-<category xml:id="tla4PYCPK4LNZHM3OGXSPPF6DFDOU">
-<catDesc>Spinnerei- &amp; Webereiutensilien</catDesc>
-<category xml:id="tlaBOOFV6D25JH3VERSDKGRQE3UZQ">
-<catDesc>Webstuhlgewicht</catDesc>
-</category>
-</category>
-<category xml:id="tla7TW6KQ5AFNCHHMFLNSC37ZDAZQ">
-<catDesc>Textilverarbeitungsutensilien</catDesc>
-<category xml:id="tla5U7ADNHPFJE6XEFMRSY4WQFMUI">
-<catDesc>Plissierholz</catDesc>
-</category>
-<category xml:id="tlaQ7CO6QJRLRCENH2KCRQ5YMEIUM">
-<catDesc>Nadel</catDesc>
-</category>
-</category>
-<category xml:id="tlaFYFPWGV4BVHYLBDYPTVLIYHT64">
-<catDesc>Transportgeräte</catDesc>
-<category xml:id="tla2C6KX2JLTJHUVP4EU4WQVTB7UY">
-<catDesc>Schlitten</catDesc>
-</category>
-<category xml:id="tlaIHYRCL3YY5DQXB6V677QJL3TZY">
-<catDesc>Wagen</catDesc>
-</category>
-</category>
-<category xml:id="tlaGOAIUPI6JNCCDCAVVM6C4HFBFE">
-<catDesc>Wagen- &amp; Jagdutensilien</catDesc>
-<category xml:id="tla33B3CQSP4ZGWNDQ65FZABY5EL4">
-<catDesc>Köcher</catDesc>
-</category>
-<category xml:id="tlaLUAZAW6FWFEANCHIHSPQXY25PE">
-<catDesc>Keule</catDesc>
-</category>
-<category xml:id="tlaSY3YLRSYOBGKBLN7XSBN4KJ2NE">
-<catDesc>Messer</catDesc>
-<category xml:id="tla6CVCFM2J2NDEFHQA6K4D45DAB4">
-<catDesc>Pescheskaf-Messer</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaKPHDZQ5JNJBG5ECJ7FSWHVKIRY">
-<catDesc>Musikinstrumente</catDesc>
-<category xml:id="tlaL6JZNJ5B4BCHRGGYJEJQPSOR5E">
-<catDesc>Menit</catDesc>
-</category>
-<category xml:id="tlaOFSBV6J67ZCP7DPIGZEX6CJKFI">
-<catDesc>Sistrum</catDesc>
-</category>
-<category xml:id="tlaR6XGJOAXWVD2VAWIS355I4ZX2A">
-<catDesc>Harfe</catDesc>
-</category>
-<category xml:id="tlaWRP7D2OX5ZHANFAZKBCFHRLCR4">
-<catDesc>Flöte</catDesc>
-</category>
-</category>
-<category xml:id="tlaNPYF7NIJNFALPOP76NXZ7F22XE">
-<catDesc>Messgeräte</catDesc>
-<category xml:id="tlaK2DCOCYK2VBWHCDD7TAX5Y6E64">
-<catDesc>Ellenmaßstab</catDesc>
-</category>
-<category xml:id="tlaLISJ6Z4ODBFRNA74Z7SRYZQBCU">
-<catDesc>Gewichte</catDesc>
-</category>
-<category xml:id="tlaRFTKXT4X3RBL3K6ANRNUR2JBCI">
-<catDesc>Waage</catDesc>
-</category>
-<category xml:id="tlaZI3KYIWKYFHPLEIORHVYZPBXDQ">
-<catDesc>Wasseruhr</catDesc>
-</category>
-</category>
-<category xml:id="tlaQ2LHAISZD5HELOC4QFRG4WDAHI">
-<catDesc>Toilettenutensilien</catDesc>
-<category xml:id="tlaCWU7KTQMI5B47PUTCUTE3HGUIA">
-<catDesc>Rasiermesser</catDesc>
-</category>
-<category xml:id="tlaDFVKM5QT5VEALMI3FULA5G4EEA">
-<catDesc>Schminkgefäß</catDesc>
-</category>
-<category xml:id="tlaFCCC2DIQCNHWJGCZAKR2JCKWUY">
-<catDesc>Schminkstäbchen</catDesc>
-</category>
-<category xml:id="tlaMU3ICRHCBRE2ZAJDJI3D4Z2DGA">
-<catDesc>Schminkpalette</catDesc>
-</category>
-<category xml:id="tlaTIYZLILISVB6BKPDHUTV56ZVAE">
-<catDesc>Spiegel</catDesc>
-</category>
-<category xml:id="tlaYQVBNGAHLZHLTDJXTTUPW2BK5U">
-<catDesc>Salbölpalette</catDesc>
-</category>
-<category xml:id="tlaZ7RJ364DONCWPNSGAGWNGBXBME">
-<catDesc>Salblöffel</catDesc>
-</category>
-</category>
-<category xml:id="tlaSSJTUKEWTJCRHN5LWLMGB4OIVQ">
-<catDesc>Schreib- &amp; Malutensilien</catDesc>
-<category xml:id="tla32XNHAGVG5FN5JOAG6OLE5ZL2I">
-<catDesc>Schreibrohr</catDesc>
-</category>
-<category xml:id="tla7752ML47CZG6RM3K2VDGRC3OPY">
-<catDesc>Malerpalette</catDesc>
-</category>
-<category xml:id="tlaD6U4R3NIKFEXXKVUSK73F6PYGQ">
-<catDesc>Schreibbinse</catDesc>
-</category>
-<category xml:id="tlaHEIHGH5M4RBNDBKHO6IHXY4CFU">
-<catDesc>Papyrusglätter</catDesc>
-</category>
-<category xml:id="tlaLDUJHIGOAZGTBJVGQC6G7NECCI">
-<catDesc>Schreiberpalette</catDesc>
-</category>
-<category xml:id="tlaXP7ENURRIJCHVOQFE2JYHV7UEY">
-<catDesc>Schreibgriffel</catDesc>
-</category>
-</category>
-<category xml:id="tlaUDJEAH7X6JAB7FLD7LOHSSDOUU">
-<catDesc>Siegelutensilien</catDesc>
-<category xml:id="tla2SFVG2GHTFEZZOEVM7BY5EUXUU">
-<catDesc>Siegelplatte</catDesc>
-</category>
-<category xml:id="tlaH3464MKLERBS5PJ4ZG4CQKWYOU">
-<catDesc>Plombierung</catDesc>
-</category>
-<category xml:id="tlaMKCB4MOILVFYNBS6PUGQ2KH5DU">
-<catDesc>Rollsiegel</catDesc>
-</category>
-<category xml:id="tlaNE4K5UKL5NG6LBSWQXNZ2RQZBM">
-<catDesc>Brenneisen</catDesc>
-</category>
-<category xml:id="tlaXJEW2NYCENB3JE57KU4O6ZNBTI">
-<catDesc>Siegelring</catDesc>
-</category>
-<category xml:id="tlaZSLLLBVUOVHR5HY27NPC4OY4RI">
-<catDesc>Stempelsiegel</catDesc>
-</category>
-</category>
-<category xml:id="tlaVGWAPYSDOBAAROLY4VOHCU4H34">
-<catDesc>Räucherutensilien</catDesc>
-<category xml:id="tlaTZITRCBJ6FCAJKS5Y7A4PY3MWA">
-<catDesc>Räucherarm</catDesc>
-</category>
-<category xml:id="tlaYBZE7FEAERDSFDVXQCCQXR6NSA">
-<catDesc>Räuchergefäß / -pfanne</catDesc>
-</category>
-</category>
-<category xml:id="tlaWVAHYFV24FCR3PZAIGIAM53PM4">
-<catDesc>Reibstein</catDesc>
-</category>
-<category xml:id="tlaXHO2MYFDFVFXFBTRYRGMTOLDRI">
-<catDesc>Spiel- &amp; Sportutensilien</catDesc>
-<category xml:id="tlaOZPXFN4JXNGEDHFRV4PMGNO4PY">
-<catDesc>Puppe</catDesc>
-</category>
-<category xml:id="tlaSTUIM6YKN5EVHM4IUIDQN56NAM">
-<catDesc>Brettspiel</catDesc>
-</category>
-<category xml:id="tlaZIPZMV2NFJHP5HB6F7XA5TDDAU">
-<catDesc>Ball</catDesc>
-</category>
-<category xml:id="tlaZV2B22FBCFHIFLBFYQRUBRD7PM">
-<catDesc>Brettspielfigur</catDesc>
-</category>
-</category>
-<category xml:id="tlaXUOU3463ENG5HJEDXR74C5GSIQ">
-<catDesc>Model / Matrize</catDesc>
-<category xml:id="tlaBBZHVAX2MVAEVBEXSIMTEW3V3A">
-<catDesc>Guß- &amp; Pressform</catDesc>
-<category xml:id="tlaUFLXRM5GHBBSHLVIMXS7FCC45I">
-<catDesc>Ziegelstreichform</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaZ6BJ3YQXRBAEVPN5EYSZS6NSRM">
-<catDesc>Töpferutensilien</catDesc>
-<category xml:id="tlaVFG5HZJCCZBFVEYOKCUXDLXINY">
-<catDesc>Töpferscheibe</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaZMDKUD6ZNBFSBMHYESKFI3A7ZI">
-<catDesc>Tracht</catDesc>
-<category xml:id="tla3MSDW5IAFZCI3FT4R4GHAHOFRQ">
-<catDesc>Textilien</catDesc>
-<category xml:id="tla2XDOY5TPI5BXPOV25RZK57MUMM">
-<catDesc>Mumienriemen</catDesc>
-</category>
-<category xml:id="tlaFZKGHRO4GBDA3EUTOYEVG525GI">
-<catDesc>Laken</catDesc>
-</category>
-<category xml:id="tlaS63JJ4SLKRHWRANIQ4ORQK64TI">
-<catDesc>Mumienbinde</catDesc>
-</category>
-<category xml:id="tlaVQEDP5UFPVDYVJPON3YNYRHVYI">
-<catDesc>Taue</catDesc>
-</category>
-<category xml:id="tlaWJZO2KQXUNE6VNIN2QLO35DOHE">
-<catDesc>Hypocephalus</catDesc>
-</category>
-<category xml:id="tlaXL2YAN6JPZDWTHOV2OMJMASBTU">
-<catDesc>Stoff</catDesc>
-</category>
-</category>
-<category xml:id="tlaHMDNBBVDMJG3RCNJ4ASN5XVDDI">
-<catDesc>Bekleidung</catDesc>
-<category xml:id="tla3FVH47ECNVB5RAFMRAS3JE4DFI">
-<catDesc>Kopfbekleidung</catDesc>
-<category xml:id="tlaQXQ5AKHAFRAFLH77GAAB6AWMCI">
-<catDesc>Perücke</catDesc>
-</category>
-</category>
-<category xml:id="tlaA7PAFCMJ75A35GSI5UUG6PN6NQ">
-<catDesc>Fußbekleidung</catDesc>
-<category xml:id="tlaJG6AIA7FNVGFZDZJYORXDWSOWI">
-<catDesc>Sandale</catDesc>
-</category>
-</category>
-<category xml:id="tlaVQ4RETLHJRGIBPMWKSNSBWIRCE">
-<catDesc>Lendentuch</catDesc>
-</category>
-<category xml:id="tlaZ3D5DJRL75FGPFIMYUDC5ZPTSQ">
-<catDesc>Tunika</catDesc>
-</category>
-</category>
-<category xml:id="tlaQ3UY3JANGZD6NN2VSUXKC47CYI">
-<catDesc>Trachtassessoirs</catDesc>
-<category xml:id="tlaLQKHCWDTSVC4NBXFVCAML2EQBU">
-<catDesc>Perlennetz</catDesc>
-</category>
-<category xml:id="tlaSA2MB42LX5EFHFDDTH6DDOXZEQ">
-<catDesc>Schmuck</catDesc>
-<category xml:id="tla3MMFFLHZI5F4DHBJTX2Q7PI3JA">
-<catDesc>Haarkranz</catDesc>
-</category>
-<category xml:id="tla5YMCM3AQXZHTZC7QLGRI7FC7SM">
-<catDesc>Menit-Kette</catDesc>
-</category>
-<category xml:id="tlaEPUEHMPEENHALE77SHS4SPPNSI">
-<catDesc>Ohrschmuck</catDesc>
-</category>
-<category xml:id="tlaIFYMOSU3BND2ZHIRFDOHHVTYGE">
-<catDesc>Leichenband</catDesc>
-</category>
-<category xml:id="tlaQNM26WD2VJFNJIEQD65MPK66KM">
-<catDesc>Perle</catDesc>
-</category>
-<category xml:id="tlaZW5XPFGVJBGIVEERAKDE3F2HSA">
-<catDesc>Anhänger</catDesc>
-</category>
-</category>
-<category xml:id="tlaUHWKE6FXGZF5NL2GH52ALWAQEA">
-<catDesc>Stöcke &amp; Stäbe</catDesc>
-</category>
-<category xml:id="tlaVLSX3M2HGJCH7NSEWS4BIGL2PY">
-<catDesc>Kronen &amp; Hüte</catDesc>
-</category>
-</category>
-</category>
-</category>
-<category xml:id="tlaO77RFF6A5BDNZALFYDSOSEMPH4">
-<catDesc>Realia / Naturformen</catDesc>
-<category xml:id="tlaEQZEGXGFTNHLLIGILFKVE2IXXA">
-<catDesc>Fels</catDesc>
-</category>
-</category>
-<category xml:id="tlaPN7PZTXCIFEZJOIEDWA7WW65EM">
-<catDesc>unbestimmt</catDesc>
-</category>
-</category>
-<category xml:id="tla7LANG42J4FH5XOJL7VIHZKH5FA">
-<catDesc>24 = Material</catDesc>
-<category xml:id="tla3NHNBPVU3VF2RERSPPZ46ELQHE">
-<catDesc>Holz</catDesc>
-</category>
-<category xml:id="tla6HRN4262MRB7ZJCTZKSQ33LLE4">
-<catDesc>Papyrus</catDesc>
-</category>
-<category xml:id="tla6SMVRSODQ5BXVIABWOLOT2GBB4">
-<catDesc>Ton</catDesc>
-</category>
-<category xml:id="tlaH7S5EKRWZ5EVBI35BBLML3MRL4">
-<catDesc>Kalkstein</catDesc>
-</category>
-<category xml:id="tlaPC6MNZWZLVC7REJRXEKIN7UMQM">
-<catDesc>Fayence</catDesc>
-</category>
-<category xml:id="tlaRA4YWGA3EFBQNLB5JORH4HJLNM">
-<catDesc>Leder</catDesc>
-</category>
-<category xml:id="tlaTCNODPO4NFBSRI7WQYIR23ALJI">
-<catDesc>Stein</catDesc>
-</category>
-<category xml:id="tlaUOGHTTMOBFAL3JU5ZH62ICOCMA">
-<catDesc>Keramik</catDesc>
-</category>
-<category xml:id="tlaY5Z4OMEPCVHCXNRDGD7MTL5H24">
-<catDesc>Elfenbein</catDesc>
-</category>
-</category>
-<category xml:id="tla2KR2OCPWNJHKRG3V5XS2C2O7UE">
-<catDesc>33 = Gruppierung</catDesc>
-<category xml:id="tlaUIOCASM5IBAV3IRO6UPRQSGNEE">
-<catDesc>unbestimmt</catDesc>
-</category>
-<category xml:id="tlaXS262SLB2FDP7CBCEZNWNE7KMQ">
-<catDesc>Archiv</catDesc>
-</category>
-</category>
-<category xml:id="tlaNUR4SFIADFGU3BTNL2G7VT67VQ">
-<catDesc>29 = Skeuomorph</catDesc>
-<category xml:id="tlaKONZHVUFIZCANIKXE654IAXFXI">
-<catDesc>Skeuomorph</catDesc>
-</category>
-</category>
-<category xml:id="tla77YNOMBDLZAMDB7JQULDBCTEVM">
-<catDesc>30 = Abschrift</catDesc>
-<category xml:id="tla6QBFHMPUNVHNFECABLQYCU5NO4">
-<catDesc>sekundäre Aufschrift</catDesc>
-</category>
-</category>
-<category xml:id="tlaJZMJSNJQ35F4BO65Q5OVGJIJVY">
-<catDesc>27 = Imitation</catDesc>
-<category xml:id="tlaSSJSULI7RFGDRNWABAGGBBVC2Q">
-<catDesc>Imitation</catDesc>
-</category>
-</category>
-<category xml:id="tla2FCXD44JGZGYXNI4LAFEKOGDPM">
-<catDesc>25 = Kontext</catDesc>
-<category xml:id="tla5YYX5M3ZMNG5TN4FH4CXIJV42U">
-<catDesc>Zauber</catDesc>
-</category>
-<category xml:id="tlaJTPKDP7HTRGIBKN34QHASPR4LE">
-<catDesc>Grabausstattung</catDesc>
-</category>
-<category xml:id="tlaRRQV23QVBRFHVGR3CUSJTMAD4E">
-<catDesc>Ritual</catDesc>
-</category>
-<category xml:id="tlaRWZ6E5P2ZJBEFPZMJTXLNGGB6Q">
-<catDesc>Kult</catDesc>
-</category>
-<category xml:id="tlaZF4KPLYHPZCVBNS4BBE2DN333E">
-<catDesc>Gebrauchsgegenstand</catDesc>
-</category>
-</category>
-<category xml:id="tla3EPPDTJ5FVCA7LO6GBN25EGXBM">
-<catDesc>28 = Miniatur</catDesc>
-<category xml:id="tlaIREQIEIXKJEL3DOBWTJA4XFUSE">
-<catDesc>Miniatur</catDesc>
-</category>
-</category>
-<category xml:id="tlaIOOFFM7DCJGJFIP5MPUNO55RVE">
-<catDesc>5 = Schriftformen</catDesc>
-<category xml:id="tla7SDIQ6CH55FODFOUJ3NVYEZOYY">
-<catDesc>Aramäisch</catDesc>
-</category>
-<category xml:id="tlaAX44V2CHHJEQ7I4UHZ2XB3WYMU">
-<catDesc>Schriften moderner Schriftsprachen</catDesc>
-</category>
-<category xml:id="tlaJ5E7HWT7JZB2FMVPVI77H7VB3A">
-<catDesc>Hieroglyphen</catDesc>
-<category xml:id="tlaEZXNXXZNJRHZFIZEQDGAHVVH5U">
-<catDesc>Kursivhieroglyphisch</catDesc>
-</category>
-<category xml:id="tlaLF5ZEAG65JG6BFTD3HTDQZPXIM">
-<catDesc>Ptol.-röm. Schriftsystem</catDesc>
-</category>
-<category xml:id="tlaRH2J5C23AVEWTIXGCUVLGCC7TY">
-<catDesc>Kryptographisch</catDesc>
-</category>
-<category xml:id="tlaTYXKD55ZDRB5NAWUTC7YWWJQRQ">
-<catDesc>reguläre Hieroglyphenschrift</catDesc>
-</category>
-</category>
-<category xml:id="tlaMRV4NILEZNFS7O5LIZAMJZKPLE">
-<catDesc>Hieratisch</catDesc>
-<category xml:id="tlaDS372PTLDNA6ZADSSC6LBEJD7M">
-<catDesc>Archaisches Hieratisch</catDesc>
-</category>
-<category xml:id="tlaFFA2PGLQSNHMJFJP2RKAOMK43E">
-<catDesc>Mittelhieratisch</catDesc>
-<category xml:id="tlaE6EFYLK5PRF6VDRCSQ3NJB526M">
-<catDesc>Mittelhieratische Kanzleischrift</catDesc>
-</category>
-<category xml:id="tlaN2T36QN2JRDVHGNTDG6ZR3FF6Q">
-<catDesc>Mittelhieratische Buchschrift</catDesc>
-</category>
-</category>
-<category xml:id="tlaLKARVWCGJFB5DL4L7OLRU66NJY">
-<catDesc>Neuhieratisch</catDesc>
-<category xml:id="tla2A65KN6SDNG5LDBR3BSWA6JSEM">
-<catDesc>Neuhieratische Kanzleischrift</catDesc>
-</category>
-<category xml:id="tlaABR7EWEFGBCJBOKIGKKDVUJS3Q">
-<catDesc>Neuhieratische Buchschrift</catDesc>
-</category>
-</category>
-<category xml:id="tlaMGESF7LTKZCDTID4ECIMFU67UY">
-<catDesc>Abnormhieratisch</catDesc>
-</category>
-<category xml:id="tlaSRFM7BGQJBFRJL5GJ2P7WGZWBA">
-<catDesc>Althieratisch</catDesc>
-</category>
-<category xml:id="tlaXPUJ7HQYQBGMTHWPGBWUCR26LQ">
-<catDesc>Späthieratisch</catDesc>
-<category xml:id="tlaZ35DNIOFZ5G3VJN6XHP2CTCUBQ">
-<catDesc>Späthieratische Buchschrift</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaMWT355LFDNE3HCEWGJVKCA2ERE">
-<catDesc>Meroitisch</catDesc>
-</category>
-<category xml:id="tlaOT3TJKRQMRHE3ERU34VMN4DF4U">
-<catDesc>Koptisch</catDesc>
-<category xml:id="tlaBCLYT4Q5YFASJMCYQJUQJRZ7AM">
-<catDesc>Koptische Kursive</catDesc>
-</category>
-<category xml:id="tlaS3DGZAE2PZD73EGLXBIDWJSLHE">
-<catDesc>Koptische Halbunziale</catDesc>
-</category>
-<category xml:id="tlaZ6Y3QAKWPNAFZEFASSITKKTYTY">
-<catDesc>Koptische Unziale</catDesc>
-</category>
-</category>
-<category xml:id="tlaUHT63RLVTNFE3BC4EM7H6L6RJY">
-<catDesc>Demotisch</catDesc>
-<category xml:id="tlaGDR4SNZFHJFFNDCHQKX7QZYPAY">
-<catDesc>Spätdemotisch</catDesc>
-</category>
-<category xml:id="tlaKLYSEDKWFBEYPBSWTNU7AM36GU">
-<catDesc>Mitteldemotisch</catDesc>
-</category>
-<category xml:id="tlaQDTWEYB6KRGZTDLEPLFFJXN7G4">
-<catDesc>Frühdemotisch</catDesc>
-</category>
-</category>
-<category xml:id="tlaYAF2UU4R25FIROCOE72WV3YVMI">
-<catDesc>Lateinisch</catDesc>
-</category>
-<category xml:id="tlaYXPU67OHQVBHVJLP7YLICWKTYA">
-<catDesc>Griechisch</catDesc>
-</category>
-</category>
-<category xml:id="tlaGDFTM4DNPRFT7ARXZSSHZ7VZJI">
-<catDesc>32 = Technik</catDesc>
-<category xml:id="tlaTPJ2XG5NGZFIJGXAPYH7IGUFUM">
-<catDesc>unbestimmt</catDesc>
-</category>
-<category xml:id="tlaXBDPINNBLZBQZDLDKZKKKAINBE">
-<catDesc>geschnitzt</catDesc>
-</category>
-</category>
-<category xml:id="tlaEM7EXOH7ONGGFBP3SB3YHS426M">
-<catDesc>3 = Fundstellen</catDesc>
-<category xml:id="tla3PEYR6TNZRCYBEGAYXCNBLUEBQ">
-<catDesc>Niltal südlich des 3. Katarats bis zum 4. Katarakt</catDesc>
-<category xml:id="tla4K63P4AVMBGGRNBYDUPI4EGBUI">
-<catDesc>Pnubs</catDesc>
-</category>
-<category xml:id="tla5XKJZBNHQ5DH3OG6DT73N2X7N4">
-<catDesc>Gebel Barkal</catDesc>
-</category>
-<category xml:id="tla5XWLGMNL4FDAPN24SBNQVGZOXY">
-<catDesc>Kawa</catDesc>
-</category>
-<category xml:id="tlaHG4QZPHNWNE2XAG3IQQZFSOZZE">
-<catDesc>Sanam Abu Dom</catDesc>
-</category>
-<category xml:id="tlaKBD54W3APBFZHAX4BQ3PFFANJM">
-<catDesc>Napata</catDesc>
-</category>
-<category xml:id="tlaPIDYXAAJ45FCPATGJWHYZAS5PM">
-<catDesc>Argo</catDesc>
-</category>
-<category xml:id="tlaPJYTUZYRY5CV7OPWID3W5LGL4Q">
-<catDesc>Kerma</catDesc>
-</category>
-<category xml:id="tlaQRX5PIJT4ZCABLC6GTM3A66QCE">
-<catDesc>Nuri</catDesc>
-</category>
-<category xml:id="tlaTQVHERHS5BFGLHSPNQGQJNXKPI">
-<catDesc>Dongola</catDesc>
-</category>
-<category xml:id="tlaUCVOSZ2YUZFLLCOXEH5IQW24T4">
-<catDesc>el-Kurru</catDesc>
-</category>
-</category>
-<category xml:id="tla6NJP62ZOOVGENAF3BKE3OR7CG4">
-<catDesc>(unbestimmt)</catDesc>
-</category>
-<category xml:id="tlaBALRMKSX4RCFJBB24NEIG4MIAE">
-<catDesc>Nildelta</catDesc>
-<category xml:id="tla22BFCHYQGFC7FHBU7DQYAUVDEI">
-<catDesc>südliches Delta</catDesc>
-<category xml:id="tlaBHD3CGTJGFBFHAB45BMC3YHHRQ">
-<catDesc>westlicher Teil</catDesc>
-<category xml:id="tlaCQEXXNY7UFFHDEWWAEM6MYJY4A">
-<catDesc>Letopolis</catDesc>
-</category>
-<category xml:id="tlaGNCHIULZSVB2XGP3WOJ6VBESK4">
-<catDesc>Merimde-Beni-Salame</catDesc>
-</category>
-<category xml:id="tlaL74GTSQTZNDOBHU7BUXKV5IOTQ">
-<catDesc>Terenuthis</catDesc>
-</category>
-<category xml:id="tlaRLO4NJHU3VFCDNPNRJ5OIQSF5U">
-<catDesc>el-Qatta</catDesc>
-</category>
-</category>
-<category xml:id="tlaLUQMOESPBVHSDKIYCVU4QJZQUE">
-<catDesc>zentraler Teil</catDesc>
-<category xml:id="tla5DBEL23ENNCO3PCILVKAG4BYA4">
-<catDesc>Athribis</catDesc>
-</category>
-<category xml:id="tlaNBRK4362GBBS5LJJ7ZWKWQH3FI">
-<catDesc>Tuch el-Meleq</catDesc>
-</category>
-</category>
-<category xml:id="tlaMQN3L5V4AVANBNS3ZNBRADMLAA">
-<catDesc>östlicher Teil</catDesc>
-<category xml:id="tla2X5LJC27KVCFDNRQXGSPZG7FDA">
-<catDesc>Gebel el-Ahmar</catDesc>
-</category>
-<category xml:id="tlaCGSB2R4IMJCTVJ6GEADDIEBNWA">
-<catDesc>Tell el-Jahudija</catDesc>
-</category>
-<category xml:id="tlaELVLGXV3QNDIXFG4WV4YGK7RIE">
-<catDesc>Ma&#039;sara</catDesc>
-</category>
-<category xml:id="tlaHYKS2XE7WFEUJOVBAKVUOSUBXY">
-<catDesc>el-Mineiar</catDesc>
-</category>
-<category xml:id="tlaIBLDCA7DNJDAXFZSTWPZDLQ7SI">
-<catDesc>Bilbeis</catDesc>
-</category>
-<category xml:id="tlaR5IJ27RPYJEC7OMMHIS6WXXK7A">
-<catDesc>Heliopolis</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaIJYTSZ3DLZDGHMJR4C43JDUUE4">
-<catDesc>vom Suezkanal zum Nil</catDesc>
-<category xml:id="tlaEJ5NSLRQNVGUFDOJCRIK3CVIWY">
-<catDesc>Wadi Tumilat</catDesc>
-<category xml:id="tla4EENHGCLKBFELOYFSL7MNBGAYI">
-<catDesc>Tjeku</catDesc>
-</category>
-<category xml:id="tlaO3TB4IYE3BES7G47ELHNP6GSTE">
-<catDesc>Tell el-Maschuta</catDesc>
-</category>
-<category xml:id="tlaWYEVB2H26JAYVKD3JDUSB66LS4">
-<catDesc>Tell er-Retabe</catDesc>
-</category>
-<category xml:id="tlaXLIXCHIMXJAKHE37SNCXEFPJUM">
-<catDesc>Pithom</catDesc>
-</category>
-</category>
-<category xml:id="tlaPU3TEBN7N5FDHKSQHHYGRHYHYE">
-<catDesc>Gebel Abu-Hassa</catDesc>
-</category>
-</category>
-<category xml:id="tlaU4Z2DGVNWBBMLD5GD24DX3QKCQ">
-<catDesc>nördliches Delta</catDesc>
-<category xml:id="tlaIWBOJMGRKZAI3FDXPNMXSFPHQM">
-<catDesc>zentraler Teil</catDesc>
-<category xml:id="tla4ZW7V6Y5QJFYRJXHJ65XTMLQQA">
-<catDesc>Behbeit el-Hagar</catDesc>
-</category>
-<category xml:id="tla5HC6ICFQ5RGMRFBYYHOD6ZOKA4">
-<catDesc>Tell Mustai</catDesc>
-</category>
-<category xml:id="tla5NGQ5UGSBFGABLAQW3XWKN3YWM">
-<catDesc>Tell el-Belamun</catDesc>
-</category>
-<category xml:id="tlaJFONOHDXD5D3NF6ABSM7IY2QOE">
-<catDesc>Tell Tibilla</catDesc>
-</category>
-<category xml:id="tlaLG6U2DG5QBFTFJTINMG4IPL2R4">
-<catDesc>Busiris</catDesc>
-</category>
-<category xml:id="tlaOV655ZB3FFFUPDPLHFMMCORSWA">
-<catDesc>Sebennytos</catDesc>
-</category>
-<category xml:id="tlaOW6IU53NCFGY3ON4R76Q6WMTAE">
-<catDesc>Ma&#039;sara</catDesc>
-</category>
-<category xml:id="tlaSOPJL3PRZ5B3JP6LBCALNKZKIA">
-<catDesc>Xois</catDesc>
-</category>
-<category xml:id="tlaV5GUCODM45AQLDEECYGSMPQQXI">
-<catDesc>Buto</catDesc>
-</category>
-<category xml:id="tlaZGMRXNW7WRFXTFSOJALIA2A7HQ">
-<catDesc>Tanta</catDesc>
-</category>
-</category>
-<category xml:id="tlaOTKNRCAOWZATDB266AYBXUXJE4">
-<catDesc>östlicher Teil</catDesc>
-<category xml:id="tlaF45DPZ36QRD2JPS4SCOKTYDADQ">
-<catDesc>Bubastis</catDesc>
-</category>
-<category xml:id="tlaJCQVTFDTSRB35IUP5DVT7XOUKI">
-<catDesc>Imet</catDesc>
-</category>
-<category xml:id="tlaMI463ZT56RAHNJZMRJ2HQUJBFM">
-<catDesc>Horbeit</catDesc>
-</category>
-<category xml:id="tlaMPEQWUPDQBGV5DOG755QTFYFXI">
-<catDesc>Mit Jaisch</catDesc>
-</category>
-<category xml:id="tlaNVIS72L2OBHPJA4IOA27WG5AOE">
-<catDesc>Tuch el-Qaramus</catDesc>
-</category>
-<category xml:id="tlaOZ4QHHCIIZA73PXFWLWHGGR5MY">
-<catDesc>Daphne</catDesc>
-</category>
-<category xml:id="tlaPNUNV5Y35FFZBHFP7ZB66MJDWA">
-<catDesc>Baklija</catDesc>
-</category>
-<category xml:id="tlaR6LJPQH3ERDJPONBEHGEKI26DQ">
-<catDesc>el-Munagat</catDesc>
-</category>
-<category xml:id="tlaRSDXUFF745C37ARA72C6QMSVAY">
-<catDesc>el-Chata&#039;na</catDesc>
-</category>
-<category xml:id="tlaSH6XJRRRJNCI5EAMNJSPU5QZ3A">
-<catDesc>Tanis</catDesc>
-</category>
-<category xml:id="tlaT43FHBSDM5ET5FP4CMOPRHQJHM">
-<catDesc>Tell el-Moqdam</catDesc>
-</category>
-<category xml:id="tlaUUFUTAO2CRGMBCCHZUSIX54NYY">
-<catDesc>Sile</catDesc>
-</category>
-<category xml:id="tlaUV7M4QWTNNHFNAOZNLDMEUQ2I4">
-<catDesc>Tell ed-Dab&#039;a</catDesc>
-</category>
-<category xml:id="tlaUZYOPM5FU5CC5AETRZKG6ETNNQ">
-<catDesc>Mendes</catDesc>
-</category>
-<category xml:id="tlaXF74GZP3A5CTXHEMEW4BAGXGAU">
-<catDesc>Faqus</catDesc>
-</category>
-<category xml:id="tlaYNGNGUJD6RBAHPPMETU6TNQX5Q">
-<catDesc>Thmuis</catDesc>
-</category>
-</category>
-<category xml:id="tlaP3CETTKCSVC2BGF6GYT2KSYYQ4">
-<catDesc>westlicher Teil</catDesc>
-<category xml:id="tla42UHTTPRIJD6BKVINF5RNCHYNQ">
-<catDesc>Kom el-Hisn</catDesc>
-</category>
-<category xml:id="tla4W3RKNA2SVA7TATDOP4WXMDPFE">
-<catDesc>Rosette</catDesc>
-</category>
-<category xml:id="tlaCJ3TD3P53VAURNH74TMRZF653A">
-<catDesc>Naukratis</catDesc>
-</category>
-<category xml:id="tlaJAPLD5QERREFTBGTVSA3Z3QYQE">
-<catDesc>Damanhur</catDesc>
-</category>
-<category xml:id="tlaV7ON34EUUBB3TJYKXB3ZNH67BQ">
-<catDesc>Sais</catDesc>
-</category>
-</category>
-<category xml:id="tlaPFIFC6WAYFBBJFTEKB7M3STHZU">
-<catDesc>Nordküste</catDesc>
-<category xml:id="tlaDSW5GW5HENDW5OLNBZLN42EWFU">
-<catDesc>Kom esch-Schugafa (Alexandria)</catDesc>
-</category>
-<category xml:id="tlaGU23DGCAIZCGRNQCYEUZTFF6FI">
-<catDesc>Taposiris Magna</catDesc>
-</category>
-<category xml:id="tlaMYI47NGXPNBZ5HNMRWYZWJ24EA">
-<catDesc>Kom el-Idris</catDesc>
-</category>
-<category xml:id="tlaON7JIYBPHFAGJFUAIZCGYCSYNU">
-<catDesc>Kanopus</catDesc>
-</category>
-<category xml:id="tlaP5PHG7ZM3ZEBRKBABQ2SZYNW4Y">
-<catDesc>Pelusium</catDesc>
-</category>
-</category>
-</category>
-</category>
-<category xml:id="tlaBUWJS23DLVAVFH7H5SRJOOAPFM">
-<catDesc>Niltal südlich des 1. Katarakts bis zum 2. Katarakt</catDesc>
-<category xml:id="tla6VL7V2BNIFCNJAFW3CRMI64FKQ">
-<catDesc>Abu Simbel</catDesc>
-<category xml:id="tlaR6Y6XEI6QBDONIUN2YDEHJDWZQ">
-<catDesc>Abu Simbel</catDesc>
-</category>
-</category>
-<category xml:id="tla7S7NTM7P2VBUVC77Z76EDJKIIE">
-<catDesc>Dakke bis Abu Simbel</catDesc>
-<category xml:id="tlaKHD2BMU6QZA37C2XZMYE7FPDYM">
-<catDesc>westliches Ufer</catDesc>
-<category xml:id="tla6UBXD73ACZAYPGKJ6XGVJNZ62Q">
-<catDesc>Sayala</catDesc>
-</category>
-<category xml:id="tlaGBRDGGW3XVARDDDY5CIGMJPSGQ">
-<catDesc>Ermenne</catDesc>
-</category>
-<category xml:id="tlaGX4XGIN7J5BDVHAOC5HEMK3SZU">
-<catDesc>Tomas</catDesc>
-</category>
-<category xml:id="tlaIHT6E676DJFO3OR5LYOGCCI6LA">
-<catDesc>Amada</catDesc>
-</category>
-<category xml:id="tlaSC352ETLQBBHFMHLESXVXAKYIQ">
-<catDesc>Aniba</catDesc>
-</category>
-<category xml:id="tlaTIDXLPPUL5HYXLFPAZ5BDEMTAE">
-<catDesc>Hierasykaminos</catDesc>
-</category>
-<category xml:id="tlaX4QQKDWFFFDB7JDHLHMLEOK624">
-<catDesc>Wadi es-Sebua</catDesc>
-</category>
-</category>
-<category xml:id="tlaTYHMMHS7NFBQFASBACI7RUHQIY">
-<catDesc>östliches Ufer</catDesc>
-<category xml:id="tla4SHOZRWM4ZDMJEXXYCEKSAYF7Q">
-<catDesc>Quban</catDesc>
-</category>
-<category xml:id="tla7Y5DUFTXTNE5RBZNGQDZRSSNLY">
-<catDesc>Toschqa</catDesc>
-</category>
-<category xml:id="tlaBBVGTJLTRBD53OQZBOEFYS63UI">
-<catDesc>Qasr Ibrim</catDesc>
-</category>
-<category xml:id="tlaTZQFPMP5JFCUZGEUHJR26CLFXE">
-<catDesc>Derr</catDesc>
-</category>
-<category xml:id="tlaXWTXKPEPWRDDVD6QUHK3USP55M">
-<catDesc>Korosko</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaADPSIZ75TZDM7P62YEGXEKKTHU">
-<catDesc>Dakke</catDesc>
-<category xml:id="tlaYGNF37YOARHYPJDAKTXMWDPJRA">
-<catDesc>Dakke</catDesc>
-</category>
-</category>
-<category xml:id="tlaKRV3GM777FBVVHBGPABDIRAPEI">
-<catDesc>1. Katarakt bis Dakke</catDesc>
-<category xml:id="tla77RGQQ53DBDFJBPNQ7RKYTYVHM">
-<catDesc>westliches Ufer</catDesc>
-<category xml:id="tlaGSDIFBXPDZHYVFT3RXA4FV2N5U">
-<catDesc>Gerf Hussein</catDesc>
-</category>
-<category xml:id="tlaKQ4VEK5G5FCP7OSBMDSVQ2QD2Q">
-<catDesc>Qertassi</catDesc>
-</category>
-<category xml:id="tlaO4UUADN375A3LDUHHX7BXIW2WM">
-<catDesc>Beit el-Wali</catDesc>
-</category>
-<category xml:id="tlaO7GX2JNVWRE3FESZO47YUCBD64">
-<catDesc>Dendur</catDesc>
-</category>
-<category xml:id="tlaQVJJXVRHRZGOPD2H7HT4ZV7CKI">
-<catDesc>Wadi Qitna</catDesc>
-</category>
-<category xml:id="tlaRJDKDN7RUZC6DLMB5SEJ2VYODI">
-<catDesc>Debod</catDesc>
-</category>
-<category xml:id="tlaSEY4ZK3JNZG3XCRD7K5QDPXFVQ">
-<catDesc>Kalabscha</catDesc>
-</category>
-</category>
-<category xml:id="tlaGA4NCPVRMNFSVD7SSTWUXNWZLI">
-<catDesc>östliches Ufer</catDesc>
-<category xml:id="tlaBEEOZJ5YFVGIVAAL7PCBPWQC6E">
-<catDesc>Ajuala</catDesc>
-</category>
-<category xml:id="tlaX26AQYRTVJFINMA4INCEMGABAA">
-<catDesc>Khor Dehmit</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaS6VBVY25EZFVJMDQKQGVT2QE5I">
-<catDesc>zwischen Abu Simbel und dem 2. Katarakt</catDesc>
-<category xml:id="tla3HMAPZL64NFLFDBQECAJX6EOCI">
-<catDesc>Gebel esch-Schams</catDesc>
-</category>
-<category xml:id="tlaBYHX25PZNNAARPSR3E4U4TLQRQ">
-<catDesc>Akscha</catDesc>
-</category>
-<category xml:id="tlaFV5HKLWMB5HY3C5ZULRPG6OBBE">
-<catDesc>Abu Oda</catDesc>
-</category>
-<category xml:id="tlaFZVUWJ5LLNHILBPOFVO3HUKIKY">
-<catDesc>Gebel Adde</catDesc>
-</category>
-<category xml:id="tlaHCGUPUIH45FXJFFRVOX4T45C4Y">
-<catDesc>Wadi Halfa</catDesc>
-</category>
-<category xml:id="tlaMTEJA5EFERBGRL22QWBG4YVXRU">
-<catDesc>Serre</catDesc>
-</category>
-<category xml:id="tlaQRIO5KUTZFERZLVV4WBGZTDIUU">
-<catDesc>Faras</catDesc>
-</category>
-<category xml:id="tlaS6GDQ67UIBGSTOSQKBQ56SB2VY">
-<catDesc>Buhen</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaE2B3E3J45ZC6DCPA5RZIGZZ7EY">
-<catDesc>Wüste östlich des Niltals und Küste des Roten Meeres (Staatsgebiet Ägypten und Sudan)</catDesc>
-<category xml:id="tla3FRDJZKIZNE3NNWU33D3CKXNF4">
-<catDesc>südliche Routen</catDesc>
-<category xml:id="tla3YZGESWDVZFPZLITU7KTF57TCM">
-<catDesc>Wadi Allaqi</catDesc>
-</category>
-<category xml:id="tlaDABYGSE4XBANPHUQLPAO7MEP2A">
-<catDesc>Wadi el-Hudi</catDesc>
-</category>
-</category>
-<category xml:id="tlaGFDPKSIYJVFMZD3DCA27FR4C24">
-<catDesc>Routen zum Roten Meer</catDesc>
-<category xml:id="tla3M3C6TGTKRA7NPZDPEUU72433I">
-<catDesc>Kanais</catDesc>
-</category>
-<category xml:id="tla3VL2L2L3KNGHBLYARDFPH6TPBU">
-<catDesc>Barramije</catDesc>
-</category>
-<category xml:id="tla54JWTN54WNBVNMPOSYF5JQJ3ZA">
-<catDesc>Wadi Gasus</catDesc>
-</category>
-<category xml:id="tla5PKEXGN6XNAGNPFXJ2JIYF726U">
-<catDesc>Berenike</catDesc>
-</category>
-<category xml:id="tlaFN72ZPMF2ZCV5GYEF7QJGAZXFY">
-<catDesc>Wadi Hamâma</catDesc>
-</category>
-<category xml:id="tlaHL6GBGX26BC2XCKMBEEFOKRC7Y">
-<catDesc>Wadi Hammamat</catDesc>
-<category xml:id="tlaIW4DXVW3KJEWFLKPHNWZSF4LSM">
-<catDesc>Qasr el-Banat</catDesc>
-</category>
-</category>
-<category xml:id="tlaKJNTDBQKQZAHNMOJUM4VDHFQCA">
-<catDesc>Wadi Abbad</catDesc>
-</category>
-<category xml:id="tlaKKSCREF2MZDLBFN3CJ6L44X3GY">
-<catDesc>Wadi Atalla</catDesc>
-</category>
-<category xml:id="tlaLP3GXRJ72VH2DARNNKWEGSXIRE">
-<catDesc>Wadi Gawasis</catDesc>
-</category>
-<category xml:id="tlaPPFR6SGBD5F3VMDHLIGU7TUARA">
-<catDesc>Wadi el-Gidâmi</catDesc>
-</category>
-<category xml:id="tlaZBF5ZADTUFFGNIBNGWQIVJVMLI">
-<catDesc>Wadi el-Fawachir</catDesc>
-</category>
-</category>
-<category xml:id="tlaYM7ABEEBHRCGZHXP7LGWFOEZMI">
-<catDesc>Sinai</catDesc>
-<category xml:id="tla4IUVOG75VNEYVJ4ZGXOSX2FT7Y">
-<catDesc>Serabit el-Chadim</catDesc>
-</category>
-<category xml:id="tla5PPRSZOGFJCMVMORMDRPS5X2QU">
-<catDesc>Wadi Nasb</catDesc>
-</category>
-<category xml:id="tlaQMBTD2UIXVHK5BKVR75VWYANNA">
-<catDesc>Rod el-Air</catDesc>
-</category>
-<category xml:id="tlaXPGRVXOALZF2FB4XVSF5USDARY">
-<catDesc>Wadi Maghara</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaHKPRMC5M5JHDHACZICND5E3NJE">
-<catDesc>Niltal südlich von Assiut bis zum 1. Katarakt</catDesc>
-<category xml:id="tla2LKORXWT6ZEVVOVZTU5WQBEKQM">
-<catDesc>zwischen Assuan und Philae</catDesc>
-<category xml:id="tla2UL2L2L5GFDBZOM42VB3F62KRY">
-<catDesc>Konosso</catDesc>
-</category>
-<category xml:id="tlaG5VRXHOVCNHXTKNM4QRNPOZFTM">
-<catDesc>Bigga</catDesc>
-</category>
-<category xml:id="tlaIIMLKYBGMRE3DGJLRUPXWORJFI">
-<catDesc>Sehel</catDesc>
-</category>
-<category xml:id="tlaPA2BRW3KTVDZNIGTZ37XKTC2YM">
-<catDesc>Philae</catDesc>
-</category>
-</category>
-<category xml:id="tla3CYKLCG42FAB3JYXJFOYMTR34E">
-<catDesc>Abydos</catDesc>
-<category xml:id="tlaUGEDNM7L25CZ5EOPKOT4HIZAFY">
-<catDesc>Abydos</catDesc>
-</category>
-</category>
-<category xml:id="tlaASKBCQLYJ5DDRCVIMWXF5ZQJZQ">
-<catDesc>Elkab und Hierakonpolis (Kom el-Ahmar)</catDesc>
-<category xml:id="tlaNWV3DQDYZ5BKFKUR6MRV76Y5XY">
-<catDesc>Hierakonpolis</catDesc>
-</category>
-<category xml:id="tlaZJ2DOAUGEBAHRDZRFNPFAWDT4A">
-<catDesc>Elkab</catDesc>
-</category>
-</category>
-<category xml:id="tlaFJ5TFXCLKNEG5MX2WSVIHC2G2U">
-<catDesc>zwischen Abydos und Theben</catDesc>
-<category xml:id="tla6UFABA3HPFFVNKLYUBUZJ5CKYI">
-<catDesc>östliches Ufer</catDesc>
-<category xml:id="tla5THBM2KC6NDHDMTLDLFPL3AQKE">
-<catDesc>Qene</catDesc>
-</category>
-<category xml:id="tlaHYET77EWLFB4FIVBIWMT5TY5ZM">
-<catDesc>el-Qala</catDesc>
-</category>
-<category xml:id="tlaK5LEZLASHBGSJP2LNAJBY4AQZQ">
-<catDesc>Schanhur</catDesc>
-</category>
-<category xml:id="tlaNDJX4X5REZDNFOMORWMO6PYZII">
-<catDesc>Medamud</catDesc>
-</category>
-<category xml:id="tlaPGBUJXILWBDLJMW777DP4VRIJU">
-<catDesc>Qus</catDesc>
-</category>
-<category xml:id="tlaXRLOXFASKNHRBA7RJ35ADQQQFY">
-<catDesc>Koptos</catDesc>
-</category>
-<category xml:id="tlaZ3DOC2J76RETBJ7G2PIJGQE2BQ">
-<catDesc>Chenoboskion</catDesc>
-</category>
-</category>
-<category xml:id="tlaM6RQB65O3JAGLAANCXH4PD2SQE">
-<catDesc>westliches Ufer</catDesc>
-<category xml:id="tla2AVZ43KNO5GVLHV6H33NG7M6CY">
-<catDesc>Abadijeh</catDesc>
-</category>
-<category xml:id="tla2UK57LIC4RDHPHBULX3YILG6KM">
-<catDesc>Ombos</catDesc>
-</category>
-<category xml:id="tla57QDPRBGGFERPJHONVR7NPAXDQ">
-<catDesc>Hu</catDesc>
-</category>
-<category xml:id="tla5GHAEE4RAFEZNOBSJCHKMB3VW4">
-<catDesc>Deir el-Ballas</catDesc>
-</category>
-<category xml:id="tla5XJ3I4MXXRC23EWQPNDWBHPDEA">
-<catDesc>Naqada</catDesc>
-</category>
-<category xml:id="tlaKVMVMBDEWBDCFBNY4E3BRCLNPQ">
-<catDesc>el-Amrah</catDesc>
-</category>
-<category xml:id="tlaN2QWVQP2NZFL7L5N4QRVMQ6EUI">
-<catDesc>Qamula</catDesc>
-</category>
-<category xml:id="tlaN4GNGV4FJZESZM67GMMZUGT2C4">
-<catDesc>Dendara</catDesc>
-</category>
-<category xml:id="tlaQUQOGN2W4VEWDEGD3MNLCE3CRY">
-<catDesc>Gebel el-Araq</catDesc>
-</category>
-<category xml:id="tlaR5NDZ43RBRESPCTXYIKOGEFMY4">
-<catDesc>Nag&#039; Hammadi</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaN2RDQCOO6VDBJHW6EVBGKKV7VM">
-<catDesc>zwischen Assiut und Abydos</catDesc>
-<category xml:id="tlaN7PVNHK625DQDDAZSQJ6ETU36M">
-<catDesc>östliches Ufer</catDesc>
-<category xml:id="tla4LGAJNYWKVFRZHKOD4LZXXROA4">
-<catDesc>Gebel Scheich el-Haridi</catDesc>
-</category>
-<category xml:id="tla4T7AO4FU7BBR5BOZ4FVQIIYOG4">
-<catDesc>el-Salamuni</catDesc>
-</category>
-<category xml:id="tla6Z46BHW7WZGDFGU46OS4HDCHWU">
-<catDesc>Balabisch</catDesc>
-</category>
-<category xml:id="tla7JIPPT7HWNBSLLKJTP32DOVQVI">
-<catDesc>Qau el-Kebir</catDesc>
-</category>
-<category xml:id="tla7LPJ2TECP5BEHAHDNNVNKRJXR4">
-<catDesc>el-Badari</catDesc>
-</category>
-<category xml:id="tlaC2Z63NXQFBBFNLB3RZEJJQTBVQ">
-<catDesc>Achmim</catDesc>
-</category>
-<category xml:id="tlaEX5WE4HJLNBG5FQSYNHVAES3SQ">
-<catDesc>Megeb</catDesc>
-</category>
-<category xml:id="tlaIEPAOJWPNFH6LLPKM235N3ZSGA">
-<catDesc>el-Hemamija</catDesc>
-</category>
-<category xml:id="tlaLYC5TPBHKZD6HFL4WYAKJDBKD4">
-<catDesc>Naga (Nag&#039;) ed-Der</catDesc>
-</category>
-<category xml:id="tlaMUUL3RFV25A2VJVQCZLZTS4W3Y">
-<catDesc>Nag&#039; Wisa</catDesc>
-</category>
-<category xml:id="tlaNGDAPYWJXVHWZOGMB4UUCAPDHE">
-<catDesc>el-Chawalid</catDesc>
-</category>
-<category xml:id="tlaOBLEFFISIVDODOY6V5WBES5ADM">
-<catDesc>Mescheich</catDesc>
-</category>
-<category xml:id="tlaOJ377AW4ZRGPFBRWDKAUB5IHMA">
-<catDesc>Tasa</catDesc>
-</category>
-<category xml:id="tlaUCJZQ2QW3FGXVBKCJX4K6JYOUI">
-<catDesc>el-Matmar</catDesc>
-</category>
-</category>
-<category xml:id="tlaWXXNUSAWOVFUTK3T64L4F4DAZ4">
-<catDesc>westliches Ufer</catDesc>
-<category xml:id="tla4OYVP4O3GJH4BJPVB2WRCFTOKM">
-<catDesc>er-Raqaqna</catDesc>
-</category>
-<category xml:id="tlaAO5OW7XDXJHLBJVS4MIGBLFN3U">
-<catDesc>Sohag</catDesc>
-</category>
-<category xml:id="tlaAVGS35DRF5EZFG4XTODL5BX7MM">
-<catDesc>Thinis</catDesc>
-</category>
-<category xml:id="tlaBGCL2CHJEJDPZHT5Q6WHF2T6HE">
-<catDesc>el-Hagarsa</catDesc>
-</category>
-<category xml:id="tlaFVSSH5HS5RBLXLR6CFOPVC7JPQ">
-<catDesc>Kom Isfaht</catDesc>
-</category>
-<category xml:id="tlaQKICI6IT7ZCJDJFUICKUYO2XTQ">
-<catDesc>Mahasna</catDesc>
-</category>
-<category xml:id="tlaSS4B5IAYWRBRZBB6Q5CHG5LNUA">
-<catDesc>Deir Rifeh</catDesc>
-</category>
-<category xml:id="tlaU3ZQSALHEREJJCI6UZK3YH5S3Q">
-<catDesc>Kom Ischqau</catDesc>
-</category>
-<category xml:id="tlaWYZFBMTMAZA2FI3AVYEWUPVXHQ">
-<catDesc>Tahta</catDesc>
-</category>
-<category xml:id="tlaYZOQ5HECXNBYLDAZPRUIIRDA5E">
-<catDesc>el-Menschiyeh (Ptolemais Hermiu)</catDesc>
-</category>
-<category xml:id="tlaZR4U6SEVWZCSRDOC7LPPLE6RDI">
-<catDesc>Beit Challaf</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaNE2TEF2YWJBWBARUXJGUAOFZXU">
-<catDesc>zwischen Theben und Elkab</catDesc>
-<category xml:id="tlaE6EBGAEOMRGB7DP4LX4XFXKTAA">
-<catDesc>östliches Ufer</catDesc>
-<category xml:id="tlaAZ7FJSBH5BHKHGDLCDWUS2EZM4">
-<catDesc>Nag&#039; el-Hammam (2 km NO von Elkab)</catDesc>
-</category>
-<category xml:id="tlaCMW4EPSVDJDQ7DD3FZ3LBOGXYA">
-<catDesc>Sarnik</catDesc>
-</category>
-<category xml:id="tlaDCSZZSLENZHY5EPFGHWYJPCZ4M">
-<catDesc>et-Tod</catDesc>
-</category>
-<category xml:id="tlaHKXOI5E7ZNF7TDLGBASBO4A46A">
-<catDesc>Mo&#039;alla</catDesc>
-</category>
-<category xml:id="tlaHNHTKVPNO5AA5BBZD356F4S4BY">
-<catDesc>Mata&#039;na</catDesc>
-</category>
-<category xml:id="tlaPXUMQCIEP5BPROZWAMTMCROGO4">
-<catDesc>Kontralatopolis</catDesc>
-</category>
-<category xml:id="tlaUN7N7J7ZDNEJ5DWDJRAUVUX7CE">
-<catDesc>Komir</catDesc>
-<category xml:id="tlaTAFEK7BMIFHMFMWSRN6JOZZFOM">
-<catDesc>Saft el-Henna</catDesc>
-</category>
-</category>
-<category xml:id="tlaVLP4OWR7TJGAZLE3OJ5GHCVQTE">
-<catDesc>el-Dibbabija</catDesc>
-</category>
-</category>
-<category xml:id="tlaEADC3TZLQRHQZDQZF3H6PD3CKE">
-<catDesc>westliches Ufer</catDesc>
-<category xml:id="tlaM4SOHCRELFHLNC27MWIGAD4VM4">
-<catDesc>Esna</catDesc>
-</category>
-<category xml:id="tlaMJFTXFNGEFBFPMQOVTCKIYMMVY">
-<catDesc>Armant</catDesc>
-</category>
-<category xml:id="tlaTJ3VC6VP2BBEDPTLQ32NGPMVV4">
-<catDesc>el-Kula</catDesc>
-</category>
-<category xml:id="tlaX4GCHEJEAFEYLCD5OMN3FWPS6M">
-<catDesc>Asfun el-Mata&#039;na</catDesc>
-</category>
-<category xml:id="tlaZZVLCRSQFRFP3KLNZNCPSA6CDQ">
-<catDesc>Gebelein</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaRGS2OLARZRFTHEFGRYNKB6YJ5E">
-<catDesc>Theben</catDesc>
-<category xml:id="tlaCLFZC44SZ5C6FJHKC3YBOLHHXI">
-<catDesc>östliches Ufer</catDesc>
-<category xml:id="tlaLBISHPC2BNBWDLMXCBZJEM76TE">
-<catDesc>Luxor</catDesc>
-</category>
-<category xml:id="tlaQSVTRJ2TVBFTNKSOZMWO7Q76J4">
-<catDesc>Theben</catDesc>
-<category xml:id="tlaGYNQQNK4NFFJDPCKFM2C5MXBRA">
-<catDesc>Tal der Könige</catDesc>
-</category>
-</category>
-<category xml:id="tlaSGFCZP5Y35GEBCOGT7RCMOXSNM">
-<catDesc>Karnak</catDesc>
-<category xml:id="tlaCQ2JRDM3PNA6TCRWMH57XBAPBU">
-<catDesc>Chonstempel, südöstlich des Karnaktempels</catDesc>
-</category>
-<category xml:id="tlaYAZ72BD3IZGOLLOCE4DPEPFT7M">
-<catDesc>Mut-Tempel</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaVHGZGISIMJG6NBSUYALIZI4TIQ">
-<catDesc>westliches Ufer</catDesc>
-<category xml:id="tla2AH3DNLH7FHXTNWZFNFEGD5ELQ">
-<catDesc>Ilwet el-Scheich Abd-el-Gurna</catDesc>
-</category>
-<category xml:id="tla36AKKTU5DBFZHPGZYBGBBIIB5Y">
-<catDesc>Gurnet Murrai</catDesc>
-</category>
-<category xml:id="tla4SHO2GKY4NEV5EYKIDN4GOHDQA">
-<catDesc>Tal der Könige (Biban el-Muluk)</catDesc>
-</category>
-<category xml:id="tla5EG2AE4HAFCBVLR3OIDWCU73HU">
-<catDesc>Djeme</catDesc>
-</category>
-<category xml:id="tlaCLERK45WSZGFJLFSFFMKFGSCF4">
-<catDesc>Malqata</catDesc>
-</category>
-<category xml:id="tlaD2JRDZPOPJFIRMIKW2HDCNLOYM">
-<catDesc>Deir el-Bachit</catDesc>
-</category>
-<category xml:id="tlaEDSWLVWAWJCZNEFLRENF4R2OCA">
-<catDesc>Deir esch-Schelwit</catDesc>
-</category>
-<category xml:id="tlaFYDEOYNWHJEBDHP62FVCZ5PQHY">
-<catDesc>Dra abu el-Naga</catDesc>
-</category>
-<category xml:id="tlaGYV7XU55WVAJZOQZGAWDIPKGZY">
-<catDesc>Khokha</catDesc>
-</category>
-<category xml:id="tlaINTSIBUJ75GFDHWIHTNKFN26IE">
-<catDesc>Asasif</catDesc>
-</category>
-<category xml:id="tlaJHMKUZN4YRGCXJEHXKRYGL5MLA">
-<catDesc>Deir el-Medineh</catDesc>
-</category>
-<category xml:id="tlaLDGG7LEGBRBCBAY37VOZ34UYWQ">
-<catDesc>Qasr el-Aguz</catDesc>
-</category>
-<category xml:id="tlaOXIU5QGX5VAABKEZT5RNVBIEBM">
-<catDesc>Deir el-Bahari</catDesc>
-<category xml:id="tla6D3V7C7DW5AZ3EIZGRNNOIQBAM">
-<catDesc>Hatschepsut-Tempel</catDesc>
-</category>
-<category xml:id="tlaLDP5XOVUXZDOLNBL7MDQELKP74">
-<catDesc>Mentuhotep-Tempel</catDesc>
-</category>
-<category xml:id="tlaQDJW2FJY5JA2DCA5SB6CYBNLCY">
-<catDesc>Birabi</catDesc>
-</category>
-<category xml:id="tlaVI2BCCQPTRB4BNYYZEGQQYCIN4">
-<catDesc>Tempel Thutmosis&#039; III.</catDesc>
-</category>
-</category>
-<category xml:id="tlaTBL6LVAUP5EBBCCHBKYW6JGJTE">
-<catDesc>Medinet Habu</catDesc>
-</category>
-<category xml:id="tlaTICHJFEOLVCP3JDWTSQD2FFBSE">
-<catDesc>Qurna</catDesc>
-</category>
-<category xml:id="tlaXNR5C5APPZASBI3EKZT6EQ5REY">
-<catDesc>Scheich Abd-el-Gurna</catDesc>
-<category xml:id="tla7VY7ICOAOJFBZEHMRFVSEZUTFU">
-<catDesc>Gurnet Murrai</catDesc>
-</category>
-<category xml:id="tlaGJYDLFCCSVFRZJ6UXBILKB5DYE">
-<catDesc>Khokha</catDesc>
-</category>
-<category xml:id="tlaNRNSZO2JSZCGFAOBTZ5GBFJNGU">
-<catDesc>Asasif</catDesc>
-</category>
-<category xml:id="tlaPW2ABM2P7FC47KPZPBCUYQJILQ">
-<catDesc>Ilwet el-Scheich Abd-el-Gurna</catDesc>
-</category>
-</category>
-<category xml:id="tlaYF6WKS2KHNBMVF4XX3PLFKIBZU">
-<catDesc>Ramesseum</catDesc>
-</category>
-<category xml:id="tlaZNHKKJOPIRFNHCHBC2FZE3EGM4">
-<catDesc>Tal der Königinnen (Biban el-Harim)</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaTZ7SXDLZKFCAJDCIMCBHLZSQHI">
-<catDesc>Assuan</catDesc>
-<category xml:id="tlaFYST3LL3LZBX3K27RVU3HFWFDM">
-<catDesc>Elephantine</catDesc>
-</category>
-<category xml:id="tlaHQ6TAYOMBZEWVFTZV33MWLVE4I">
-<catDesc>Assuan</catDesc>
-</category>
-</category>
-<category xml:id="tlaYR4D246MOZGR3H5THHUQ2ULS4Q">
-<catDesc>zwischen Elkab und Assuan</catDesc>
-<category xml:id="tlaUB536QMTFNHDXJ6PDL22M6KSNE">
-<catDesc>östliches Ufer</catDesc>
-<category xml:id="tla4O7Y64CXSRBKVO43ENCXOKOIOA">
-<catDesc>Nag&#039; el-Kagug</catDesc>
-</category>
-<category xml:id="tla6ZMA7B4GDNF23F5BETZDVAM6AI">
-<catDesc>Kom Ombo</catDesc>
-</category>
-<category xml:id="tlaDBSOTKB6BNFSZLEA45IS7TNA4E">
-<catDesc>Gebel el-Hammam</catDesc>
-</category>
-<category xml:id="tlaUVWHR354GJC7FBW2DY2GMWVP7Q">
-<catDesc>Bueb</catDesc>
-</category>
-</category>
-<category xml:id="tlaW5XH4PUGO5FQTBVIWYSPDJZ3WY">
-<catDesc>westliches Ufer</catDesc>
-<category xml:id="tlaF5ZUDOTN3VGTHJDCWGXRLSBMHQ">
-<catDesc>el-Qubanije</catDesc>
-</category>
-<category xml:id="tlaFND3IEZXXJFA7GYJMCSFR6OZEI">
-<catDesc>Esbet er-Reseiris</catDesc>
-</category>
-<category xml:id="tlaIBLZAC23NFFBXDTB2MXOFFDZBI">
-<catDesc>Nag&#039; el-Hammam (ca. 3 km nördlich von Gebel es-Silsile)</catDesc>
-</category>
-<category xml:id="tlaIC3Y3AOARBGDHPUIZHNNILGF7U">
-<catDesc>Gebel es-Silsile</catDesc>
-</category>
-<category xml:id="tlaMHKQZNF5IRAMHETGHU32FI67NE">
-<catDesc>Wadi Schatt er-Rigale</catDesc>
-</category>
-<category xml:id="tlaONO4KXU4RNH3HCECVJO5JTV2MY">
-<catDesc>Qubbet el Hawa</catDesc>
-</category>
-<category xml:id="tlaRBYSK262OZCSNB2PX3ZMUXXSAY">
-<catDesc>Nag&#039; el-Hisaja</catDesc>
-</category>
-<category xml:id="tlaSFEBWV2ASBBXZEO23U3QPV27GU">
-<catDesc>Tell Edfu</catDesc>
-</category>
-</category>
-</category>
-</category>
-<category xml:id="tlaKKNV5MDOBFFCRBQDXDLN4FUVOQ">
-<catDesc>Niltal von Kairo bis Assiut</catDesc>
-<category xml:id="tla5EFAK4CGMVDZPIDIST4QUAMDCA">
-<catDesc>Fajjum</catDesc>
-<category xml:id="tla4UOMQ5KBONF6VGYD5CJXVIFH64">
-<catDesc>Tebtynis</catDesc>
-</category>
-<category xml:id="tla7E6I7CAI3NBH3DME5D3SZUUSN4">
-<catDesc>Bakchias</catDesc>
-</category>
-<category xml:id="tla7VCUGQCIVVBOHFDW57YHBJBLNU">
-<catDesc>Medinet el-Fajjum</catDesc>
-</category>
-<category xml:id="tlaDADYX4WVYJHXXJ3IERRW4SMXXU">
-<catDesc>Dimeh</catDesc>
-</category>
-<category xml:id="tlaETNCVGLC6ZB5TK4XPKLCLUT6SE">
-<catDesc>Theadelphia</catDesc>
-</category>
-<category xml:id="tlaJ5FCHXYBRBCBZNFDBFWEI4CEN4">
-<catDesc>Seila</catDesc>
-</category>
-<category xml:id="tlaQRQWG2UN25DYJFOFKIXX3OO2ZU">
-<catDesc>Medinet Quta</catDesc>
-</category>
-<category xml:id="tlaR735ML6THRFIFE5BQLKRMB5QZU">
-<catDesc>Hawara</catDesc>
-</category>
-<category xml:id="tlaU5T6QBQIQBBDTBOEZX5DJ3H54Y">
-<catDesc>Karanis</catDesc>
-</category>
-<category xml:id="tlaV23GS5PBZRDJVHVDTA5Z6FFKPA">
-<catDesc>Qasr el-Banat (im SW des Moerissees)</catDesc>
-</category>
-<category xml:id="tlaXLA5GLIZZJGJXPZMKPH6W4OPAM">
-<catDesc>Magdola</catDesc>
-</category>
-<category xml:id="tlaXS3ZPIWINVCNFASQHDT3PFNVGQ">
-<catDesc>Medinet Madi</catDesc>
-</category>
-<category xml:id="tlaZQTYT2OUNBGO7F4WJ2K3T3NZ4Y">
-<catDesc>Biahmu</catDesc>
-</category>
-</category>
-<category xml:id="tlaAHTCKEAK3ZDYFBAVDDBPC5HAHI">
-<catDesc>zwischen Tell el-Amarna und Assiut</catDesc>
-<category xml:id="tlaQY23YBPECVCLFBZGS2CSVREDDU">
-<catDesc>östliches Ufer</catDesc>
-<category xml:id="tlaFJMAFBHVPNFWNE6RCA23I5XWQ4">
-<catDesc>Deir el-Gebrawi</catDesc>
-</category>
-<category xml:id="tlaI5SMOHSU35F5LGC36MLVSY25P4">
-<catDesc>el-Ataula</catDesc>
-</category>
-<category xml:id="tlaNWMFEJJZDNAPXFKDDIWBOIM35Q">
-<catDesc>Quseir el-Amarna</catDesc>
-</category>
-<category xml:id="tlaOJCZRXYVDJD2TF3C3KRPYZP6II">
-<catDesc>Gebel Abu-Foda</catDesc>
-</category>
-</category>
-<category xml:id="tlaU6XX66EL3JFIPP24E3Z5L7XBKM">
-<catDesc>westliches Ufer</catDesc>
-<category xml:id="tlaEZQGV6DAUVEU7PSIUP2B3LPHUM">
-<catDesc>Dara</catDesc>
-</category>
-<category xml:id="tlaHT5AFZMHQ5FSZH7FSWNRRVB7NY">
-<catDesc>Manqabad</catDesc>
-</category>
-<category xml:id="tlaNHQPDAFP25BL3MPRLPXU2TCSKQ">
-<catDesc>Qusae</catDesc>
-</category>
-<category xml:id="tlaQTOOQ4NKC5DRHENFEFV66RZUBY">
-<catDesc>Meir</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaAJDSKE22X5DO7FNKB5TZY3KXVY">
-<catDesc>Beni Hassan und Speos Artemidos</catDesc>
-<category xml:id="tlaRQUYIDMHKVHCPHBBYB6326VWHU">
-<catDesc>Speos Artemidos</catDesc>
-</category>
-<category xml:id="tlaWPH2JS6LO5AWDK75YPUXIXKA2Q">
-<catDesc>Beni Hassan</catDesc>
-</category>
-</category>
-<category xml:id="tlaKBEB43OQ3ZF5JE7N5WRIQRFGYY">
-<catDesc>zwischen Assiut und Deir Dronka</catDesc>
-<category xml:id="tla6MAM7ELCSJHCNDCEDDS3OI253I">
-<catDesc>Medjedni</catDesc>
-</category>
-<category xml:id="tlaGA7YUW532BCUNC2I5RIXZY6NFQ">
-<catDesc>Deir Dronka</catDesc>
-</category>
-<category xml:id="tlaM7A7SPCUZFHW5CKA7IVEAQKAHA">
-<catDesc>Assiut</catDesc>
-</category>
-</category>
-<category xml:id="tlaOMQT7YQ5JRCMPH232CO2P26VKQ">
-<catDesc>zwischen Beni Hassan und Tell el-Amarna</catDesc>
-<category xml:id="tlaJORE4GYJK5F7DFOZJ2CQ3VGP2Y">
-<catDesc>westliches Ufer</catDesc>
-<category xml:id="tla2NBYC433Q5ANTDAFFZCNFH2ZPQ">
-<catDesc>Tuna el-Gebel</catDesc>
-</category>
-<category xml:id="tlaN7YO57C7QBEM5OHX5MNIZMAJSQ">
-<catDesc>Roda</catDesc>
-</category>
-<category xml:id="tlaOGW32RJD2RDVBJ3VAYTLQGN4T4">
-<catDesc>Mallawi</catDesc>
-</category>
-<category xml:id="tlaSTJPU2W2XRARXPLSVM4L4OSMC4">
-<catDesc>Hermupolis magna</catDesc>
-</category>
-</category>
-<category xml:id="tlaZRGESISAP5CQNKWHOJRI4H4XQA">
-<catDesc>östliches Ufer</catDesc>
-<category xml:id="tla4AYMD3DAKBG6DGK7LTQLW4CTLU">
-<catDesc>el-Maabde</catDesc>
-</category>
-<category xml:id="tlaGY5XTNHWU5CZVDPY7N4RD4OMVI">
-<catDesc>Antinooupolis</catDesc>
-</category>
-<category xml:id="tlaI4NHLIY73ZHFBIZWRW2AJ5F3ZM">
-<catDesc>el-Berscheh</catDesc>
-</category>
-<category xml:id="tlaVO43WZHRPZBLPDJ54VVWYHW3OY">
-<catDesc>Menat-Chufu</catDesc>
-</category>
-<category xml:id="tlaZLDIJHRPZJAN5GZ7NNZS77MRJU">
-<catDesc>Scheich Said</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaP6EP5SODRNDS7B5NWHUYMO2MXI">
-<catDesc>zwischen Fajjum und Beni Hassan</catDesc>
-<category xml:id="tlaMP4B4NCPUJAHLMZTDLRIBDBZCQ">
-<catDesc>östliches Ufer</catDesc>
-<category xml:id="tla6NUVJOZF3FFVJAIHWZAKGCHS2M">
-<catDesc>Scheich Mubarrak</catDesc>
-</category>
-<category xml:id="tlaAW6DFAYEUZFKRBHZYVKBFQ2BRA">
-<catDesc>Scheich el-Fadl</catDesc>
-</category>
-<category xml:id="tlaC6P66U3HP5F5TKUGO3V7VFRREE">
-<catDesc>Saujet el-Meitin</catDesc>
-</category>
-<category xml:id="tlaDCJ4PJ2LB5C37HF3HSBTILH6LM">
-<catDesc>el-Hibe</catDesc>
-</category>
-<category xml:id="tlaOPURGU2JLNCJ7EXKNOCLPTTGG4">
-<catDesc>es-Siririya</catDesc>
-</category>
-<category xml:id="tlaPSKJ6UPKQNAJXO7ZH77XF5P2CY">
-<catDesc>Tehne (Akoris)</catDesc>
-</category>
-<category xml:id="tlaSA7IYRTLGJDNPMZ5MNJFWSYHBU">
-<catDesc>Scharuna</catDesc>
-</category>
-<category xml:id="tlaTRNCUPI5L5GK7PBZ62WQC4PE7E">
-<catDesc>Hebenu</catDesc>
-</category>
-</category>
-<category xml:id="tlaXIQBE6XISRGJTLNHKVE62Y23G4">
-<catDesc>westliches Ufer</catDesc>
-<category xml:id="tla3S2ZY76R7BF7NJCOFQZIGYGL24">
-<catDesc>Abusir el-Meleq</catDesc>
-</category>
-<category xml:id="tla5K5MFHJIAJDX3HZ5BSH2IICN2U">
-<catDesc>el-Lahun (Illahun)</catDesc>
-<category xml:id="tla6YDVZ6RHSBAIJEN5YNOJZPTECE">
-<catDesc>Nekropole</catDesc>
-</category>
-<category xml:id="tlaXAAEKHSKSJDQJAYLGFIGGZWUSM">
-<catDesc>Siedlung</catDesc>
-</category>
-</category>
-<category xml:id="tlaAOF7W5GQXBDARKIID5DM2SPM2Q">
-<catDesc>Oxyrhynchos</catDesc>
-</category>
-<category xml:id="tlaBPUQJWLRIVCHJJ2NMCTASQQKSM">
-<catDesc>Harageh</catDesc>
-</category>
-<category xml:id="tlaDFSNUEXE6JA3XIJ4NZGURE3RZQ">
-<catDesc>Maiyana</catDesc>
-</category>
-<category xml:id="tlaGDJZ5TUTS5FGDI3XKLKEOWBKLQ">
-<catDesc>el-Minieh</catDesc>
-</category>
-<category xml:id="tlaKFA4OETSINAEZMWPIFZELLQBNA">
-<catDesc>Herakleopolis magna</catDesc>
-</category>
-<category xml:id="tlaSNYAXVBAMRFHVA6MDEWJJQ4XVE">
-<catDesc>Balansura</catDesc>
-</category>
-<category xml:id="tlaVMLZOM2MXZCYPNFHGX5I5S3VP4">
-<catDesc>Deschasche</catDesc>
-</category>
-<category xml:id="tlaZRXRXA7K5BACTHHDLTSLG2GTBA">
-<catDesc>Sedment</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaUK2KUTLMDJAKZPS7DCG2NU4ISM">
-<catDesc>zwischen Kairo und Fajjum</catDesc>
-<category xml:id="tla32B64TXG6NHEZNLL7NNPOBDSTU">
-<catDesc>östliches Ufer</catDesc>
-<category xml:id="tlaC2WYK4H6QVGURE6KW6ANFXU5KU">
-<catDesc>Wadi Garawi</catDesc>
-</category>
-<category xml:id="tlaGWZSUYUOXZAVLPVB2FRT5AJJKE">
-<catDesc>Kairo</catDesc>
-</category>
-<category xml:id="tlaHJMQUWO3ZRHPVNPR3IJPFAVN7M">
-<catDesc>Atfih</catDesc>
-</category>
-<category xml:id="tlaHXK3G4OJ4JFIPOXMPZE5LL5WCI">
-<catDesc>Heluan</catDesc>
-</category>
-<category xml:id="tlaMGEPQWTLB5EHXHSUEZF4WMLPHA">
-<catDesc>Tura</catDesc>
-</category>
-<category xml:id="tlaNQTB3CIFTZCJRCWJRLGNHAC3OU">
-<catDesc>Maadi</catDesc>
-</category>
-<category xml:id="tlaUTOE5VBTO5FKZMZX65IMFZF4PI">
-<catDesc>Lischt</catDesc>
-</category>
-</category>
-<category xml:id="tlaPCZACZVC7JCHXNPXO2XJT4WWS4">
-<catDesc>westliches Ufer</catDesc>
-<category xml:id="tla22XDL7RDBFGW7CEJYPNQG3HYEU">
-<catDesc>Meidum</catDesc>
-</category>
-<category xml:id="tlaCFVNIMLRNZAKXJAN7SHA5XSZYM">
-<catDesc>Gebel er-Rus</catDesc>
-</category>
-<category xml:id="tlaEEWOTHSWCJB3HMJ4LQPYJT4IRQ">
-<catDesc>el-Gerzeh</catDesc>
-</category>
-<category xml:id="tlaEYL2L7M2SZCFXENP23R2P6HISI">
-<catDesc>Memphis</catDesc>
-</category>
-<category xml:id="tlaFHCXX5V3NNDE3L3BPCI6H4TLWY">
-<catDesc>Saujet el-Arjan</catDesc>
-</category>
-<category xml:id="tlaG3UOUVQETVA6DIBKA52PPC5V5Y">
-<catDesc>Tarchan</catDesc>
-</category>
-<category xml:id="tlaGGE4E7XI6NBFDK7KZQ53JDGAJE">
-<catDesc>Saujet Abu Mesallem</catDesc>
-</category>
-<category xml:id="tlaIB62VUULORB6THW24GAK2A5TOY">
-<catDesc>Dahschur</catDesc>
-</category>
-<category xml:id="tlaN7QFGPYE6ND55LIMSXLZ7HUAHY">
-<catDesc>Abu Gurab</catDesc>
-</category>
-<category xml:id="tlaO5AYJCUXENDODEGUIMCH2YWXWM">
-<catDesc>Abusir</catDesc>
-</category>
-<category xml:id="tlaOBWGLZS4ZRBM5BPAYARBF4AJBQ">
-<catDesc>Kafr Ammar</catDesc>
-</category>
-<category xml:id="tlaPWJMHAWWJBBKTNH5IMZYHOLBNY">
-<catDesc>Abu Roasch</catDesc>
-</category>
-<category xml:id="tlaRRQHQZRF6JAGXM36AK5VTUZKV4">
-<catDesc>Masghuna</catDesc>
-</category>
-<category xml:id="tlaTZ7HFSUO3ZCLLAAXX3AEWXALIE">
-<catDesc>Gisa</catDesc>
-</category>
-<category xml:id="tlaYE5ZC7D6LZDTZN2IQKMCRQHW44">
-<catDesc>Saqqara</catDesc>
-<category xml:id="tlaEWXT4Q4QYBAOHELCDQ5VPXNRXQ">
-<catDesc>Nekropolen</catDesc>
-</category>
-<category xml:id="tlaXVL3OFT6FRBKHI2ID3HMPWLVDY">
-<catDesc>Serapeum</catDesc>
-</category>
-<category xml:id="tlaYSHJQHOKUZHKJEJMNXA54O7WTE">
-<catDesc>Pyramiden</catDesc>
-</category>
-</category>
-<category xml:id="tlaZMZ63WJE2NE5ZGLQ6JMREE67B4">
-<catDesc>Riqqeh</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaY2H7KF7JC5HKHD4QXSXPZEH26Y">
-<catDesc>Tell el-Amarna und Hatnub</catDesc>
-<category xml:id="tlaE2J4NAPJFBHQTGSFIKRCFC6V4E">
-<catDesc>Tell el-Amarna</catDesc>
-</category>
-<category xml:id="tlaGGN7WFYXI5DTLG43NOFG7SVJ6A">
-<catDesc>Hatnub</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaKWWFQI5HHNE2BNRUV6EAFS7J5I">
-<catDesc>Niltal südlich des 2. Katarakts bis zum 3. Katarakt</catDesc>
-<category xml:id="tla3J57LVGE65EWPEJQM6NGWERKBA">
-<catDesc>Sesibi</catDesc>
-</category>
-<category xml:id="tla4VV2ZQFQSNFUXL7GLJ2QP3BFAM">
-<catDesc>Askut</catDesc>
-</category>
-<category xml:id="tla7P7Z2OTKOJDH7B3VOHVKSJ33RQ">
-<catDesc>Semna</catDesc>
-</category>
-<category xml:id="tlaCHXFPBC7SBE2TB5O72GRHGNMZE">
-<catDesc>Mirgissa</catDesc>
-</category>
-<category xml:id="tlaKGC2HFYONVDC7IRGXOYXCMHB4M">
-<catDesc>Amara West</catDesc>
-</category>
-<category xml:id="tlaNGHY34ANYRC3TOUTJFTCNXQUYE">
-<catDesc>Sai</catDesc>
-</category>
-<category xml:id="tlaPZZM3SUQPNDDVKNF3CIBOBXRXY">
-<catDesc>Amara East</catDesc>
-</category>
-<category xml:id="tlaUCILL36KLZFH7DAMIITUCYCMWU">
-<catDesc>Sedeinga</catDesc>
-</category>
-<category xml:id="tlaVC2HMWLXQNFI7OO5C5A2DQVX2M">
-<catDesc>Kumme</catDesc>
-</category>
-<category xml:id="tlaWCMER7GMDVDGPE6SBI4A323HRI">
-<catDesc>Uronarti</catDesc>
-</category>
-<category xml:id="tlaZO7AKABNLBDAVKSPREDRGBSARE">
-<catDesc>Soleb</catDesc>
-</category>
-</category>
-<category xml:id="tlaPMP7VF6LBNG3FKPINED7YOO3LM">
-<catDesc>Wüste westlich des Niltals (Staatsgebiet Ägypten und Sudan)</catDesc>
-<category xml:id="tlaAGPAHG75QRFV5OULSV2MQG3WO4">
-<catDesc>Oase Kurkur</catDesc>
-</category>
-<category xml:id="tlaC4SPEOALFBAFBHXHFISVMPRQ4A">
-<catDesc>Oase Dachla</catDesc>
-<category xml:id="tlaLBFSRL3U65DEVGDTGRAPWRAU5Y">
-<catDesc>Balat</catDesc>
-</category>
-<category xml:id="tlaMRE4ONGFNJE6JBQ54NMN2YOPK4">
-<catDesc>Deir el-Hagar</catDesc>
-</category>
-</category>
-<category xml:id="tlaCJT44PZWENHFPIZGQ72NN3H44A">
-<catDesc>Oase Dungul</catDesc>
-</category>
-<category xml:id="tlaD3QHNMZXFVB2HF2YSAR57BDLSM">
-<catDesc>Oase Selima</catDesc>
-</category>
-<category xml:id="tlaFKBDCIH3FNHYFN4L56HWVZTFIE">
-<catDesc>Oase Charga</catDesc>
-<category xml:id="tla5ISL7EXGYJHPRPFN24WHY5P6MU">
-<catDesc>Qasr Gueida</catDesc>
-</category>
-<category xml:id="tlaA6HKMDHMHFG5VHZZZ4O5LEUOWU">
-<catDesc>Gebel et-Teir</catDesc>
-</category>
-<category xml:id="tlaIVSRGWTX5BCPFDTPCUTBPPG2BE">
-<catDesc>Qasr Dusch</catDesc>
-</category>
-<category xml:id="tlaVUPHX5FDDJF6DK2YNH5YYGCOHI">
-<catDesc>Hibis</catDesc>
-</category>
-<category xml:id="tlaWBISS7Q7TBABBITCXNXFZL66N4">
-<catDesc>Qasr Sajjan</catDesc>
-</category>
-</category>
-<category xml:id="tlaPYXD5MKDMRHM5D6OMV24BZLF5Q">
-<catDesc>Wadi &#039;n-Natrun</catDesc>
-</category>
-<category xml:id="tlaSWRTITVT45BSBHQXPAYKBINNME">
-<catDesc>Oase Farafra</catDesc>
-</category>
-<category xml:id="tlaU4DBTWP5RVHGHBAUNQWG5GL7ZY">
-<catDesc>Oase Siwa</catDesc>
-</category>
-<category xml:id="tlaYQ6F5S3RIFFXDDDA4GFGGBU2GI">
-<catDesc>Oase Bahrija</catDesc>
-</category>
-</category>
-<category xml:id="tlaQOWZUQU5KVA5ZLY4L3SCWZAKTI">
-<catDesc>Niltal südlich des 4. Katarakts bis Chartum</catDesc>
-<category xml:id="tla33X5KPWRTNDKNAKNZCO7QAIAMQ">
-<catDesc>Meroe</catDesc>
-</category>
-<category xml:id="tlaII2NXFEVRNFKBJZ2FOCXLGJXEU">
-<catDesc>Naga</catDesc>
-</category>
-<category xml:id="tlaNLFGBK5HWBBO5JIOMD3M772V4I">
-<catDesc>Musawwarat es-Sufra</catDesc>
-</category>
-</category>
-<category xml:id="tlaTEG7WX4B3VCTHBUQLPCNM4RHFE">
-<catDesc>Nordafrika</catDesc>
-<category xml:id="tla6TU623R66JBBVJMJROR4ICRLKY">
-<catDesc>Umm er-Raham</catDesc>
-</category>
-<category xml:id="tlaU3I33GWG4JEIXGC56EJDTDCSDI">
-<catDesc>Berenike (kyrenäische Stadt an der Ostküste der Großen Syrte, heute Bengazi)</catDesc>
-</category>
-</category>
-<category xml:id="tlaTIQ4FWZDNZGJHDOQ5IOQMEFM4E">
-<catDesc>Vorderasien und Europa</catDesc>
-<category xml:id="tla2GUN2SILEBGNHDMNDRBU37FXPM">
-<catDesc>Timna&#039;</catDesc>
-</category>
-<category xml:id="tla2HRFZYCFRBBVXHATBBN7UKOFQY">
-<catDesc>Hamath. B. Tell el Hamme (13 km südlich von Besan)</catDesc>
-</category>
-<category xml:id="tla5N7EFKJ3HBEKFEQWSBFKSSSXEA">
-<catDesc>Ostia antica</catDesc>
-</category>
-<category xml:id="tla5TLIW3RY5NAKNF4CS7NJ2O5WMM">
-<catDesc>Benevent</catDesc>
-</category>
-<category xml:id="tlaA77DPUMJ6ZD4VE53RZGCJOVRGE">
-<catDesc>Assur</catDesc>
-</category>
-<category xml:id="tlaASNDBNLBEZFQDFWMQ7P5Y76DHE">
-<catDesc>Hamath. C. Hamat Tiberias (südlich von Tiberias)</catDesc>
-</category>
-<category xml:id="tlaBFVOAF5NLBGBTOBBROOXLXARWI">
-<catDesc>Hamath. A. Hamah (am Orontes, Mittelsyrien)</catDesc>
-</category>
-<category xml:id="tlaBLCB4C7LAVAHRGQSMHY5HJUTRI">
-<catDesc>Pompeji</catDesc>
-</category>
-<category xml:id="tlaEUATHPGDEFCFLKWUX3J3YALGGE">
-<catDesc>Raphia</catDesc>
-</category>
-<category xml:id="tlaGHKHPFSFDRC6RH65KFMQEOOVWM">
-<catDesc>Gezer</catDesc>
-</category>
-<category xml:id="tlaHWHDNIG4SJAKBJPDZDFGQD66UM">
-<catDesc>Beirut</catDesc>
-</category>
-<category xml:id="tlaKEWO73CGSJCFDBJXHLHQ4TALQI">
-<catDesc>Gasa</catDesc>
-</category>
-<category xml:id="tlaLXWZAW4Z6JGSZDYBUZKCKB2DXM">
-<catDesc>Rom</catDesc>
-</category>
-<category xml:id="tlaPAZVKLJLXBE5TKLFRBKD5R4LTI">
-<catDesc>Tayma</catDesc>
-</category>
-<category xml:id="tlaQF6KKTLEMVCALOZRON4JAI5IGM">
-<catDesc>Hazor</catDesc>
-</category>
-<category xml:id="tlaXYAORBBGBVGMJICREDG7A5ETUA">
-<catDesc>Qatna</catDesc>
-</category>
-<category xml:id="tlaZLJ4J2EB3RGJ3F6MTS7PQCUBSQ">
-<catDesc>Byblos</catDesc>
-</category>
-</category>
-<category xml:id="tlaVKVTR4BA7NAX7PXTNFZ45JEKK4">
-<catDesc>(unbekannt)</catDesc>
-</category>
-</category>
-<category xml:id="tlaMXWX4WG43ZHI7D4RLTGK3IBGXY">
-<catDesc>9 = Datierungen</catDesc>
-<category xml:id="tlaD3R5CH5NZBDA7IZMCKKJPWYZKU">
-<catDesc>(Jahrhunderte v.Chr.)</catDesc>
-<category xml:id="tla2ZIZTYBKYNFNVFTFBA32CAAY7A">
-<catDesc>1. Jhdt. v.Chr.</catDesc>
-<category xml:id="tla3V5NOJIC3VBIZBA7QCD6OFSAQY">
-<catDesc>4. Viertel 1. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tla7LG7A3WDXNFCVDQICH6CXVIJXM">
-<catDesc>1. Hälfte 1. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaEIO2LWBQURGJVC7LQZE5UHGMPU">
-<catDesc>2. Viertel 1. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaOSHKAITIJJAOVE4XNMQOVUA6JA">
-<catDesc>2. Hälfte 1. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaUQRNNAQXKBBLFEREMXSODORMFY">
-<catDesc>1. Viertel 1. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaZLKNXXGL7VA7VEECINB7NS65WI">
-<catDesc>3. Viertel 1. Jhdt. v.Chr.</catDesc>
-</category>
-</category>
-<category xml:id="tla5I4CKE7K4FE67NZU4FYVG66GG4">
-<catDesc>9. Jhdt. v.Chr.</catDesc>
-<category xml:id="tlaEHYAY2QQMFBLXE4DYP6AR3ZN3I">
-<catDesc>4. Viertel 9. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaFMKPIG5ISZH6JOPISBT7M5INSU">
-<catDesc>2. Hälfte 9. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaKNIVMJRE45AXBDQFA37HTNZZF4">
-<catDesc>1. Hälfte 9. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaTA5P36EB5NABBB6Q4J22ZQNF3I">
-<catDesc>1. Viertel 9. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaVZHQZE6KPJFARE6JBNNOWVD7JI">
-<catDesc>3. Viertel 9. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaZBQWVJND7ZCKNG4LSV64RXUJJU">
-<catDesc>2. Viertel 9. Jhdt. v.Chr.</catDesc>
-</category>
-</category>
-<category xml:id="tlaJ5JVKLZBXJH5VGTKXCTPBJ2KZE">
-<catDesc>4. Jhdt. v.Chr.</catDesc>
-<category xml:id="tla2VUPFL5N5FCC7FF4ECKTUY35Q4">
-<catDesc>2. Hälfte 4. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tla33LKEBW63FFSNCVMGOSMDBGFNQ">
-<catDesc>1. Hälfte 4. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaCSL4LTLEQBBSXGZ353PCVGCFZQ">
-<catDesc>1. Viertel 4. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaIPYKL4XDHJBFJE7D7AZ47HXVIM">
-<catDesc>3. Viertel 4. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaPYJNB3V355DMZERYYWMFHZ5NNI">
-<catDesc>4. Viertel 4. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaSX4FBQBUQFCSHBJFDSCPRLRRY4">
-<catDesc>2. Viertel 4. Jhdt. v.Chr.</catDesc>
-</category>
-</category>
-<category xml:id="tlaL34UY7MQCRB2JCBPNZKLGP2ZL4">
-<catDesc>2. Jhdt. v.Chr.</catDesc>
-<category xml:id="tlaBZNFBS76HVCPTJSYIUV22TSXBQ">
-<catDesc>2. Hälfte 2. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaDZUK4KHXJZBK5DIDGR6JDOMV4A">
-<catDesc>2. Viertel 2. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaHXGOS6R4BFGJRAFU6ZWTFAIYOA">
-<catDesc>1. Hälfte 2. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaPTSGMJ72MVDM3LGZS63DM4ENQI">
-<catDesc>1. Viertel 2. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaWFXACEBXJZA77IUNL2T2G4WJWA">
-<catDesc>4. Viertel 2. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaXQOCZAYRS5B4FA7XUIXRLZXOCA">
-<catDesc>3. Viertel 2. Jhdt. v.Chr.</catDesc>
-</category>
-</category>
-<category xml:id="tlaNVFQR5PSCZEFPELBXY57W2VQPM">
-<catDesc>3. Jhdt. v.Chr.</catDesc>
-<category xml:id="tla2EPYVX63FFBRJBCOEKC2E42K6Y">
-<catDesc>2. Viertel 3. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tla2RNQRYRR75HBHJQXKCIINNWCIE">
-<catDesc>2. Hälfte 3. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tla7FG3AE5TKBHCBCQIUHZIQS5SPE">
-<catDesc>3. Viertel 3. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaCXCXYSLLUFHMPGQ7ROYMAHLCAA">
-<catDesc>1. Hälfte 3. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaRDSBFVI3QJG7XNZOXVDLV3LU6I">
-<catDesc>1. Viertel 3. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaRUEGPD2BQBAIRAF35NA3L4VJHY">
-<catDesc>4. Viertel 3. Jhdt. v.Chr.</catDesc>
-</category>
-</category>
-<category xml:id="tlaPBLVUQXCI5HETLV6ICT7YYYOZI">
-<catDesc>7. Jhdt. v.Chr.</catDesc>
-<category xml:id="tlaQIVC46ND4BDUXAWR4EYMD4AUME">
-<catDesc>4. Viertel 7. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaR7RP4HBK7FCSTB74WGGFMBAXJE">
-<catDesc>1. Hälfte 7. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaVPDCMRCERVH3JBGCJQFWOEV4PE">
-<catDesc>2. Viertel 7. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaVRYK3DNABFC37OCSLTNEE6SX2M">
-<catDesc>2. Hälfte 7. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaYJ43LQBBSNEVHJTOY2KXTZ4KSQ">
-<catDesc>1. Viertel 7. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaZ7SE63TCNBHDNCAJXDFKZVI43M">
-<catDesc>3. Viertel 7. Jhdt. v.Chr.</catDesc>
-</category>
-</category>
-<category xml:id="tlaSUWAELMXDVA5VF7G6BGY5FP24Q">
-<catDesc>5. Jhdt. v.Chr.</catDesc>
-<category xml:id="tla2SVJUWTG65CGBPSRR2JVGCFZQI">
-<catDesc>3. Viertel 5. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tla37AKJCT3O5EXHKZVR4OERWJUMM">
-<catDesc>2. Viertel 5. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tla3RSAUA2SMZGCDEMLGVH47P6IOM">
-<catDesc>1. Hälfte 5. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaGGPOQYXYZBDUZNTFBXUVFYGDEM">
-<catDesc>2. Hälfte 5. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaM5RNBQZBHJDSJLRFTESD5PXUUM">
-<catDesc>4. Viertel 5. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaSWTOWPX765HQBK4FBHAFFBF4XE">
-<catDesc>1. Viertel 5. Jhdt. v.Chr.</catDesc>
-</category>
-</category>
-<category xml:id="tlaSYVSDPY4UFC7VFGH34ZDTEPMMM">
-<catDesc>6. Jhdt. v.Chr.</catDesc>
-<category xml:id="tla5RWQE6I76ZDJ7C6RZZHDZ5NZOA">
-<catDesc>2. Hälfte 6. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tla742V5NN54JCLRMXZSWDVTG4YK4">
-<catDesc>4. Viertel 6. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tla7WVJGW33WFHVZI2UBOIDWIKIPI">
-<catDesc>1. Hälfte 6. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaONBKOHQ33BA2ZC2SC2HQHOG3UY">
-<catDesc>2. Viertel 6. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaRDVGZ5PV4BAGRG2ZBOUB4SBJHI">
-<catDesc>3. Viertel 6. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaWHI6OSNIHJEDFI4VOSPL3NGNQM">
-<catDesc>1. Viertel 6. Jhdt. v.Chr.</catDesc>
-</category>
-</category>
-<category xml:id="tlaTIKGPKBTXVA6PHCKCHQJ6VIM2M">
-<catDesc>8. Jhdt. v.Chr.</catDesc>
-<category xml:id="tla3T5D7CE7MZFTXM5NHH6TB354A4">
-<catDesc>1. Hälfte 8. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tla6SL7CB3TV5GCDOFNO6SEKXCPDU">
-<catDesc>1. Viertel 8. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaAY7RFFECHJFYXJVVW7UO73DNDM">
-<catDesc>3. Viertel 8. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaG4YYFKH7ARFA5JOTIHYTNEI4LY">
-<catDesc>2. Viertel 8. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaUH3G5FM2SREITBEJ5RTX7TZYZ4">
-<catDesc>2. Hälfte 8. Jhdt. v.Chr.</catDesc>
-</category>
-<category xml:id="tlaVIZ3CULWTNB6FPFNJ3OBEDTL5I">
-<catDesc>4. Viertel 8. Jhdt. v.Chr.</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaDUVGWT7GSRCKDM5LFTGU6MZ3GY">
-<catDesc>(Epochen und Dynastien)</catDesc>
-<category xml:id="tla3GGZCLNRQVF6PAEQA6LCFBNE6M">
-<catDesc>Zweite Zwischenzeit</catDesc>
-<category xml:id="tlaE4VXX5LISZC2XIR6AYPM3Y3TQI">
-<catDesc>15. / 16. / 17. Dynastie</catDesc>
-</category>
-<category xml:id="tlaGKB34UGJLZA6ZPUYTDRQ7UNPH4">
-<catDesc>13. / 14. Dynastie</catDesc>
-<category xml:id="tlaQXLWLXSIOBEBRBINKZ7WPX6C3U">
-<catDesc>Sebekhotep IV.</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tla7FUWX6PWFJDAXEWQDOAA4FYXFU">
-<catDesc>prädynastische Zeit</catDesc>
-<category xml:id="tla6YAAR2WRI5F6BLP6YMW3G67P6Q">
-<catDesc>Neolithikum vor der Badari-Kultur</catDesc>
-</category>
-<category xml:id="tlaFMNBFXWGA5C2TEXFRDXOGXBEPE">
-<catDesc>Badari-Kultur</catDesc>
-</category>
-<category xml:id="tlaIPXSCTKV4REDHIXWTZWDXVXJWY">
-<catDesc>Naqada III</catDesc>
-</category>
-<category xml:id="tlaP5F2WOP6YZGBHK5KCSCP2UXJHM">
-<catDesc>Naqada I</catDesc>
-</category>
-<category xml:id="tlaWLIRCHQ3DRF4ZOTIREDVCPKC5A">
-<catDesc>Naqada II</catDesc>
-</category>
-</category>
-<category xml:id="tlaBILVGTX4DVEERA2TQ2DFPYYTK4">
-<catDesc>Thinitenzeit</catDesc>
-<category xml:id="tlaRHWO4WZITFG7LC64PRWKXGSBLE">
-<catDesc>1. Dyn.</catDesc>
-<category xml:id="tla6OQR45RINVBEXKRXU67UUYG5WI">
-<catDesc>Semerchet / Semempses</catDesc>
-</category>
-<category xml:id="tla7W7ATEIEBBB7JBXHCOIEEDK3X4">
-<catDesc>( ) / Itj</catDesc>
-</category>
-<category xml:id="tlaC36PPQYVH5G4LLVMYYF4KAQ7V4">
-<catDesc>Den / Usaphais</catDesc>
-</category>
-<category xml:id="tlaDXQSYPUVZ5ENLH22UECZNJZFSY">
-<catDesc>Aha / Menes</catDesc>
-</category>
-<category xml:id="tlaIT24BFWQQ5FL7NSNEPBYN3JUQA">
-<catDesc>Wadj / Ita</catDesc>
-</category>
-<category xml:id="tlaO23PARFR5BEZDPKFYTPTWNISIM">
-<catDesc>Adj-ib / Miebis</catDesc>
-</category>
-<category xml:id="tlaWJGLV3QK3BEPZGHRP6D5EYZMOQ">
-<catDesc>Qa-a / Bieneches</catDesc>
-</category>
-<category xml:id="tlaWOKINRAGTVBY5ER4WSNTGPTAIU">
-<catDesc>Djer / Athotis</catDesc>
-</category>
-</category>
-<category xml:id="tlaRRYWO76XVZHRHDJI4376RX5OXM">
-<catDesc>2. Dyn.</catDesc>
-<category xml:id="tla727RS3OFRFACXG74OQBUG4CYYA">
-<catDesc>unteräg. Könige parallel zu Peribsen</catDesc>
-</category>
-<category xml:id="tlaGFTQ3LZ2NFFXFN5WCQWTHB25UA">
-<catDesc>Nebre / Kiechos</catDesc>
-</category>
-<category xml:id="tlaJSG47O3RY5DP3JBUHLKVBBPI4U">
-<catDesc>Nineter / Binothis</catDesc>
-</category>
-<category xml:id="tlaKJ7NJARIAFDH3DQBXQXJPIHK44">
-<catDesc>Hetepsechemui / Boethos</catDesc>
-</category>
-<category xml:id="tlaNLBRXU2SHBA53A3CBNJNFJUNEU">
-<catDesc>Sechem-ib / Sethenes</catDesc>
-</category>
-<category xml:id="tlaOUIVW3MIHNHIPC7R333PQRIGYM">
-<catDesc>Chasechemui / Chasechem</catDesc>
-</category>
-<category xml:id="tlaVHOWISQK4FB6LJYLLQUBLBINUU">
-<catDesc>Peribsen</catDesc>
-</category>
-<category xml:id="tlaY7ZEMNUP3VGFNMNVJTHPC5A7VY">
-<catDesc>Weneg-Nebti / Tlas</catDesc>
-</category>
-</category>
-<category xml:id="tlaZ4YNGVLCKBBYTETIZHVGTUQAOM">
-<catDesc>0. Dyn.</catDesc>
-<category xml:id="tla2SRQ3JK6ZJDMNGUGSSLVAS2EUY">
-<catDesc>&quot;Mund&quot;</catDesc>
-</category>
-<category xml:id="tla3HF272323RDJXBXFYT7IVUSFSU">
-<catDesc>Skorpion</catDesc>
-</category>
-<category xml:id="tla7E6ZCCAAKJAUHM2T67D4D5G5CI">
-<catDesc>Narmer</catDesc>
-</category>
-<category xml:id="tlaFQEHFFBL6ZEA7LVBPHY4A6JP7A">
-<catDesc>&quot;Arme&quot; / Ka / Sechen</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaDBDBZEFDGZGGBMERHVKJ6PMPHQ">
-<catDesc>Altes Reich</catDesc>
-<category xml:id="tla7QKSXYEUCFHNBCFOS7XUZFGCJU">
-<catDesc>3. Dyn.</catDesc>
-<category xml:id="tla35QR2MPL3NF4HIHPDLJJF7NC6U">
-<catDesc>Huni / Qahedjet</catDesc>
-</category>
-<category xml:id="tlaATAYWXKNBVHT3FWOC65D5273BU">
-<catDesc>Nebka / Sanacht</catDesc>
-</category>
-<category xml:id="tlaFDTMSNLYBNFERMB64GHLI4OXKI">
-<catDesc>( ) / Chaba</catDesc>
-</category>
-<category xml:id="tlaI3U2PPJRONEWZDZE3DPBLRH35Y">
-<catDesc>Djoser / Netjeri-chet</catDesc>
-</category>
-<category xml:id="tlaKVW4S6I4ZRECNMJTM6FFTFLMYI">
-<catDesc>Djeserteti / Sechemchet</catDesc>
-</category>
-</category>
-<category xml:id="tlaGH2RXLTQ2BCEHPQ6R2SPBER7OM">
-<catDesc>6. Dyn.</catDesc>
-<category xml:id="tla3DBCMXAP3ZA2TCSSOGPRVOXKME">
-<catDesc>6. Dyn. nach Pepi II.</catDesc>
-</category>
-<category xml:id="tla3ESLSUHOURDCPFZ2UDUJACFV7Q">
-<catDesc>Pepi II.</catDesc>
-</category>
-<category xml:id="tlaACJUYKAESFH4JAWU2KOOHKW3HM">
-<catDesc>Pepi I.</catDesc>
-</category>
-<category xml:id="tlaEBTM44JP7NA5BBJ4XXKU7RMX7Y">
-<catDesc>Userkare</catDesc>
-</category>
-<category xml:id="tlaH5RYRC56WNGXFFMSSKXFWRRDLE">
-<catDesc>Merenre</catDesc>
-</category>
-<category xml:id="tlaJDHTPUAWMZBCZJDBBD2JP4PAD4">
-<catDesc>Teti</catDesc>
-</category>
-</category>
-<category xml:id="tlaOSQYKCRYMFGJRD3LESUKPOZG4E">
-<catDesc>8. Dyn.</catDesc>
-</category>
-<category xml:id="tlaRI3TSGKXUFCE3HV43BX2N2MJVE">
-<catDesc>5. Dyn.</catDesc>
-<category xml:id="tla3X3HIVLWDVCHVM7OKEQG4RIKIA">
-<catDesc>Sahure</catDesc>
-</category>
-<category xml:id="tlaE3KJFINUWJGZHI3ROCURKZQF2Q">
-<catDesc>Neferirkare</catDesc>
-</category>
-<category xml:id="tlaF2WUXBPF6ND7ZAEU4GIZTIBOQ4">
-<catDesc>Niuserre</catDesc>
-</category>
-<category xml:id="tlaJISVUMEI3NG25FQDYLYD3R6MJ4">
-<catDesc>Schepseskare</catDesc>
-</category>
-<category xml:id="tlaKQY2F5SJVBBN7GRO5WUXKG5M6M">
-<catDesc>Djedkare Asosi</catDesc>
-</category>
-<category xml:id="tlaLOCJJXDY4RDZRFMENMXLKBKYYQ">
-<catDesc>Neferefre</catDesc>
-</category>
-<category xml:id="tlaSC4IKOXD5NFI7B6FO3LGEM4P34">
-<catDesc>Menkauhor</catDesc>
-</category>
-<category xml:id="tlaVXCXYJF7QFDKHG4XNG7B7JSOIM">
-<catDesc>Unas</catDesc>
-</category>
-<category xml:id="tlaWM77TXYU2VAYJJGYHPUZPZXSGA">
-<catDesc>Userkaf</catDesc>
-</category>
-</category>
-<category xml:id="tlaWCVSHAEC7ZA4FKQOWR4E2GC6OM">
-<catDesc>4. Dyn.</catDesc>
-<category xml:id="tla4SJRB25AURBUZMSZBBXRRHDO3A">
-<catDesc>Djedefre</catDesc>
-</category>
-<category xml:id="tla4XVWKCUISJDA5OWB724D2CPBRI">
-<catDesc>Chefren</catDesc>
-</category>
-<category xml:id="tlaB6LUZDUOMJDC3G3JVUHHECQCAM">
-<catDesc>Schepseskaf</catDesc>
-</category>
-<category xml:id="tlaHOX5L57VFFDMTBCTWJNSHQ3OJA">
-<catDesc>Snofru</catDesc>
-</category>
-<category xml:id="tlaIS52YO4UPBG6ZO5BFFVWJ26OWY">
-<catDesc>Cheops</catDesc>
-</category>
-<category xml:id="tlaONSX4LNQWJH7LHFD64LQJIWJAA">
-<catDesc>Bicheris</catDesc>
-</category>
-<category xml:id="tlaPPBZN6VP2ZEXPAUZOK3ST3SO3M">
-<catDesc>Tamphthis</catDesc>
-</category>
-<category xml:id="tlaWEB5KGYGWJFUTDVTZP5PO5GBOY">
-<catDesc>Mykerinos</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaHYYNMJRFTVFIHB7JUA6M2QW3LQ">
-<catDesc>Makedonen, Ptolemäer</catDesc>
-<category xml:id="tla5EXFFIIQ2BFLJBUPM345Q52RYE">
-<catDesc>Ptolemaios XIII.</catDesc>
-</category>
-<category xml:id="tla6CEMTQHBPVCKRGBPZV3SBCJFHM">
-<catDesc>Ptolemaios II. Philadelphos</catDesc>
-</category>
-<category xml:id="tla7SZBT5EB75DZVEYNMMNDRAR6WM">
-<catDesc>Ptolemaios I. Soter</catDesc>
-</category>
-<category xml:id="tlaBB2LXNAEFRHAFOQHR7VCS2GUDE">
-<catDesc>Kleopatra VII.</catDesc>
-</category>
-<category xml:id="tlaBHAOO6DORBCPVDTRZTJSLM3MHM">
-<catDesc>Ptolemaios VI. Philometor</catDesc>
-</category>
-<category xml:id="tlaBJBGAQ4PCJHSRISGG6ZIEP26YI">
-<catDesc>Alexander IV.</catDesc>
-</category>
-<category xml:id="tlaEAIXVOD3ZFAQXCGUYG2MUERGXU">
-<catDesc>Ptolemaios VIII. Euergetes II.</catDesc>
-</category>
-<category xml:id="tlaEB27VJIJZZFPLDR5ONLBMQUJQY">
-<catDesc>Philipp Arrhidaios</catDesc>
-</category>
-<category xml:id="tlaETFKXMIJTBE45KASN7GX4BG5VI">
-<catDesc>Ptolemaios XIV. Philopator</catDesc>
-</category>
-<category xml:id="tlaKAK54XJY4BBU3PXESJCBL6YQHM">
-<catDesc>Ptolemaios V. Epiphanes</catDesc>
-</category>
-<category xml:id="tlaM2BT2KZR4RAYJIWGOO6N3P4C64">
-<catDesc>Alexander der Große</catDesc>
-</category>
-<category xml:id="tlaMHVALMEFXBE7BKJGFSD7LCSRVM">
-<catDesc>Ptolemaios XII. Philopator Philadelphos Neos Dionysos</catDesc>
-</category>
-<category xml:id="tlaMP63BC4W6NHILLBC2NAFBF7ZTA">
-<catDesc>Ptolemaios IX. Soter II.</catDesc>
-</category>
-<category xml:id="tlaPCA5EX57QNGOFAJAM3SOI6VV4M">
-<catDesc>Ptolemaios VII. Neos Philopator</catDesc>
-</category>
-<category xml:id="tlaQU2M4UGNUNDHTE5DUANDIT5K4M">
-<catDesc>Ptolemaios X. Alexander I.</catDesc>
-</category>
-<category xml:id="tlaTU4NLFP3EBHXHGMDL7F7IOGFCQ">
-<catDesc>Ptolemaios III. Euergetes</catDesc>
-</category>
-<category xml:id="tlaUGINSOQZARG3NJSLGNVX3STTIE">
-<catDesc>Ptolemaios XI. Alexander II.</catDesc>
-</category>
-<category xml:id="tlaXYP4XJ2LEVCS7DBSHGYOH4WYOU">
-<catDesc>Ptolemaios IV. Philopator</catDesc>
-</category>
-</category>
-<category xml:id="tlaJS32JKX2CNG25GZ3B6MGYMDU4I">
-<catDesc>Dritte Zwischenzeit</catDesc>
-<category xml:id="tla3XW6DLUBKVCLHD6KY45JN2PRD4">
-<catDesc>Kuschiten</catDesc>
-<category xml:id="tla2ZQQIYQHVRDGTH6PPY2LWEQCUQ">
-<catDesc>Schabataka</catDesc>
-</category>
-<category xml:id="tla7FDXNLDP5FFK5EBDS5TKXVPP6A">
-<catDesc>Kaschta</catDesc>
-</category>
-<category xml:id="tla7PIUCJYC7BBVXLMOIZYT72PWJQ">
-<catDesc>Alara</catDesc>
-</category>
-<category xml:id="tlaEFGOT3UFWZG27GZOSTKIU3X2KE">
-<catDesc>Tanutamon</catDesc>
-</category>
-<category xml:id="tlaNL6KKNWSCFGGLO75JDALYFOL4U">
-<catDesc>Taharqa</catDesc>
-</category>
-<category xml:id="tlaSCJLUQ4CSFFRJF6XNZ34OV4DFQ">
-<catDesc>Pije</catDesc>
-</category>
-<category xml:id="tlaXNHKJRIXSNB77GIB66CWTBWGHQ">
-<catDesc>Schabaka</catDesc>
-</category>
-</category>
-<category xml:id="tla744HIAA6FRHBROALBB3DV4VV3I">
-<catDesc>25. Dyn.</catDesc>
-<category xml:id="tlaCWZ4MSSSSBEIPK2RBFSX45ZBMI">
-<catDesc>Schabataka</catDesc>
-</category>
-<category xml:id="tlaFLAXS36WHJA5TJUDDWKHQONVEM">
-<catDesc>Tanutamon</catDesc>
-</category>
-<category xml:id="tlaUWRHN5WFJ5GGBCYKPZXK4YE2GU">
-<catDesc>Schabaka</catDesc>
-</category>
-<category xml:id="tlaVNUNBFCAMNFC7KMHL4QWVJXFTE">
-<catDesc>Taharqa</catDesc>
-</category>
-</category>
-<category xml:id="tla7J6HVBL7CJHQPJHG6TBBXJMYMM">
-<catDesc>24. Dyn.</catDesc>
-<category xml:id="tla47CU2AIR3BAGXEDHUKRZ5NLI44">
-<catDesc>Bokchoris</catDesc>
-</category>
-<category xml:id="tlaJMRTQ7BOBZCUPEREM5VMJ2WJZE">
-<catDesc>Tefnachte</catDesc>
-</category>
-</category>
-<category xml:id="tlaE7YEQAEKZVEJ5PX7WKOXY2QEEM">
-<catDesc>21. Dyn.</catDesc>
-<category xml:id="tla677YHBKQIRHB3HVZG45V2N6DU4">
-<catDesc>Siamun</catDesc>
-</category>
-<category xml:id="tlaBBZR65BX2JHZJHOPWOGMFFE42A">
-<catDesc>Smendes</catDesc>
-</category>
-<category xml:id="tlaG2XFFZLE4ZHDNMISPFYCHJJB4M">
-<catDesc>Psusennes I.</catDesc>
-</category>
-<category xml:id="tlaNOTZ5UOGYZD2VBH6D6JXBOW6LI">
-<catDesc>Psusennes II.</catDesc>
-</category>
-<category xml:id="tlaO5QKFTC7YBCKNDSQJOKBWT63BY">
-<catDesc>Amenemopet</catDesc>
-</category>
-<category xml:id="tlaSBF7EA7BN5FOVO6JXZQHUWGYTQ">
-<catDesc>Amenemnisut / Nephercheres</catDesc>
-</category>
-<category xml:id="tlaXVUCQSGCYBHKFNXJYMSKRL4R2M">
-<catDesc>Osochor</catDesc>
-</category>
-</category>
-<category xml:id="tlaWASRAHTUHNE6HDWN5URBHDIR2M">
-<catDesc>22. / 23. Dyn.</catDesc>
-<category xml:id="tlaARW2M7F3JFF7HP7XCQ34JREODY">
-<catDesc>Scheschonq III.</catDesc>
-</category>
-<category xml:id="tlaBFBDVC3P25FALCKMNPTNBNYQNA">
-<catDesc>Pemu</catDesc>
-</category>
-<category xml:id="tlaBPYQBIAZPVCWZHDS7M3C2GL53U">
-<catDesc>Scheschonq V.</catDesc>
-</category>
-<category xml:id="tlaBV3NUTCOVBAHDOBBNO44T2F4VY">
-<catDesc>Scheschonq II.</catDesc>
-</category>
-<category xml:id="tlaD7L7SMVVVFEWREVPZSXPGMDMUA">
-<catDesc>Harsiese</catDesc>
-</category>
-<category xml:id="tlaDUH5NGZGPZHIXA2SBPDTFYRV54">
-<catDesc>Psammus</catDesc>
-</category>
-<category xml:id="tlaIZT7J5CGRZEX3OT5ERPRYWQTYY">
-<catDesc>Scheschonq IV.</catDesc>
-</category>
-<category xml:id="tlaKNKTVZBWMBDOPKZ4RVIK43DSME">
-<catDesc>Osorkon IV.</catDesc>
-</category>
-<category xml:id="tlaLJNCZ3RENZGYDDTSANDPNMVKRI">
-<catDesc>Petubastis I.</catDesc>
-</category>
-<category xml:id="tlaMPKA3BGQ5VDRDE4SQKHBU7I5RM">
-<catDesc>Osorkon II.</catDesc>
-</category>
-<category xml:id="tlaN47PT66YEVCDHFFZUVIML2BE2M">
-<catDesc>Petubastis II.</catDesc>
-</category>
-<category xml:id="tlaNUDYSH53HVGNTM2FTELC5TFSQI">
-<catDesc>Osorkon I.</catDesc>
-</category>
-<category xml:id="tlaPBUFJKFM4NH2XEBUVIEZCB6A3M">
-<catDesc>Takelot II.</catDesc>
-</category>
-<category xml:id="tlaR2UVPCKDIRFOBF4QR5W6UY73QY">
-<catDesc>Osorkon III.</catDesc>
-</category>
-<category xml:id="tlaT3PXE2RRVRCIFCRUQP4PCSQMOI">
-<catDesc>Iuput I.</catDesc>
-</category>
-<category xml:id="tlaT6GEYS2Y3RGF3O3ZGQWHBJZMQI">
-<catDesc>Iuput II.</catDesc>
-</category>
-<category xml:id="tlaTLM3NFHYG5HRHICGSS6SI6HEBI">
-<catDesc>Rudamun</catDesc>
-</category>
-<category xml:id="tlaTMQJAUESNRGSXF4GT75ECQKKYQ">
-<catDesc>Iny</catDesc>
-</category>
-<category xml:id="tlaUUZQDMMULNCRHNP2EV4OBUNCOM">
-<catDesc>Takelot III.</catDesc>
-</category>
-<category xml:id="tlaVFTMODKBGZAGNENLGHGNGNBXM4">
-<catDesc>Takelot I.</catDesc>
-</category>
-<category xml:id="tlaXZ2WE35X5NGFTN37A7ZOS4CD54">
-<catDesc>Scheschonq I.</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaMM4QYACJOJCCLJWBD6VAX2FLKE">
-<catDesc>Mittleres Reich</catDesc>
-<category xml:id="tla7G4I7VLRZFCZFBDWXWJBCSPIPI">
-<catDesc>11. Dyn. (Gesamtzeitraum)</catDesc>
-<category xml:id="tlaDD6XPV4VBFE2ZAP66IXKVPGWKQ">
-<catDesc>Intef I. Sehertawi</catDesc>
-</category>
-<category xml:id="tlaE2BYRJX5Z5DSBOJFVF6WO7KZRE">
-<catDesc>Intef III. Nachtnebtepnefer</catDesc>
-</category>
-<category xml:id="tlaEKCGS4YHKNCBNNBKQSBLGT4J7E">
-<catDesc>Mentuhotep III. Seanchkare</catDesc>
-</category>
-<category xml:id="tlaEUFPI7IUJFHVJGT6AOATFIZPNA">
-<catDesc>Intef II. Wahanch</catDesc>
-</category>
-<category xml:id="tlaKXXWNISHB5AWFHAYWKV5PCALSY">
-<catDesc>Mentuhotep IV. Nebtawire</catDesc>
-</category>
-<category xml:id="tlaPGZO7FG47BFK3LN2IQEOJBZJNU">
-<catDesc>Mentuhotep I. Tepi-a</catDesc>
-</category>
-<category xml:id="tlaQH4ZVV4SZREKNEY5UDCC3AZ3E4">
-<catDesc>Mentuhotep II. Nebhepetre</catDesc>
-</category>
-</category>
-<category xml:id="tlaJVTUL4HL45FRHF7TREHQXYZSWM">
-<catDesc>11. Dyn., 2. Hälfte</catDesc>
-<category xml:id="tlaB2OHIBEXNZHCTNGEXMEVV2VWIU">
-<catDesc>Mentuhotep II. Nebhepetre (nach der Reichseinigung)</catDesc>
-</category>
-<category xml:id="tlaIVVRWFXHMZCXBJRH5W2ZRMMVUE">
-<catDesc>Mentuhotep III. Seanchkare</catDesc>
-</category>
-<category xml:id="tlaUD2UDBHPXBCUXB5XZOMXZ5AN6E">
-<catDesc>Mentuhotep IV. Nebtawire</catDesc>
-</category>
-</category>
-<category xml:id="tlaWFSMZWLWMFDG5FAGQOB436TKUU">
-<catDesc>12. Dyn.</catDesc>
-<category xml:id="tla2N3CSTWVMRCXXLTRGTLKLJQZZU">
-<catDesc>Sobeknofru</catDesc>
-</category>
-<category xml:id="tla3O45XPYQXJATRP5CHBOH2EZYG4">
-<catDesc>Amenemhet III.</catDesc>
-</category>
-<category xml:id="tla43UOVHLOUVCWVK3L543HR44GSA">
-<catDesc>Amenemhet I.</catDesc>
-</category>
-<category xml:id="tlaCHLJ7SQNMVF33JVUBIZTIYH5PQ">
-<catDesc>Amenemhet II.</catDesc>
-</category>
-<category xml:id="tlaEBGTMF7GURDVZDFRV6XQU7OEOE">
-<catDesc>Sesostris I.</catDesc>
-</category>
-<category xml:id="tlaOKZXTLKCTZHVRGYAIBR5BGKZRI">
-<catDesc>Amenemhet IV.</catDesc>
-</category>
-<category xml:id="tlaQGFPPB7TBJC4DOC46YTOAH4UYM">
-<catDesc>Sesostris III.</catDesc>
-</category>
-<category xml:id="tlaUODUII6XLBAJFCSQQNBMW7H4XM">
-<catDesc>Sesostris II.</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaQBN55U2GTFA27GHK3IACBTMK2U">
-<catDesc>Erste Zwischenzeit</catDesc>
-<category xml:id="tlaGAQRDJP4OBB27JFBUQHAKXFEK4">
-<catDesc>9./10. Dyn. parallel zur frühen 11. Dyn.</catDesc>
-</category>
-<category xml:id="tlaPLVPK4FNBFHC3JQJC4J5YYJA2E">
-<catDesc>11. Dyn., 1. Hälfte</catDesc>
-<category xml:id="tlaGD5TMK62EREULP3HDTZUOIAEKA">
-<catDesc>Intef III. Nachtnebtepnefer</catDesc>
-</category>
-<category xml:id="tlaGQP66JAMPVHVLPQOJF72DRIEGA">
-<catDesc>Intef II. Wahanch</catDesc>
-</category>
-<category xml:id="tlaHVQOKLCRNZAP3BAXQMXFG2HQY4">
-<catDesc>Mentuhotep II. Nebhepetre (vor der Reichseinigung)</catDesc>
-</category>
-<category xml:id="tlaPNCIHL25ZFEW3EUOF47LJL45BE">
-<catDesc>Intef I. Sehertawi</catDesc>
-</category>
-<category xml:id="tlaSD3DMLVNJZETRPVYBPQJ353T34">
-<catDesc>Mentuhotep I. Tepi-a</catDesc>
-</category>
-</category>
-<category xml:id="tlaR5VWTPWBVBAAHA5VCWLUUD4SFU">
-<catDesc>9./10. Dyn. vor Beginn der 11. Dyn.</catDesc>
-</category>
-<category xml:id="tlaSQN2QN7IYZBYHCEUH7PBTHMKAU">
-<catDesc>Herakleopolitenzeit (Gesamtzeitraum)</catDesc>
-</category>
-</category>
-<category xml:id="tlaS62ITYADMZGCHBHTHTAFV3RUGQ">
-<catDesc>byzantinische Zeit</catDesc>
-</category>
-<category xml:id="tlaUGTUTKXZHBDYLG7YJZ5AGOJXQY">
-<catDesc>Spätzeit</catDesc>
-<category xml:id="tla2AVEQ3VFT5EEPF7NBH7RHCVBXA">
-<catDesc>27. Dyn.</catDesc>
-<category xml:id="tla7MP3UDFCTNH7HPPCH3RRJGEUOI">
-<catDesc>Kambyses</catDesc>
-</category>
-<category xml:id="tlaAY5C3JQWXNAM5NIBQVZFPAU7OU">
-<catDesc>Artaxerxes I.</catDesc>
-</category>
-<category xml:id="tlaCX7WTFO76NEIREYNBAZEMCKZJA">
-<catDesc>Artaxerxes II.</catDesc>
-</category>
-<category xml:id="tlaDFOATHXUQJFSJLTVPASC3TQF7M">
-<catDesc>Xerxes II.</catDesc>
-</category>
-<category xml:id="tlaDHKNUBJOYVE4DNGXMYMVUFJHTU">
-<catDesc>Dareios II.</catDesc>
-</category>
-<category xml:id="tlaLG2ZONR34VEQROX4FJ7MTCXKLM">
-<catDesc>Dareios I.</catDesc>
-</category>
-<category xml:id="tlaMJ3WULDBQVD3NJM4NFJQWMAYWI">
-<catDesc>Xerxes I.</catDesc>
-</category>
-</category>
-<category xml:id="tla2Z7FB3JW3BHGRPWOII5PAYY4DM">
-<catDesc>31. Dyn.</catDesc>
-<category xml:id="tla6XFG65VENRHERHIHREIUEPT7V4">
-<catDesc>Arses</catDesc>
-</category>
-<category xml:id="tlaHULJPMHB4FGENJGZ7DPTWIADZE">
-<catDesc>Artaxerxes III. Ochos</catDesc>
-</category>
-<category xml:id="tlaI6OREN4DZFDKDDCN6FDFJDB5ZE">
-<catDesc>Dareios III.</catDesc>
-</category>
-</category>
-<category xml:id="tla42CP5AWFYFFVXFWGXMJLO2ZWWI">
-<catDesc>28. Dyn.</catDesc>
-<category xml:id="tlaONG6H7BR5VBQPMWVKIG5RYZQWE">
-<catDesc>Amyrtaios</catDesc>
-</category>
-</category>
-<category xml:id="tlaFZRARLPZPZG5JM6XGGLTTEU3KM">
-<catDesc>29. Dyn.</catDesc>
-<category xml:id="tlaR3R4WMMU3VANVIGTRB5VPTHDYY">
-<catDesc>Nepherites II.</catDesc>
-</category>
-<category xml:id="tlaRX4OI7SAIJD4PIPLKCSDEHC5DQ">
-<catDesc>Nepherites I.</catDesc>
-</category>
-<category xml:id="tlaWSDXCFS7NBAZ7J6P6XHEKJ4CZA">
-<catDesc>Achoris</catDesc>
-</category>
-</category>
-<category xml:id="tlaQHQZNMAUZFCTZMLD5BGMDIKS6M">
-<catDesc>26. Dyn.</catDesc>
-<category xml:id="tla26FQR3PAGBFZLNTFH2VIKTYGVY">
-<catDesc>Necho</catDesc>
-</category>
-<category xml:id="tlaAX5RS54IHNHLLHTG5ACTVOAUII">
-<catDesc>Amasis</catDesc>
-</category>
-<category xml:id="tlaL3OEF7GYRZAVDA5J3RRDFHKKSQ">
-<catDesc>Psammetich III.</catDesc>
-</category>
-<category xml:id="tlaRWBAUHG5OVARXHA3ZVA4TFKSHQ">
-<catDesc>Psammetich II.</catDesc>
-</category>
-<category xml:id="tlaSSHXBGXDW5BJ3AEFHXVYZLBWAI">
-<catDesc>Psammetich I.</catDesc>
-</category>
-<category xml:id="tlaWBJEV25Q3RHT5NUYRUEGBY5LC4">
-<catDesc>Apries</catDesc>
-</category>
-</category>
-<category xml:id="tlaZAQON3S37NHEJMZP33RUX47ZY4">
-<catDesc>30. Dyn.</catDesc>
-<category xml:id="tla2EYHVBPX4NGUZPVTRAKO36TDWE">
-<catDesc>Teos</catDesc>
-</category>
-<category xml:id="tla5J7P2WPKN5GMNJD735VZP5JARQ">
-<catDesc>Nektanebos II.</catDesc>
-</category>
-<category xml:id="tlaAS735FI63FEQTISOFW6R6ITQQI">
-<catDesc>Nektanebos I.</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaWX32K2TQTRETLDX2IO6SL5DDBU">
-<catDesc>Neues Reich</catDesc>
-<category xml:id="tlaKXND4U5N5VBQLN4XMZGFVBHOCM">
-<catDesc>20. Dyn.</catDesc>
-<category xml:id="tla3L7VTD3RIFDP3P6WD55HOUP5ZU">
-<catDesc>Ramses IV.</catDesc>
-</category>
-<category xml:id="tla6JOFBEHJGJD3FKFGPRMBGDT6XM">
-<catDesc>Ramses VIII.</catDesc>
-</category>
-<category xml:id="tlaD3JLTVY33NF4VBTVIJRR4N5QUY">
-<catDesc>Ramses III.</catDesc>
-</category>
-<category xml:id="tlaEJKPV5YRHZDUNFSHN2C5CZ22YU">
-<catDesc>Ramses VI.</catDesc>
-</category>
-<category xml:id="tlaLRSMDL7ITFEJBAHAZN2KSV7IRE">
-<catDesc>Ramses VII.</catDesc>
-</category>
-<category xml:id="tlaMOM3DW5NLZAB5JCM2ZKX5GICCE">
-<catDesc>Ramses IX.</catDesc>
-</category>
-<category xml:id="tlaPNMK6Q7XZNESBJPTUSW7FGQ7YA">
-<catDesc>Ramses XI.</catDesc>
-</category>
-<category xml:id="tlaT5G5CJPBKBGW3DAGCAUTS35JRY">
-<catDesc>Ramses V.</catDesc>
-</category>
-<category xml:id="tlaTNO3MXXXJFF45IUPEUMCNHXK4Q">
-<catDesc>Ramses X.</catDesc>
-</category>
-<category xml:id="tlaVP6WK4UCRJAXHJT6XQEO2ZG6OI">
-<catDesc>Sethnachte</catDesc>
-</category>
-</category>
-<category xml:id="tlaNUW3K7UK3BBUFDPHZDD2ZZ3LYI">
-<catDesc>18. Dyn.</catDesc>
-<category xml:id="tla4EVBMCD2U5GQPBJ6QS622PTSQQ">
-<catDesc>Amenophis IV. / Echnaton</catDesc>
-</category>
-<category xml:id="tla4QEIACZDZ5F7ZHVQCMJKSBMZXM">
-<catDesc>Thutmosis III. (Gesamtzeitraum)</catDesc>
-</category>
-<category xml:id="tlaBVENTZHAEJERXCJI2Y45XAYKN4">
-<catDesc>Amenophis I.</catDesc>
-</category>
-<category xml:id="tlaDTH6NOX35ZBYNMGQH4SCKDS4GQ">
-<catDesc>Ahmose</catDesc>
-</category>
-<category xml:id="tlaF52ILUTH6RBWJI36ENPFTB22SI">
-<catDesc>Thutmosis I.</catDesc>
-</category>
-<category xml:id="tlaKMQ26R2F3VEJDIOTNUTDWO4Z4Y">
-<catDesc>Amenophis II.</catDesc>
-</category>
-<category xml:id="tlaMOFI6DFV5VD7RBARIW4TL33IZE">
-<catDesc>Semenchkare</catDesc>
-</category>
-<category xml:id="tlaPRDOZUMR2FDPNKK2OV6TUS4XEA">
-<catDesc>Thutmosis II.</catDesc>
-</category>
-<category xml:id="tlaQYLA6ANYSRER7I3JFTCKIPRHOY">
-<catDesc>Hatschepsut</catDesc>
-</category>
-<category xml:id="tlaTGGVPV3PMFAP5O5OBSMOIKEX74">
-<catDesc>Amenophis III.</catDesc>
-</category>
-<category xml:id="tlaU3LID524EVGI7MWJUIJYNLNSAE">
-<catDesc>Haremhab</catDesc>
-</category>
-<category xml:id="tlaWMSRSEY4LBALVAQEKU4GKNLTMU">
-<catDesc>Thutmosis IV.</catDesc>
-</category>
-<category xml:id="tlaXB6A2YYCL5AGHN4YU24CWFOVKY">
-<catDesc>Thutmosis III. (Alleinregierung)</catDesc>
-</category>
-<category xml:id="tlaZ45USXGJBNCVZLOVM5CRMAAL3Y">
-<catDesc>Tutanchamun</catDesc>
-</category>
-<category xml:id="tlaZHZNTKKCLJFT5FUOH2Y7QESCWM">
-<catDesc>Eje</catDesc>
-</category>
-</category>
-<category xml:id="tlaPFJ4POQ5VBFU3EHNXP4MRDLXBA">
-<catDesc>19. Dyn.</catDesc>
-<category xml:id="tla54VED6E3TBESLGFQGGQVXZ6GLM">
-<catDesc>Merenptah</catDesc>
-</category>
-<category xml:id="tla6KMCKKTQ4FFMLOYH264TPBW4IU">
-<catDesc>Siptah u. Tausret</catDesc>
-</category>
-<category xml:id="tlaBVMSDQRPX5ECXFKTIGQWIOXQOM">
-<catDesc>Sethos I.</catDesc>
-</category>
-<category xml:id="tlaFCJURX24JZGXZEKP3TW36U3ZFA">
-<catDesc>Ramses II.</catDesc>
-</category>
-<category xml:id="tlaSP2O7AHMRVFFNA6YJ2TIIYPS3A">
-<catDesc>Sethos II.</catDesc>
-</category>
-<category xml:id="tlaW4R7J6OTNFAVTN24X6SJGFKZ6I">
-<catDesc>Ramses I.</catDesc>
-</category>
-<category xml:id="tlaYOIYNB3BFVBEFDDS5V3AZCVFNQ">
-<catDesc>Amenmesse</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaYZP5WTOZV5FB5EZFGQDY7MYKIQ">
-<catDesc>römische Zeit</catDesc>
-<category xml:id="tla2A6LYDLVHRBPXFZKPZU7CEOAIM">
-<catDesc>&quot;Soldatenkaiser&quot;</catDesc>
-</category>
-<category xml:id="tla4XAVOEBBHVCGZIGICZCPL2N2N4">
-<catDesc>Severer</catDesc>
-<category xml:id="tla3TAIGNOV5BDMLOMA5QOH4OOHHU">
-<catDesc>Macrinus</catDesc>
-</category>
-<category xml:id="tla5IHX5Q7WPNEM3GUPGVUQJ55S2M">
-<catDesc>Severus Alexander</catDesc>
-</category>
-<category xml:id="tla6I2IJQAXYVG3ZCPOQE2JR6RFGU">
-<catDesc>Septimius Severus</catDesc>
-</category>
-<category xml:id="tlaJCO2GZFWPJHT3O2VMQLPOCWMQU">
-<catDesc>Caracalla</catDesc>
-</category>
-<category xml:id="tlaU4NUJYYIJFBYRJP3OHALCEQSM4">
-<catDesc>Elagabal</catDesc>
-</category>
-</category>
-<category xml:id="tlaFLZYUFLZMBCYZFIV6HIBSRIMPM">
-<catDesc>Adoptivkaiser</catDesc>
-<category xml:id="tla67URIQ5T5BAC5H7TPXM437SPU4">
-<catDesc>Antoninus Pius</catDesc>
-</category>
-<category xml:id="tla7CND52XKPNC5PIVU42CQ7FWAF4">
-<catDesc>Nerva</catDesc>
-</category>
-<category xml:id="tlaK7FNLUAFURALDGBN4FV3LSUWZI">
-<catDesc>Commodus</catDesc>
-</category>
-<category xml:id="tlaSBPP7UMVLNFRROVHN5MV4P3JMY">
-<catDesc>Hadrian</catDesc>
-</category>
-<category xml:id="tlaT5JLVAADRVCFFEE4AYQG7JUZXQ">
-<catDesc>Marcus Aurelius</catDesc>
-</category>
-<category xml:id="tlaXPSJ2LYDHBGNFD6CCPHJDKX4AY">
-<catDesc>Trajan</catDesc>
-</category>
-</category>
-<category xml:id="tlaKNI3FP7F3ZD7NLNZLEQOAIIG5U">
-<catDesc>Tetrarchenzeit</catDesc>
-</category>
-<category xml:id="tlaNWBNCEAMTFCPTNGFVWWNQMPTVI">
-<catDesc>julisch-claudische Dynastie</catDesc>
-<category xml:id="tla2HOJVMMCYBGGZBLAJPG2UMXHP4">
-<catDesc>Augustus</catDesc>
-</category>
-<category xml:id="tla6JNLCELRGFGW5DDAMGPF56DUAY">
-<catDesc>Tiberius</catDesc>
-</category>
-<category xml:id="tlaGKPIXD7FTBDQJETU2TITXC4QFQ">
-<catDesc>Claudius</catDesc>
-</category>
-<category xml:id="tlaOTVJNIXD7NCJZHX4YZ7HEWCPXM">
-<catDesc>Gaius</catDesc>
-</category>
-<category xml:id="tlaQVSUL54D5ZHFXP3S7MIOEU6GGA">
-<catDesc>Nero</catDesc>
-</category>
-</category>
-<category xml:id="tlaTLFBMDUZ2RE6JNZW7GZDBHWATM">
-<catDesc>Flavier</catDesc>
-<category xml:id="tla7QV5OTUCG5BG3HMCRBR4CCVYGU">
-<catDesc>Domitian</catDesc>
-</category>
-<category xml:id="tlaOSXPG6CJZNHRFG3CC7SYHU654Q">
-<catDesc>Titus</catDesc>
-</category>
-<category xml:id="tlaUEGCHD2YV5HL3E4DQ2C57NYFIU">
-<catDesc>Verspasian</catDesc>
-</category>
-</category>
-</category>
-</category>
-<category xml:id="tlaFHZEINDCEJAOTHIVC35NYGMC2Q">
-<catDesc>(Jahrhunderte n.Chr.)</catDesc>
-<category xml:id="tla4GVKWKAP4VFSLFPBUBAI7XF2YA">
-<catDesc>5. Jhdt. n.Chr.</catDesc>
-<category xml:id="tla57U3TQQLHZGSFHQ3GAWVITBYUQ">
-<catDesc>1. Viertel 5. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaAGZE4BISKREPFOZJJ5SZMRBKJQ">
-<catDesc>3. Viertel 5. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaDHJI2BOMWFCKBM52LDN3NEUYO4">
-<catDesc>2. Viertel 5. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaNXGHKWOMDZCZRHV474Y3FSMSVU">
-<catDesc>2. Hälfte 5. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaPZP2HLFD4ZD7PAJWWJA4C6IDHQ">
-<catDesc>1. Hälfte 5. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaXDJUGWOTXFFDZD344WXR5QQBPQ">
-<catDesc>4. Viertel 5. Jhdt. n.Chr.</catDesc>
-</category>
-</category>
-<category xml:id="tla77UKMRWAJZC5LALMVTEAD6L7VA">
-<catDesc>1. Jhdt. n.Chr.</catDesc>
-<category xml:id="tla2EGWXRGUCBHIDCTZXMZGGEYHPE">
-<catDesc>2. Viertel 1. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tla4GCBH775S5GTVNDXXASM2HFY3Q">
-<catDesc>3. Viertel 1. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaAIVG3ELQKNC4HKUIDHONGLB4TQ">
-<catDesc>1. Hälfte 1. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaJSFEL3SGN5DW5JSWMKHGRW7GSA">
-<catDesc>2. Hälfte 1. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaOZZZBMWUEBA7FHBJFEKZRKK3SQ">
-<catDesc>1. Viertel 1. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaWRWGTJLJNRHETBFC52BVHERDCQ">
-<catDesc>4. Viertel 1. Jhdt. n.Chr.</catDesc>
-</category>
-</category>
-<category xml:id="tlaDU6YTUV2IZEYTOA7GVBMTBCV3I">
-<catDesc>4. Jhdt. n.Chr.</catDesc>
-<category xml:id="tla5J4Y3SI54NGWZHHKU63JMNFKCA">
-<catDesc>1. Viertel 4. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tla6Y3WYJK76VFQRLZIMWF443PLUI">
-<catDesc>3. Viertel 4. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaMG2USRRI6BB57BC2SCZTBMIG4Q">
-<catDesc>2. Hälfte 4. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaNP53EQUQQ5AN7JPKA77LISIWPI">
-<catDesc>2. Viertel 4. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaWDMZ3ZJLVVAYTA4ZX4SXLI4MPA">
-<catDesc>1. Hälfte 4. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaWPEQO2GQTNE5XHPPIYVJG75WLE">
-<catDesc>4. Viertel 4. Jhdt. n.Chr.</catDesc>
-</category>
-</category>
-<category xml:id="tlaEQM4LZPKYJCWFNQ445M6XU3UCY">
-<catDesc>2. Jhdt. n.Chr.</catDesc>
-<category xml:id="tla5HNMTTVLOREQ3LKMJOCIH7Z5GU">
-<catDesc>1. Hälfte 2. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaDXLYH5WDSRHZVE3XTFKN72X7ZQ">
-<catDesc>2. Hälfte 2. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaHT44AOEA5ZFFJBINX2DBUS3LYE">
-<catDesc>1. Viertel 2. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaIIPELUHXL5G3TEZXTVQMSJCMIE">
-<catDesc>2. Viertel 2. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaIO2NFBCQMJDSJGZB4QF7QRMMSY">
-<catDesc>4. Viertel 2. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaMPCVCKDBWNC77GRCMHQQM66CUE">
-<catDesc>3. Viertel 2. Jhdt. n.Chr.</catDesc>
-</category>
-</category>
-<category xml:id="tlaFV6TQYR4MJBDTCWZABXH4E4OMY">
-<catDesc>9. Jhdt. n.Chr.</catDesc>
-<category xml:id="tla3MEPLXDHJZH25EFWG4ONSPBADU">
-<catDesc>1. Hälfte 9. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaGCOGRW2AFNFAZC7CAH5VY2TIYI">
-<catDesc>4. Viertel 9. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaMVDHBIPHCNEEVIZYTF4HL7XTGM">
-<catDesc>1. Viertel 9. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaQSRVICICSJD6VOVHOP3Z3BBG5Y">
-<catDesc>3. Viertel 9. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaSQYBTEXKORB6VCUCL5P5CABDBY">
-<catDesc>2. Hälfte 9. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaZ2OYYVNKXNCUDJRR6ZFGJHBBZ4">
-<catDesc>2. Viertel 9. Jhdt. n.Chr.</catDesc>
-</category>
-</category>
-<category xml:id="tlaIMBHKBIKV5AUHEAAU2DL2K2GN4">
-<catDesc>3. Jhdt. n.Chr.</catDesc>
-<category xml:id="tlaC5KTZJIALBBA3BP3DB3BHAF3RA">
-<catDesc>4. Viertel 3. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaKENXXLN7BRAYHAMA7O447DA73Y">
-<catDesc>2. Viertel 3. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaQPUHN5VYWVAGPKZ3ZHYQFMYPNQ">
-<catDesc>2. Hälfte 3. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaRNVKCEB3GJBZNDSHZSA6UDH5BU">
-<catDesc>1. Hälfte 3. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaX7UGMEM77FBDXEPEMLGPVANWOI">
-<catDesc>3. Viertel 3. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaZDX4UT6C7NGQZEUL55SAXFWDIQ">
-<catDesc>1. Viertel 3. Jhdt. n.Chr.</catDesc>
-</category>
-</category>
-<category xml:id="tlaMRHDSYHO4FCH5FRYRE3F47QHSQ">
-<catDesc>6. Jhdt. n.Chr.</catDesc>
-<category xml:id="tla4BMTXUOSFBH6VBJLBMCOBFANBQ">
-<catDesc>1. Viertel 6. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaOJPO7GMS75E75LTRJNRX2DCTGQ">
-<catDesc>2. Hälfte 6. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaUGV7KEWHUBBHNOKSVSU6EDZ5UU">
-<catDesc>4. Viertel 6. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaXNT2W3PJZZHY7C46BD6UZHRLJA">
-<catDesc>2. Viertel 6. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaXWW436FZEZC23OUSX7IPSXLWXA">
-<catDesc>1. Hälfte 6. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaZYRH3FYJNNAQDOACTPR2YKSV6U">
-<catDesc>3. Viertel 6. Jhdt. n.Chr.</catDesc>
-</category>
-</category>
-<category xml:id="tlaTU6P6HMKY5AB7DLLOJVA77746E">
-<catDesc>7. Jhdt. n.Chr.</catDesc>
-<category xml:id="tla22SCMOXZQFDXRNHIOVRBPNOPZM">
-<catDesc>1. Viertel 7. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tla74MF3BTZAVEBBFNK6KFLKUEHVA">
-<catDesc>4. Viertel 7. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaFMT2DC5ZUJD2HEQACDEMXUFZB4">
-<catDesc>2. Viertel 7. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaI5IQORK3F5BVZPETMCXQSJP5WA">
-<catDesc>1. Hälfte 7. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaTZTJKFTIEZCKBGVD2NSIPT2JQY">
-<catDesc>3. Viertel 7. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaUKKBW2H6HJFIZCVHBREHPIGGVQ">
-<catDesc>2. Hälfte 7. Jhdt. n.Chr.</catDesc>
-</category>
-</category>
-<category xml:id="tlaY55AYTMYANAOFCYUMYJWZRPSZA">
-<catDesc>8. Jhdt. n.Chr.</catDesc>
-<category xml:id="tlaI5GTTHOZWJCY5LTQLIFAM4WYDM">
-<catDesc>3. Viertel 8. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaPTTURIUYEVGRNIDYMJWFOHLZSI">
-<catDesc>2. Hälfte 8. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaPVZ6R3YIHZBRPNWWLX5VZTIUZU">
-<catDesc>1. Hälfte 8. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaQVPJSG5RUFGMNMAQNWUHEBYJKM">
-<catDesc>1. Viertel 8. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaSJGD7JW3PZAHHB2FHJKWVTSIBM">
-<catDesc>4. Viertel 8. Jhdt. n.Chr.</catDesc>
-</category>
-<category xml:id="tlaVTOAVISRORHJPAQK3FTRPHYAQE">
-<catDesc>2. Viertel 8. Jhdt. n.Chr.</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaFKLXKTC5RJFSZCBDU5HWK6KHGU">
-<catDesc>(unbekannt)</catDesc>
-</category>
-<category xml:id="tlaGTIHALKZWJFTNCLZ3ITXK7HBXA">
-<catDesc>(unbestimmt)</catDesc>
-</category>
-</category>
-<category xml:id="tlaN4EKSVODAND4VALYASB5BQOFB4">
-<catDesc>26 = Modell</catDesc>
-<category xml:id="tlaXAP23YHBTNCCRJYJGDRHLURSE4">
-<catDesc>Modell</catDesc>
-</category>
-</category>
-<category xml:id="tlaOQCVRKIWEBFTHMH5XORMHYCMRM">
-<catDesc>4 = Sprachen</catDesc>
-<category xml:id="tla3SDSQWACYZBF5BQPORO2IYGKK4">
-<catDesc>Semitische Sprachen</catDesc>
-<category xml:id="tla5FQLDVWUMREZVLDMDUCGYRF3W4">
-<catDesc>Akkadisch</catDesc>
-</category>
-<category xml:id="tlaIIXDCYEWE5BJPG5JD4FC6NPLHM">
-<catDesc>Aramäisch</catDesc>
-</category>
-<category xml:id="tlaJH6OFL5DJJEY3OIDTSP6Q23CIU">
-<catDesc>Arabisch</catDesc>
-</category>
-<category xml:id="tlaKHIFJEW7S5DNRDEWECCC2LWKGY">
-<catDesc>Hebräisch</catDesc>
-</category>
-</category>
-<category xml:id="tlaIBMOCXFSHFFYXNIJ4M6LKU7ODM">
-<catDesc>Ägyptisch-Koptisch</catDesc>
-<category xml:id="tla3UOTPOGTZVBXJBAEKNXMOPSNG4">
-<catDesc>Ägyptisch</catDesc>
-<category xml:id="tla2MWPAPVOK5EORDGYCLKVMF2EPU">
-<catDesc>Mittelägyptisch</catDesc>
-<category xml:id="tlaGJKKSU5V6VHKBPVTIYQ4PFOBJ4">
-<catDesc>frühes und klassisches Mittelägyptisch</catDesc>
-</category>
-<category xml:id="tlaRXK2LXKUFREIJP2QQVZHHUSKLI">
-<catDesc>traditionelles Mittelägyptisch</catDesc>
-</category>
-</category>
-<category xml:id="tlaJ3SNMB4AF5ERPDGE4VPMBZSYRE">
-<catDesc>Neuägyptisch</catDesc>
-<category xml:id="tla6OVKIYNZEZCUHADVKMCAL6TTLQ">
-<catDesc>literarisches Neuägyptisch</catDesc>
-</category>
-<category xml:id="tlaG4CEYVBUZRDLLAEUPRZAOCVFNE">
-<catDesc>neuägyptische Geschäfts- und Kanzleisprache</catDesc>
-</category>
-</category>
-<category xml:id="tlaRYVHCFERAVCABE2VHI7FRKB6PM">
-<catDesc>Altägyptisch</catDesc>
-</category>
-</category>
-<category xml:id="tlaR3BF4BGUFFBMZFKMX3YMA4EINE">
-<catDesc>Koptisch</catDesc>
-<category xml:id="tla2AR6H4MCONHXBFZOQULXVCBNXI">
-<catDesc>Achmimisch</catDesc>
-</category>
-<category xml:id="tla5CYPHYWWSRDXZDXNVNER7YVZWU">
-<catDesc>Sahidisch</catDesc>
-</category>
-<category xml:id="tla5JGJ5FT7ORFFNOQTACML47C2GY">
-<catDesc>Bohairisch</catDesc>
-</category>
-<category xml:id="tlaBJTCRK7HFRCKDCYPXRFB47C2MU">
-<catDesc>Altkoptisch</catDesc>
-</category>
-<category xml:id="tlaFT6T5GHUDJAQDNG2UQEGD3YZWE">
-<catDesc>Fajumisch</catDesc>
-</category>
-<category xml:id="tlaMN53OUCBWNGCXLY5P7BE6VUFEA">
-<catDesc>Subachmimisch / Lykopolitanisch</catDesc>
-</category>
-<category xml:id="tlaPLXSBMH7A5B5RCGHOY5TLLPOGM">
-<catDesc>Mittelägyptisch / Oxyrhynchitisch</catDesc>
-</category>
-</category>
-<category xml:id="tlaWGLEOWZBQNE6TFLKV3JGNB66GE">
-<catDesc>Demotisch</catDesc>
-<category xml:id="tla6OQRGDEY5BDZFHKTHKPWB6EX7E">
-<catDesc>Frühdemotisch</catDesc>
-</category>
-<category xml:id="tlaTBCPVG5LEJEEBBCXKE6AWWALQA">
-<catDesc>ptolemäisches Demotisch</catDesc>
-</category>
-<category xml:id="tlaXOS6A6Q7ZRGYLNGNRZXGV2H75M">
-<catDesc>römisches Demotisch</catDesc>
-</category>
-</category>
-</category>
-<category xml:id="tlaIDQRSSGSQ5F6VEN3QEYVJHXBHM">
-<catDesc>Nilosaharanische Sprachen</catDesc>
-<category xml:id="tla6KPEYMCYMZEAJPTGC5HP3XRTJQ">
-<catDesc>nubische Sprache(n) der pharaonischen Zeit</catDesc>
-</category>
-<category xml:id="tlaS4SLR4HKWRCOXPZ32XG2QILYIA">
-<catDesc>Meroitisch</catDesc>
-</category>
-<category xml:id="tlaTWF73ENRUFGNHK4FPY33266TPM">
-<catDesc>Altnubisch</catDesc>
-</category>
-</category>
-<category xml:id="tlaSELUQECNFZHHFPC5WQM7T6IXB4">
-<catDesc>Indoeuropäische Sprachen</catDesc>
-<category xml:id="tlaN5K5S75ZMVEKNBRXZN7G2B2ECE">
-<catDesc>Griechisch</catDesc>
-</category>
-<category xml:id="tlaVDSLR44XTNAKZPIRJIAIZWE76M">
-<catDesc>Lateinisch</catDesc>
-</category>
-</category>
-</category>
-</taxonomy>
-</classDecl>
-</encodingDesc>
-</teiHeader>
-<text>
-<body>
-<p>No text.</p>
-</body>
-</text>
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Taxonomies for the AED - Version 0.1</title>
+        <respStmt>
+          <resp>compiler</resp>
+          <name>Peter Dils</name>
+          <name>Angela Böhme</name>
+          <name>Altägyptisches Wörterbuch</name>
+          <name>Anja Weber</name>
+        </respStmt>
+      </titleStmt>
+      <publicationStmt>
+        <publisher>someone</publisher>
+        <availability xml:lang="en" status="free">
+          <licence target="http://creativecommons.org/licenses/by-sa/4.0/">Metadata and texts are released as Creative Commons, Attribution-ShareAlike 4.0 (CC BY-SA 4.0)</licence>
+        </availability>
+        <date>heute</date>
+      </publicationStmt>
+      <sourceDesc>
+        <p>Based on <link target="urn:nbn:de:kobv:b4-opus4-29190"/> = Thesaurus of the TLA (<link target="http://aaew.bbaw.de/tla"/>)</p>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <classDecl>
+        <taxonomy>
+          <category xml:id="tlaZZWYPESU5FAC7D5ECPUHG44NO4">
+            <catDesc>31 = Zustand</catDesc>
+            <category xml:id="tlaEICEWSLI4RFWHMCXGBCXS4TETM">
+              <catDesc>fragmentarisch</catDesc>
+            </category>
+            <category xml:id="tlaEPPC4OJ555HDTBPYWWL7XCG56A">
+              <catDesc>vollständig</catDesc>
+            </category>
+            <category xml:id="tlaJ6AQL2TE6VH3RKTBK6FHAGQJ6A">
+              <catDesc>unbestimmt</catDesc>
+            </category>
+          </category>
+          <category xml:id="tla42VQWCPXKRA4VCE4WKSGZMTSWY">
+            <catDesc>22 = Komponente</catDesc>
+            <category xml:id="tla2CBV5TBESBA3DDRJGFY5S4XWFA">
+              <catDesc>Stütze</catDesc>
+              <category xml:id="tla3E6OENGZ3NB7VGUHAS5WEV26H4">
+                <catDesc>Säule</catDesc>
+                <category xml:id="tla2ZL4XRLN4VHHTKCREGH2F564E4">
+                  <catDesc>Lotossäule</catDesc>
+                </category>
+                <category xml:id="tlaA3XMXLX36JC5TNCGDPFCZQGQXM">
+                  <catDesc>Halbsäule</catDesc>
+                </category>
+                <category xml:id="tlaUAXPZZF4FZB7FPSJKBEZOB6DDQ">
+                  <catDesc>Zeltstangensäule</catDesc>
+                </category>
+                <category xml:id="tlaUCNYVVRUIJERVEM6PO7AIJJRMI">
+                  <catDesc>Papyrusbündelsäule</catDesc>
+                </category>
+                <category xml:id="tlaYCLNKJNVOZFRFAYNQJEUDNYZ6Y">
+                  <catDesc>protodorische Säule</catDesc>
+                </category>
+              </category>
+              <category xml:id="tla7VEAOTTHR5D3DMYJDV2U5HLMZY">
+                <catDesc>Pfeiler</catDesc>
+                <category xml:id="tla2IWK4VOUDZAUTEU5IS3P4GUXTE">
+                  <catDesc>Rückenpfeiler</catDesc>
+                </category>
+                <category xml:id="tlaEA4PO22EERABDFK5UULHOTFCZU">
+                  <catDesc>Statuenpfeiler</catDesc>
+                  <category xml:id="tlaVETN43WACRGCVFQGK4YCNVOMTI">
+                    <catDesc>Osirispfeiler</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaES7MCMBMGNGJ7E6M5X626PB7E4">
+                  <catDesc>Reliefpfeiler</catDesc>
+                  <category xml:id="tlaIK2YYENWGZAZBFSL4MIEDGV6SM">
+                    <catDesc>Hathorsäule / -pfeiler</catDesc>
+                  </category>
+                  <category xml:id="tlaIREACYALRRBURGP4MKYMDJTSAA">
+                    <catDesc>Wappenpflanzenpfeiler</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaQSF7VQGYQFB5DBYI23GFW5I5NE">
+                  <catDesc>Oktogonalpfeiler</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaHRUHQD5C2FHSTJYXW5Q7Q6AAGQ">
+                <catDesc>Pilaster</catDesc>
+              </category>
+            </category>
+            <category xml:id="tla3DYLEF6K45DTRMKYFVDZSRWL2U">
+              <catDesc>Pyramidion</catDesc>
+            </category>
+            <category xml:id="tla4BRO67SGNRBJXPNF3PN4JCZRYQ">
+              <catDesc>Säulentrommel</catDesc>
+            </category>
+            <category xml:id="tla4JO3TTA3JJBBFPVI466MLWKSOY">
+              <catDesc>Altar</catDesc>
+            </category>
+            <category xml:id="tla4X5ASCFQXRECLMHVT6HO35A32Q">
+              <catDesc>Fixierelement</catDesc>
+              <category xml:id="tlaJFL52MW6WBAU5KHGVBSZV3OOYU">
+                <catDesc>Flachdübel</catDesc>
+              </category>
+              <category xml:id="tlaRLCJUW4TXFERPBNBF5AWWLEQEE">
+                <catDesc>Schwalbenschwanzklammer</catDesc>
+              </category>
+            </category>
+            <category xml:id="tla55YZ4SFE5JH63BBO4G6V4FYNQY">
+              <catDesc>Rahmen</catDesc>
+            </category>
+            <category xml:id="tla5I2ZW5FHC5EGTJAPOK74GJ6H6Y">
+              <catDesc>Abacus</catDesc>
+            </category>
+            <category xml:id="tla5YZWVI3KP5HQRJCV7L2TTRXWGE">
+              <catDesc>Obelisk</catDesc>
+            </category>
+            <category xml:id="tla6KHHGJLJ35GPNMKND64IBPWXXE">
+              <catDesc>Basis / Standplatte</catDesc>
+            </category>
+            <category xml:id="tla6WLOEG2MORAWLNEZPZBHNUASWA">
+              <catDesc>Mauer</catDesc>
+              <category xml:id="tlaVJONX36OKNA3VLZEIOVNZ37AFA">
+                <catDesc>Umfassungsmauer</catDesc>
+              </category>
+              <category xml:id="tlaXL76XAXJ5BBKTKUKNYQCNVRDTQ">
+                <catDesc>Palastfassadenmauer</catDesc>
+              </category>
+              <category xml:id="tlaYRDE7JAJANG7LITTW4PJ2ZEBGU">
+                <catDesc>Wellenmauer</catDesc>
+              </category>
+            </category>
+            <category xml:id="tla7QDLKQDQSRENHNADLIFETVUHEY">
+              <catDesc>Ständer</catDesc>
+            </category>
+            <category xml:id="tlaBWBUYO5XKFHXND2Q22HDNGPBX4">
+              <catDesc>Verschluss</catDesc>
+              <category xml:id="tlaFQZPT6WLOBDRJB2PUM4YHXCRXI">
+                <catDesc>Riegel</catDesc>
+              </category>
+              <category xml:id="tlaIR7KWBPA5NBJRAV7HBUIU4UPUQ">
+                <catDesc>Stopfen</catDesc>
+              </category>
+              <category xml:id="tlaNGU5WOAESVEOVK6FBF74ZKLQYI">
+                <catDesc>Deckel</catDesc>
+              </category>
+              <category xml:id="tlaRW4WWT3MKNCSZKOZXGAMSH5XAI">
+                <catDesc>Plombierung</catDesc>
+                <category xml:id="tlaJIJLTWRSGJHLPNM6AX76SJJ2BI">
+                  <catDesc>Klumpen</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaZKLDI6SUCZA4XOSV3PJNALBTRQ">
+                <catDesc>Knauf</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaCP5BO2LDS5EXTCBIK7PQYRONFE">
+              <catDesc>Pylon</catDesc>
+            </category>
+            <category xml:id="tlaCTXME3US35BCFGZFSKEECMIXEE">
+              <catDesc>Pyramide</catDesc>
+            </category>
+            <category xml:id="tlaD2TBGO3L3VB2XMVS3FGKIYKICI">
+              <catDesc>Einlage</catDesc>
+              <category xml:id="tla5A62UW4HVRGTRNABJRIV5VBYVM">
+                <catDesc>Grabkegel</catDesc>
+              </category>
+              <category xml:id="tlaVWMPIUY3FJF2TEUYOARB6ZR6SE">
+                <catDesc>Kachel</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaDRJ4J5PX5RGEFAWL3QY5CNP5G4">
+              <catDesc>Griff &amp; Henkel</catDesc>
+            </category>
+            <category xml:id="tlaDZAW646H4ZBQHEEZZHLE24VR4M">
+              <catDesc>Raum</catDesc>
+              <category xml:id="tla32WTLATMOVGQXFD6G2XCGLVAQA">
+                <catDesc>Speisesaal</catDesc>
+                <category xml:id="tlaKVNDPPBIFZGGBAQXWVGE45EY5Q">
+                  <catDesc>Opfertischsaal (Tempel)</catDesc>
+                </category>
+                <category xml:id="tlaLMFRX3ZEVFA55H7ZBS7KD6YXQQ">
+                  <catDesc>Refektorium</catDesc>
+                </category>
+              </category>
+              <category xml:id="tla3AASO4EHYRD6VMAMPM2MISN66U">
+                <catDesc>Barkenraum</catDesc>
+              </category>
+              <category xml:id="tla7NKDXUABEJCETNYNKYQXXJXUBU">
+                <catDesc>Krypta</catDesc>
+              </category>
+              <category xml:id="tlaC24FBQDROJEWNOI3ZK2CIZILYI">
+                <catDesc>Sanktaur / Allerheiligstes</catDesc>
+              </category>
+              <category xml:id="tlaDN77FVWFYFFHPJOKZMVJGY3VNI">
+                <catDesc>Serdab</catDesc>
+              </category>
+              <category xml:id="tlaDWEWYQUVW5F2ZDLIM2MD73IK5I">
+                <catDesc>Grabkammer</catDesc>
+              </category>
+              <category xml:id="tlaECROFKMWINBO7IY4ZETDPLMAZI">
+                <catDesc>Treppenhaus</catDesc>
+              </category>
+              <category xml:id="tlaEROENXHNDBDB3IXLXN3MGWQGYI">
+                <catDesc>Längshalle (TT)</catDesc>
+              </category>
+              <category xml:id="tlaHIKUSPBKJFC5RDCFIMPTCHASZA">
+                <catDesc>Entlastungskammer</catDesc>
+              </category>
+              <category xml:id="tlaI5GWESQ6RVCEXLWOFCL7FKGDII">
+                <catDesc>Querhalle (TT)</catDesc>
+              </category>
+              <category xml:id="tlaJWJ7HWJUUNC5FEEQ7GKCJI4ZGA">
+                <catDesc>Kolonnade</catDesc>
+              </category>
+              <category xml:id="tlaK737M2VGRFDSLLHMXETLSGJGHE">
+                <catDesc>Hypostyl / Säulenhalle</catDesc>
+              </category>
+              <category xml:id="tlaKKMBVKIKQBGKHFWDU4K76V3QGY">
+                <catDesc>Schacht</catDesc>
+              </category>
+              <category xml:id="tlaL22ZAGE7XZHV7BWX7HEKQ7G6VA">
+                <catDesc>Hof</catDesc>
+                <category xml:id="tlaIDE6SM4VHJFEXD5NBMJ32QJITA">
+                  <catDesc>Lichthof</catDesc>
+                </category>
+                <category xml:id="tlaVE6HF2APKRGDRIJQ6JZHFSL63Q">
+                  <catDesc>Vorhof / Vorplatz</catDesc>
+                </category>
+                <category xml:id="tlaW5JIOWYPSZCXRHAKUPBORDIUUE">
+                  <catDesc>Säulenhof / Peristylhof</catDesc>
+                </category>
+                <category xml:id="tlaZD54ACJMXRHK3O4Z3LKFB7GEHI">
+                  <catDesc>Sonnenaltarhof</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaRWQCB5LXKJEHHFPIESQSO34HAU">
+                <catDesc>Magazinraum</catDesc>
+              </category>
+              <category xml:id="tlaRWXDM4BCE5AUHLT7G5WBC2HTK4">
+                <catDesc>Barkensanktuar</catDesc>
+              </category>
+              <category xml:id="tlaUZLZJ7COMZBFBF7GVW7KTCQZCI">
+                <catDesc>Totenopferraum</catDesc>
+              </category>
+              <category xml:id="tlaV22IABB6YFBAVLSKWLHTFOLUMU">
+                <catDesc>Korridor</catDesc>
+              </category>
+              <category xml:id="tlaVG2L3E5RLFCULEK5CZRNVPOI6E">
+                <catDesc>Reinigungsraum</catDesc>
+                <category xml:id="tlaJAGXC6GPQJH3ZOHEKPALX3YV3Q">
+                  <catDesc>Reinigungsbrunnen (Moschee)</catDesc>
+                </category>
+                <category xml:id="tlaS7QU7NEC65EHRNITXTWLDV22OA">
+                  <catDesc>Bad</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaYUMSK4GHU5E2DH2YS2JS3OLS4A">
+                <catDesc>Pronaos</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaEQF3JGXWIRDFRC7SGIXK4UPUFU">
+              <catDesc>Wasserspeier</catDesc>
+            </category>
+            <category xml:id="tlaF3BRJFT7U5HJ7MXZ47RJ44HXJU">
+              <catDesc>Decke</catDesc>
+              <category xml:id="tlaIIUJ6RUFLNDSJN5N64KALE5KV4">
+                <catDesc>Balkendecke</catDesc>
+              </category>
+              <category xml:id="tlaTEJYLHONBBCPVHW5XWMAJNIKXE">
+                <catDesc>Gewölbe</catDesc>
+                <category xml:id="tlaFOSXMHMJKZA6HE4A5SPBWNRV6Y">
+                  <catDesc>Scheingewölbe</catDesc>
+                </category>
+                <category xml:id="tlaQVTETO5MBNBPNC2HL2CEYW62RA">
+                  <catDesc>Tonnengewölbe</catDesc>
+                </category>
+                <category xml:id="tlaZCS4ESJOLFHU7KSN6YJ5QP2VDA">
+                  <catDesc>Kraggewölbe</catDesc>
+                </category>
+              </category>
+            </category>
+            <category xml:id="tlaGHMRAQY5Z5DTPLAXWE57EKWC2Y">
+              <catDesc>Laibung</catDesc>
+            </category>
+            <category xml:id="tlaID2IA3T5PREWRGADU7VVBIDZRI">
+              <catDesc>Sockel</catDesc>
+            </category>
+            <category xml:id="tlaIGXF5ZVEI5ALPHRZKHMJFUA2FQ">
+              <catDesc>Architrav</catDesc>
+            </category>
+            <category xml:id="tlaISLG6MXASBFKJD3RYBEVXQ4LBU">
+              <catDesc>Tür</catDesc>
+              <category xml:id="tla2L6RZ4PAZREGDE4E7WLH255UGI">
+                <catDesc>Scheintür</catDesc>
+                <category xml:id="tlaIXXEPFLHGJGXJJLEW33LE4QYKA">
+                  <catDesc>Prunkscheintür</catDesc>
+                </category>
+                <category xml:id="tlaS3VSVDAGIRGAPHUGFBL4BKO2Z4">
+                  <catDesc>Mittelstützenscheintür</catDesc>
+                </category>
+                <category xml:id="tlaZJIVEZKTMFDILDEOQKI33YYW24">
+                  <catDesc>Normalscheintür</catDesc>
+                </category>
+              </category>
+            </category>
+            <category xml:id="tlaJ3ZM4CQXGBBARBBNWN3TVXJH2Y">
+              <catDesc>Fassade</catDesc>
+            </category>
+            <category xml:id="tlaJ43UX5HS3REBHETB744F5VZYYI">
+              <catDesc>unbekannt</catDesc>
+            </category>
+            <category xml:id="tlaJKM6TBMSG5AUPBPGOX62FUTN54">
+              <catDesc>Terrasse</catDesc>
+            </category>
+            <category xml:id="tlaKECXMHLYQNHHRPPWVM4ELXLCFE">
+              <catDesc>Ziegel</catDesc>
+              <category xml:id="tla4VSRXVGX6BGOFJLYK5G7SBNVRU">
+                <catDesc>Friesziegel</catDesc>
+                <category xml:id="tlaPMZMQEWSP5HUHBO5BJESAMWW4U">
+                  <catDesc>Grabkegel</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaJ7NTYP4WFNDKPJ5MZEGESVDLGE">
+                <catDesc>Mauerziegel</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaKEH3I2FU65AK3JY3XQN2Q6CPCY">
+              <catDesc>Nische</catDesc>
+              <category xml:id="tlaFBDSJJRBUFESBKA2DXTSMX6GBU">
+                <catDesc>Tornische (Spätzeitgräber</catDesc>
+              </category>
+              <category xml:id="tlaJO46ZD3ULZEZDHB4QWB6QMB35M">
+                <catDesc>Gebetsnische</catDesc>
+              </category>
+              <category xml:id="tlaTVLT4A4BHRARFMUSVGNVW5NG7A">
+                <catDesc>Fahnenmastnische</catDesc>
+              </category>
+              <category xml:id="tlaUTOHZ3KHONHYLA46AQSMGIGEYQ">
+                <catDesc>Statuennische</catDesc>
+              </category>
+              <category xml:id="tlaYQ5R65R6FRB6JDCCYD5V6T2OWY">
+                <catDesc>Scheintürnische</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaLB4BCDDMWZCJ5GBVNUVP6ELV5Y">
+              <catDesc>Steinblock</catDesc>
+              <category xml:id="tla6N6MLULAR5FBZCG65ZD4TDLUAQ">
+                <catDesc>Spolie</catDesc>
+              </category>
+              <category xml:id="tla756O4LU6DBD73AKXGDJC554AMY">
+                <catDesc>coping block</catDesc>
+              </category>
+              <category xml:id="tlaCKA5PIRNDBG2JLRW7KRJADNQ6E">
+                <catDesc>Gesimsblock</catDesc>
+              </category>
+              <category xml:id="tlaER33D7RKHBA7BLNLBNHRPA7IN4">
+                <catDesc>casing stone</catDesc>
+              </category>
+              <category xml:id="tlaLX3Y4CC32VEK7AEFIR24H5WLCQ">
+                <catDesc>Talatat</catDesc>
+              </category>
+              <category xml:id="tlaTA2WZDK3UFD7XN5AIU3NB66LUA">
+                <catDesc>Fallstein</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaLPN6Y6VN4JCRPPVBJ4XODXB6FE">
+              <catDesc>Fenster</catDesc>
+              <category xml:id="tlaFPJDBNF3GRG7LDWISQGBBMNHEY">
+                <catDesc>Lichtschacht</catDesc>
+              </category>
+              <category xml:id="tlaYGCBSINXMRB7FAHNP6YQJ75NM4">
+                <catDesc>Erscheinungsfenster</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaM74COZQB5JD25M2HPEWPFXU334">
+              <catDesc>Gitter</catDesc>
+              <category xml:id="tla7ML2BZPRFNBIFKJ5P6BCYFIZ4Y">
+                <catDesc>Lattenrost</catDesc>
+              </category>
+              <category xml:id="tlaJKIVOS4WKVGZBPEH6KK4RG7QVU">
+                <catDesc>Fenstergitter</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaN7CPDTDAZZC57E5N56HKNXAEDQ">
+              <catDesc>Flügel / Blatt</catDesc>
+            </category>
+            <category xml:id="tlaNZSM5HFQYNHLHFZJUHHCYD3Z74">
+              <catDesc>Zuwege / Wege</catDesc>
+              <category xml:id="tlaHVJLOIF4UFBFLPFGJ3LV2CDWOQ">
+                <catDesc>Sphinxallee</catDesc>
+              </category>
+              <category xml:id="tlaXUYBXBA6XFBW3JR7LQGCNWZDSA">
+                <catDesc>Aufweg</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaPWGM75NZGRA57OF5OMLBT7LMPI">
+              <catDesc>Hohlkehle + Rundstab</catDesc>
+            </category>
+            <category xml:id="tlaPZOFZZSGIBC57JWRXFJ3PNJ7KI">
+              <catDesc>Giebel</catDesc>
+              <category xml:id="tlaU32IERSR7NE6XLLUC6R5DDKZ4A">
+                <catDesc>Sprenggiebel</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaQ2SYQ5XAZJG7HIEUSSLOP4I7OU">
+              <catDesc>Wand</catDesc>
+              <category xml:id="tlaMDOE7AUJDZF4PNZJ26FFXI45L4">
+                <catDesc>Nischenwand</catDesc>
+              </category>
+              <category xml:id="tlaMGZVRRGHONCKZLR63ZJOXAO7FE">
+                <catDesc>Interkolumnium</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaSSTXKEQK2REINMKVMJ7Y4T7SVM">
+              <catDesc>Aufgang</catDesc>
+              <category xml:id="tlaCF7DBMTN2REZ7HFYMRTCD75YJQ">
+                <catDesc>Rampe</catDesc>
+              </category>
+              <category xml:id="tlaWNN3BAMQYZEGFO3RJXDWY6FHZA">
+                <catDesc>Treppe</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaTA6Q2AX6WNDLXEQMPCMABU6QHY">
+              <catDesc>Mumienporträt</catDesc>
+            </category>
+            <category xml:id="tlaTF7EPBLNS5HGNHFJBSOTDPA7R4">
+              <catDesc>Kopf- / Aufsatzstück</catDesc>
+            </category>
+            <category xml:id="tlaU3LTOG7CZZGAZNAE2FOPGQOXD4">
+              <catDesc>Türrolle</catDesc>
+            </category>
+            <category xml:id="tlaVHZ5AFIKHBCGFFLWC7MYJB7EQE">
+              <catDesc>Bein</catDesc>
+            </category>
+            <category xml:id="tlaVPNPQPLHDBE7RJMZ7G4EFUDD2A">
+              <catDesc>Schaft</catDesc>
+            </category>
+            <category xml:id="tlaW45TXQORPZA3FJDFPJFBNZLD6U">
+              <catDesc>Kapitell</catDesc>
+              <category xml:id="tla7RPOC2C7S5DBNGTZ25SJ6F44TE">
+                <catDesc>dorisches Kapitell</catDesc>
+              </category>
+              <category xml:id="tlaA44PJPEO75HRVOPXQ3ZDFB4AWU">
+                <catDesc>Papyruskapitell</catDesc>
+                <category xml:id="tlaSOIHFQHJZNFBHCTLSI4U6Q3OUE">
+                  <catDesc>offenes Papyruskapitell</catDesc>
+                </category>
+                <category xml:id="tlaUJW4APUQPBD7BFBYOKEP3XMEI4">
+                  <catDesc>geschlossenes Papyruskapitell</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaARHP3FALBJA5HDDSA56PSHJBGE">
+                <catDesc>Palmenkapitell</catDesc>
+              </category>
+              <category xml:id="tlaGHAQMG6CE5BNVEWVNFTGUAO5MU">
+                <catDesc>Kompositkapitell</catDesc>
+              </category>
+              <category xml:id="tlaNK4ENUFGUFB23ASLPK55MDH7DE">
+                <catDesc>Hathorkapitell</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaW4UDOKUXIFG25MI3IZGMHWEJQ4">
+              <catDesc>Lunette</catDesc>
+            </category>
+            <category xml:id="tlaWCICGZUQKVEBRAG5PVX7VHS5LY">
+              <catDesc>Pfosten</catDesc>
+            </category>
+            <category xml:id="tlaWLBV5TPMDRH2PJ23FIYN6LBNHI">
+              <catDesc>Dach</catDesc>
+              <category xml:id="tlaH2I24BJF5BAPZFBYKWVVXXAN2I">
+                <catDesc>Flachdach</catDesc>
+              </category>
+              <category xml:id="tlaWRPREVWANJCAPOWWUKQRTNIPHU">
+                <catDesc>Giebeldach</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaWQGBNVOZQZD7FECJPRLX724TWM">
+              <catDesc>Fußboden</catDesc>
+            </category>
+            <category xml:id="tlaX5C6WY3M7VBWZBEQHR5EYMK7UM">
+              <catDesc>unbestimmt</catDesc>
+            </category>
+            <category xml:id="tlaXUJVLCQKKZDSXDCE7Y6TWZGPYY">
+              <catDesc>Supraporte</catDesc>
+            </category>
+            <category xml:id="tlaXZYBOSB3RJFPDEAMFEXKEDQYN4">
+              <catDesc>Klinge</catDesc>
+              <category xml:id="tla7UMTHAL2UBFA7P4VAPLSTSL37A">
+                <catDesc>Netjerui-Klinge</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaYPVD27R3SBHPLJUFB5SJYAHBMQ">
+              <catDesc>Sturz</catDesc>
+            </category>
+          </category>
+          <category xml:id="tlaRJLJDROM3ZAH7DOSBYM3YZC5XY">
+            <catDesc>2 = Aufbewahrungsorte, Museen</catDesc>
+            <category xml:id="tla3FCBF7YMYBDXLEBSFXKBWTAXCE">
+              <catDesc>(unbestimmt)</catDesc>
+            </category>
+            <category xml:id="tlaDO564E6CRJC4BJJJZIPHCFXZHM">
+              <catDesc>(Privatsammlung)</catDesc>
+            </category>
+            <category xml:id="tlaHPUFUHJMEZF7ZGM2VXBQNHZUYM">
+              <catDesc>Europa</catDesc>
+              <category xml:id="tla37NMIQHT5FAOVISLYKNKP2HGYY">
+                <catDesc>Schweden</catDesc>
+                <category xml:id="tla6EQ2CASSQFF5VBTYOJU3VL4POQ">
+                  <catDesc>Malmö</catDesc>
+                  <category xml:id="tlaM5Z3ORYCPVFF3PI3WPH5ND3MYE">
+                    <catDesc>Museer, Ägyptische Sammlung</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaQOWEQH5UBJFPPFUEL6Y26XSDPM">
+                  <catDesc>Mora</catDesc>
+                  <category xml:id="tla2NZP4HLIFRE4ZA3EUDXA2EVYUU">
+                    <catDesc>Zornsamlingarna</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaQVZ5VE5L3ZHXHNWCPBMSTVBWHA">
+                  <catDesc>Stockholm</catDesc>
+                  <category xml:id="tlaGRENVJZJUBFK7J7CGIXNNRN3J4">
+                    <catDesc>Medelhavsmuseet</catDesc>
+                  </category>
+                  <category xml:id="tlaQXVL656JQZE55K7WRUIX2ESREA">
+                    <catDesc>Cypernsamlingarna</catDesc>
+                  </category>
+                  <category xml:id="tlaTBHPPILVFNHTHF7DTH6KUF4PCA">
+                    <catDesc>Nationalmuseum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaRESFLL5O3FGRXKJ64YHEDV425U">
+                  <catDesc>Linköping</catDesc>
+                  <category xml:id="tlaJNWO4U3TEVCAVL6UMH2A6VLSOM">
+                    <catDesc>Stifts och Landsbibliothek</catDesc>
+                  </category>
+                  <category xml:id="tlaLXKVR7K3HVAMPPXCOXO4W3KPH4">
+                    <catDesc>Östergötlands och Linköpings Stadsmuseum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaTC74N3OJMNEGBP2H5DZVMJ5XVA">
+                  <catDesc>Vanersborg</catDesc>
+                  <category xml:id="tlaBUQCIAN4ONC6NI7UZBAASVYEB4">
+                    <catDesc>Vanersborgs Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaUXRD63GUDNGYBNO2WEL254T6AA">
+                  <catDesc>Kristianstad</catDesc>
+                  <category xml:id="tlaTFT7IPO45BEM5NEAPDTXVBXTS4">
+                    <catDesc>Kristianstads Landsmuseum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaVYV63BTZU5GIFCF4MWN52HFAL4">
+                  <catDesc>Lund</catDesc>
+                  <category xml:id="tlaISPFLTPGD5GIZMS5NUTKVEYE7A">
+                    <catDesc>Kulturhistoriska Museet</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaZBQYEE43IVHMDAIW5O2B6AFWPI">
+                  <catDesc>Uppsala</catDesc>
+                  <category xml:id="tla2EZGVZFPFRG4HPBO3544PM55FE">
+                    <catDesc>Victoriamuseet för Egyptiska Fornsaker</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tla3RBC5HKEVRHSFBYBMPHCAXU2WE">
+                <catDesc>Griechenland</catDesc>
+                <category xml:id="tlaGBX34TGAMJFE3DNY34GW4MIXYE">
+                  <catDesc>Sparta</catDesc>
+                  <category xml:id="tlaYKWOUYRWHFFMZI2L2H3Z5IQTRE">
+                    <catDesc>Archaeological Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaI2QZVIMZKNAINCTJNIVGGKUQRY">
+                  <catDesc>Delos</catDesc>
+                  <category xml:id="tlaVJ67ZJBBTJGGDCEMEG3GW4BBRE">
+                    <catDesc>Archaeological Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaJNDEKHFPV5EOFJUOBS6TEMUXQI">
+                  <catDesc>Athen</catDesc>
+                  <category xml:id="tla7LKLWZRVQBBD7B26FT6OZSX7WA">
+                    <catDesc>National Archaeological Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaO6RLNOMQXVHR5F72F3S24RZVVY">
+                    <catDesc>Kanellopoulos Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaLP43BXG7NJCRBBDM6ZYEZCS4PE">
+                  <catDesc>Iraklion</catDesc>
+                  <category xml:id="tlaTBZFB4OXOJF4XDTRHLO57M5XQM">
+                    <catDesc>Archaeological Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaNERPVQEKCNGPLN4YOUWL54TZIA">
+                  <catDesc>Chios</catDesc>
+                  <category xml:id="tlaKH46WS664VHRJLSXYPEDOSMA2E">
+                    <catDesc>Archaeological Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaNZPTUNNRTBDT3BQKY2CV3I4JGE">
+                  <catDesc>Phaistos</catDesc>
+                  <category xml:id="tlaDJOVKFVYBFHKNHV7KFMM3ZKEMI">
+                    <catDesc>Museum Candia</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaPVXJQAVDORDFLLWICCZCPEOR4M">
+                  <catDesc>Rhodos</catDesc>
+                  <category xml:id="tlaSIKXUNJBLJCR7BV7GZCYVE5HJA">
+                    <catDesc>Rhodos Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaU4UK6OULCJCKDDPYLYL2ANMGFE">
+                  <catDesc>Samos</catDesc>
+                  <category xml:id="tlaZTBKPCOOLJDL7H3UEYVCHQ32TA">
+                    <catDesc>Archaeological Museum of Vathy</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tla52CWIGKMEBFGLBT5CAL7V2PECQ">
+                <catDesc>Ungarn</catDesc>
+                <category xml:id="tla6PMFVRIHG5H4FIEQICRY5FMN6Y">
+                  <catDesc>Budapest</catDesc>
+                  <category xml:id="tlaHTTJJDSLQFFMVPOIIYLZT4TNB4">
+                    <catDesc>Szépmüvészeti Múzeum</catDesc>
+                  </category>
+                  <category xml:id="tlaMES6PQUTJRD2FBMNLWI2MTZEPM">
+                    <catDesc>Magyar Nemzeti Muzeum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla6ZXQXRMMGRC2FJB743EADHBQ7E">
+                  <catDesc>Zirc</catDesc>
+                  <category xml:id="tlaH35ZPICQXBBQ7LBOGCCO5WYIOM">
+                    <catDesc>Múzeum Antal Regály</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaA6OZZVJWJFHINGHWFUDBBJBGX4">
+                  <catDesc>Papa</catDesc>
+                  <category xml:id="tlaFHAQ3YO5XRGFVMMXAL5REU77AU">
+                    <catDesc>Dunántuli Egyháztorteneti és Egyházmüvészeti Múzeum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaALNQ5AYNWBAFTH6XIKE5T77A7U">
+                  <catDesc>Szombathely</catDesc>
+                  <category xml:id="tla5CMFBNW4OJFB7FNSJ3MNE44BCM">
+                    <catDesc>Savaria Múzeum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaFKZFA4S76JBVTD3HUO3CJATQII">
+                  <catDesc>Székesfehérvár</catDesc>
+                  <category xml:id="tlaJPWEBBYODZHZ5FYNPRYPGXMFPM">
+                    <catDesc>István Király Múzeum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaTDSYQV2KQRFUFFPNEAKN66KG64">
+                  <catDesc>Debrecen</catDesc>
+                  <category xml:id="tla572DX2U7MNA33HUCK2QJKCVP7E">
+                    <catDesc>Déri Múzeum</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaALPPWH2JPVE5BH4BZMPCTP7EVM">
+                <catDesc>Irland</catDesc>
+                <category xml:id="tla22SGRPV56NGFBEBA446MV4LKZY">
+                  <catDesc>Island</catDesc>
+                  <category xml:id="tla46DF53SQXRAUNE373LKKHQHIDY">
+                    <catDesc>Reykjavik</catDesc>
+                    <category xml:id="tla6CPFQFH7BBGX3ITZBP6WW3EPSY">
+                      <catDesc>Thjodminjasafn</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tlaKNUADDX6PZABDCJU5DARMHPCE4">
+                  <catDesc>Cork</catDesc>
+                  <category xml:id="tlaMMHNK5ABVRGG7JQER7E7BASUDM">
+                    <catDesc>Boole Library, University College</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaMN6YZGZYC5GGXOBRNMKDEG7DGE">
+                  <catDesc>Dublin</catDesc>
+                  <category xml:id="tla3AIH5N3DDBAZTCZ7QSHSEG52KM">
+                    <catDesc>Chester Beatty Library</catDesc>
+                  </category>
+                  <category xml:id="tlaJFGDOUD2BVDJLDBZU7VZTMDJZU">
+                    <catDesc>National Museum of Ireland</catDesc>
+                  </category>
+                  <category xml:id="tlaM7GSGJLTV5HUJITBRZCLG5XPT4">
+                    <catDesc>Trinity College, Weingreen Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaPTZGAFFCPNFYRJJZ2T2A2NQGV4">
+                    <catDesc>University College</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaB2JLY6JETRGCLFE6BUCQW23AAU">
+                <catDesc>Jugoslawien</catDesc>
+                <category xml:id="tla4M55E5BDSZDILGBQW4N4MF66XM">
+                  <catDesc>Belgrad</catDesc>
+                  <category xml:id="tlaCVN6XIIMBNGSNEMKIU35SDXUD4">
+                    <catDesc>Narodni Muzej</catDesc>
+                  </category>
+                  <category xml:id="tlaFB4SXC7EYRGLFDQJ6UYGDFVX3E">
+                    <catDesc>Memorial Centre Josip Broz Tito</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaBJ6BV7WHJVCRDJQH6AVCGDLYSE">
+                <catDesc>Russland</catDesc>
+                <category xml:id="tla3TAFQPV63FATHF4UNMSU5GN6WY">
+                  <catDesc>Kazan</catDesc>
+                  <category xml:id="tlaQNJMT4YSPFDGRHN3MNTRTTN66E">
+                    <catDesc>State Republical Museum of Tatarstan</catDesc>
+                  </category>
+                  <category xml:id="tlaQRLSIA6TKFEWPBPJGWCMB3WWBM">
+                    <catDesc>Regional Museum of the Chechen Republic</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla4SHPASAHSBDWJLMRKXTIBK3ONM">
+                  <catDesc>Rostow</catDesc>
+                  <category xml:id="tlaFGNKQZOZXJDJZLPUFXL274VWZI">
+                    <catDesc>Rostov Regional Museum of Fine Arts</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla7265TWEHZBDWRHUNNAYI7UMH5U">
+                  <catDesc>Jekaterinenburg</catDesc>
+                  <category xml:id="tla6BPV4LYUVBC27L75WYUGIEWHZ4">
+                    <catDesc>Jekaterinenburg State Museum of History</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla7WFPRL5U6BCBPCY6IJ63NXPMBU">
+                  <catDesc>Tambow</catDesc>
+                  <category xml:id="tla5CMTOWOERNBEPNKHGLK64ALBKA">
+                    <catDesc>Tambov Regional Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaBX25OPHACFH6PFGGR73OLMKAHA">
+                  <catDesc>Irkutsk</catDesc>
+                  <category xml:id="tlaLWK7WRXVINGVXKG3K2NWNTL4UQ">
+                    <catDesc>Irkutsk Regional Museum of Art</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaEEMGG645AJDWHD56D7E7BMKK7Q">
+                  <catDesc>Moskau</catDesc>
+                  <category xml:id="tlaBZPDEX62XBAFDPOBXKYGDMHCUM">
+                    <catDesc>State Pushkin Museum of Fine Arts</catDesc>
+                  </category>
+                  <category xml:id="tlaDVNBKBS3GREXBCHDHPMUWZF644">
+                    <catDesc>State Historical Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaEEIVGEWIPZGA3IK6HQIWG5PP4M">
+                    <catDesc>Glinka State Central Museum, Central State Museum of Musical Culture</catDesc>
+                  </category>
+                  <category xml:id="tlaEY5RRZIDOZDDRCI5GBYNAJMLGQ">
+                    <catDesc>State Museum of Oriental Art</catDesc>
+                  </category>
+                  <category xml:id="tlaQZXWIZJNJNEIVATVX7BX74WFQU">
+                    <catDesc>Country Museum Arkhangelskoya</catDesc>
+                  </category>
+                  <category xml:id="tlaZ5JZKIN6NNCQTNKGUEFGR2YEQM">
+                    <catDesc>State Abramtsevo Museum, Collection of History, Art and Literature</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaEGJ3AKIS6RFAPMI67D4L2PVNBQ">
+                  <catDesc>Woronesh</catDesc>
+                  <category xml:id="tlaK623WPDFSNBLJOMESEMFFJZZKM">
+                    <catDesc>Oblastnoj chud. Muzej</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaGFYOWA2JRRCKLG6IXEKM56T33M">
+                  <catDesc>Ivanova</catDesc>
+                  <category xml:id="tla6EW2ANCWIRHJNHX4LLZIDNO2XI">
+                    <catDesc>Ivanova Regional Museum of Art</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaLL2EFFZHWJHKXNTLGHLSJNLSLY">
+                  <catDesc>Murom</catDesc>
+                  <category xml:id="tla5KFTM6UMBVGC5JREY7P5ICUKBM">
+                    <catDesc>Murom Regional Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaNFI7AKDVEFCQBHNH6HYHRXD4EA">
+                  <catDesc>Kertsch</catDesc>
+                  <category xml:id="tlaDVSAGXELTFEKJBXDV5SFP3RB3Q">
+                    <catDesc>Kerch Museum of History and Archaeology</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaNWFNAAKNJVESRH2OWF7O455E4A">
+                  <catDesc>St. Petersburg</catDesc>
+                  <category xml:id="tlaAA6TRKGF2BAVNDT3IFAHEW3FQY">
+                    <catDesc>Museum of the History of Religion</catDesc>
+                  </category>
+                  <category xml:id="tlaDLE7NWSLKZEQ3A2SLB6H5K2MDA">
+                    <catDesc>Museum of Arts</catDesc>
+                  </category>
+                  <category xml:id="tlaNPKWBKFOYRGB3P6WT2ZMXPCLBM">
+                    <catDesc>State Hermitage Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaPPHFEANV5REZFDQ23LEK2SOXLU">
+                    <catDesc>Museum of the Ecclesiastical Academy</catDesc>
+                  </category>
+                  <category xml:id="tlaPYCNJJ3G7VDNHBRL26HRA5HXBQ">
+                    <catDesc>Imperial Museum of the Russian Archaeological Society</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaOX7JACLRPVBXRONCP75N73B3BQ">
+                  <catDesc>Sarapul</catDesc>
+                  <category xml:id="tlaAMLVROP3KZDARB3LSCG37SNVUU">
+                    <catDesc>Museum of History and Culture of Middle Kama Region</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaR2L4RRDFDZEPTJP4FBVNMZZH3A">
+                  <catDesc>Grozny</catDesc>
+                  <category xml:id="tlaMY3I63V3XRHGZKCRB4HBUQWTXE">
+                    <catDesc>Regional Museum of the Chechen Republic</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaRFGPXBCZPBDAFIT4TNTN4Q6KKU">
+                  <catDesc>Perm</catDesc>
+                  <category xml:id="tlaB7OABOTLIZF4DFDHRHKTV7Y5TY">
+                    <catDesc>Perm State University</catDesc>
+                  </category>
+                  <category xml:id="tlaNWR4KUMYOVFB3AXRDKYYFRH6LE">
+                    <catDesc>Perm State Art Gallery</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaRHMY7PVMKJA77NVHBMJRN4GGWY">
+                  <catDesc>Kaliningrad</catDesc>
+                  <category xml:id="tlaSUTZXRQCKVH3FOUJNOKQQFJFIA">
+                    <catDesc>Institute of Archaeology</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaSBT6FLF6PVBSZJ3DE7HM6IKITM">
+                  <catDesc>Taganrog</catDesc>
+                  <category xml:id="tlaWZMDA2T5RFFBRI2JCGVNODIHWE">
+                    <catDesc>Taganrog Regional Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaT22KKDWXLVEBFLKF2O4J3L53Z4">
+                  <catDesc>Polenova</catDesc>
+                  <category xml:id="tlaDYCPJMAQDRC5BJV53KN5BYKRWY">
+                    <catDesc>State Historical, Art and Landscape Museum, Collection of V.D. Polenov</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaYPXTV4ZD65D5HINR643ZYO4E3U">
+                  <catDesc>Smolensk</catDesc>
+                  <category xml:id="tlaQGC2OYQCRVEGRBE7H3FGPYRYQM">
+                    <catDesc>Smolensk State Museum, Collection of History, Architecture and Art</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaCHO4GHR5UJF7FLGW72I7XO34WM">
+                <catDesc>Schweiz</catDesc>
+                <category xml:id="tlaGUNIHTMVV5GCTCO2VUOFSWOLMA">
+                  <catDesc>(Städte L-Z)</catDesc>
+                  <category xml:id="tla4GB7OJLOMNFO5NUKTTNNPLLQYE">
+                    <catDesc>Winterthur</catDesc>
+                    <category xml:id="tlaNJNGTTO575C6JHHLB66DWMDTNQ">
+                      <catDesc>Ethnographische Sammlung (Naturwissenschaftliche Sammlungen)</catDesc>
+                    </category>
+                    <category xml:id="tlaQMGA4KXGPZCYVMXTT2WLGJIG6M">
+                      <catDesc>Antikensammlung des Münzenkabinetts</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla5IW6QEQV7ZANBG7ZSZK5KO4HRM">
+                    <catDesc>Solothurn</catDesc>
+                    <category xml:id="tlaN6PRUB5EDBEJDB3LX5LSKF4WWI">
+                      <catDesc>Kunsthaus</catDesc>
+                    </category>
+                    <category xml:id="tlaOLFLFEWQC5EKDD26SFZGI47JWM">
+                      <catDesc>Musée d'Histoire Naturelle</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla5VOXFUEZJ5D4XEGJYSEDRP45T4">
+                    <catDesc>Schönenwerd</catDesc>
+                    <category xml:id="tlaM33GEHHL7ZFERBCX3IAKMWWF3E">
+                      <catDesc>Museum für Naturkunde</catDesc>
+                    </category>
+                    <category xml:id="tlaUH2AZHJH5VHYBBH2G4DSTQJ3MY">
+                      <catDesc>Bally Schuhmuseum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaB3X47AEIJRBABLHNJTC7RBO2VM">
+                    <catDesc>Pregny-Chambésy</catDesc>
+                    <category xml:id="tlaSOEZB4MFENFTFC5I54A3WRTVQA">
+                      <catDesc>Musée des Suisses à l'Étranger</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaCWJ6V3F2MNDX5CRA23Y2XSQB2Q">
+                    <catDesc>Nyon</catDesc>
+                    <category xml:id="tlaE35AV65YIJFLPDY2YS3SY3AN4E">
+                      <catDesc>Musée Romain</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaDTASLBBQNRHWLL7SKQJV2VECBE">
+                    <catDesc>Riggisberg</catDesc>
+                    <category xml:id="tla3PIF3AZMK5HOBLOY67NUFDEQE4">
+                      <catDesc>Abegg-Stiftung Bern</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaDYV4SS7JJBGOVGAIPE3N2R3FFE">
+                    <catDesc>Schaffhausen</catDesc>
+                    <category xml:id="tla3PXY3P325BDNTA22JDYMCM54BM">
+                      <catDesc>Museum zu Allerheiligen</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaEIFP6IPPEBFIDNULW3G56F3EQM">
+                    <catDesc>Lenzburg</catDesc>
+                    <category xml:id="tlaKH3DZYH73FCOHPSKMAN2Z2MQSU">
+                      <catDesc>Historisches Museum Aargau, Kantonale Sammlungen</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaGBA7JB5VDVCS3CUCOZKEVB5KGU">
+                    <catDesc>La-Chaux-de-Fonds</catDesc>
+                    <category xml:id="tlaX4D35VNIR5GDZJAF2NDJF4PQ6A">
+                      <catDesc>Musée des Beaux-Arts</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaHP23RTJ6GBDEVC34URJUPJDECA">
+                    <catDesc>Lausanne</catDesc>
+                    <category xml:id="tlaGADLBBQHTFDSDLGFGPXZ3JJXJ4">
+                      <catDesc>Musée Historique</catDesc>
+                    </category>
+                    <category xml:id="tlaIYDZTKRUKVCQNF72MYFYCEULDQ">
+                      <catDesc>Musée Romain de Lausanne-Vidy</catDesc>
+                    </category>
+                    <category xml:id="tlaQINZPP5ZIFE3NBDX27UF54RYFI">
+                      <catDesc>Musée Cantonal d'Archéologie et d'Histoire</catDesc>
+                    </category>
+                    <category xml:id="tlaSG5TAX6ATBBS7MBZ627YPAFBU4">
+                      <catDesc>Musée Cantonal des Beaux-Arts</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaIMUBHZGA4BDQTIQDNAKOGKOYYM">
+                    <catDesc>Sion</catDesc>
+                    <category xml:id="tlaYPKZGADW4RGRJC6UCQRGWMF7FA">
+                      <catDesc>Musée Cantonal d'Archéologie du Valais</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaJ3LOP25LRVFD3EYO6ID6DFITBE">
+                    <catDesc>Neuchâtel</catDesc>
+                    <category xml:id="tlaUP67FT6VRJFFNL6MO7MDGBDWPE">
+                      <catDesc>Musée d'Art et d'Histoire</catDesc>
+                    </category>
+                    <category xml:id="tlaV34JC2CWRJHJHHQJVS65UEPDG4">
+                      <catDesc>Musée d'Ethnographie</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaJQM2UZG6IJEQPFKZBSCCEFFJHQ">
+                    <catDesc>Olten</catDesc>
+                    <category xml:id="tlaPUUPEDXAY5AOVI6KFJTP4F3DCI">
+                      <catDesc>Historisches Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaQQWU7V3F7FBENKUPND2GEWMPXA">
+                    <catDesc>Sankt Gallen</catDesc>
+                    <category xml:id="tla2PHXAUBCCBH6HD2G3FRTXK2Y74">
+                      <catDesc>Stifts-Bibliothek</catDesc>
+                    </category>
+                    <category xml:id="tlaXFVNGTBDIFDXRELQOSMOETWZR4">
+                      <catDesc>Historisches Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaRHXZXNCW5VAI5CSLMLZKJB5O3E">
+                    <catDesc>Yverdon</catDesc>
+                    <category xml:id="tla2E7F5EPXOVF3FO5GGDFU4EC4WM">
+                      <catDesc>Musée du Chateau</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaT4QONYQ3V5FTVCS2YNCHV66T7I">
+                    <catDesc>Locarno</catDesc>
+                    <category xml:id="tlaAXM5GZCACBAUXEAEWEHEQSNVSE">
+                      <catDesc>Museo Civico Visconti</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaTI2RD3XJIRGTHFUFVGHCGILPRY">
+                    <catDesc>Môtiers</catDesc>
+                    <category xml:id="tlaJOU7RFRFONEUXGQVKOGXMXQGRY">
+                      <catDesc>Musée Régional d'Histoire et d'Artisanat du Val-de-Travers</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaU44WWAED7RBYLA2FKN3JHOBULY">
+                    <catDesc>Tour-de-Peilz</catDesc>
+                    <category xml:id="tlaLJV6QVPCOFBVFIWW475WQVQ2ME">
+                      <catDesc>Musée Suisse du Jeu</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaUKVUFS6I5BGMLB5AYNXMYJDP5Y">
+                    <catDesc>Liestal</catDesc>
+                    <category xml:id="tla7IRHFUZXOBFG5GIPOHJQ3HGXRE">
+                      <catDesc>Kantonsmuseum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaVAELYUTGUFFURMSTVVU34DAONQ">
+                    <catDesc>Saint-Imier</catDesc>
+                    <category xml:id="tla4S7WDDMMEVDAJCTFR4Z3KR44XY">
+                      <catDesc>Musée Municipal</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaVIDMYE7Z2BFC7BDG42IYQJTTZE">
+                    <catDesc>Vevey</catDesc>
+                    <category xml:id="tlaDSTSATVUEFEQLGY5RUK6CAXAQM">
+                      <catDesc>Musée Historique du Vieux-Vevey</catDesc>
+                    </category>
+                    <category xml:id="tlaVYUZHH2AUBF7BNLMWAEAIPOT6Q">
+                      <catDesc>Musée des Beaux-Arts</catDesc>
+                    </category>
+                    <category xml:id="tlaZTTMDSB34FEQNA2I3377HHRYIQ">
+                      <catDesc>Musée Suisse du Jeu</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaVLTOT4PXPVBXNNWXDNIU6G6VFE">
+                    <catDesc>Zürich</catDesc>
+                    <category xml:id="tla5IYWCRIEKRHITIS5BEVCWAJ4AA">
+                      <catDesc>Museum Bellerive</catDesc>
+                    </category>
+                    <category xml:id="tlaDCMDNN3QBVAIBHKKAVDLSYSBNM">
+                      <catDesc>Kunsthaus</catDesc>
+                    </category>
+                    <category xml:id="tlaGNGMIFZN5JHRRDRVMQTTWMLYNU">
+                      <catDesc>Schweizerisches Landesmuseum</catDesc>
+                    </category>
+                    <category xml:id="tlaP6SW2T6K4NAVHJ2SFD7W7LRBWI">
+                      <catDesc>Völkerkundemuseum</catDesc>
+                    </category>
+                    <category xml:id="tlaRTBHRS74LBHIDAAXEHGBGX7QXQ">
+                      <catDesc>Museum Rietberg</catDesc>
+                    </category>
+                    <category xml:id="tlaT4KXCM3GYZDBRMAQO7FYRQ2PYE">
+                      <catDesc>Archäologische Sammlung der Universität Zürich</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tlaP3QTRAGUOBEOLOWBEIIJQHWNA4">
+                  <catDesc>(Städte A-K)</catDesc>
+                  <category xml:id="tla2EKQHEKPFFCJ5H5TR2BCEMN6CM">
+                    <catDesc>Fribourg</catDesc>
+                    <category xml:id="tlaJAN26N2C3JCGVL3L73HNFE3DBA">
+                      <catDesc>Institut Biblique de l'Université</catDesc>
+                    </category>
+                    <category xml:id="tlaLHPQIRDU7RCVHIHGJ6GQGKXDJE">
+                      <catDesc>Service Archéologique Cantonal</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla2FOMNU2M7ZEPVN7U7QNAZFX2IY">
+                    <catDesc>Chur</catDesc>
+                    <category xml:id="tlaDT3RS3JLAJC7JFIX7M2YJZSG5I">
+                      <catDesc>Rhätisches Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla2JJQ6GOM2BFPFCIKCKECV4GMOU">
+                    <catDesc>Augst</catDesc>
+                    <category xml:id="tlaWJIXFRIEIFFAVHVT64576TMLV4">
+                      <catDesc>Römermuseum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla5OA3PS6DJJDZ7OXS5AA2TG4SAE">
+                    <catDesc>Aarau</catDesc>
+                    <category xml:id="tlaPYWM5TSSVRHVZPUBRSCTAAHKXY">
+                      <catDesc>Aargauer Kunsthaus</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaBSRQLJR2KNBKPCDVYFWEG4RBVY">
+                    <catDesc>Cologny</catDesc>
+                    <category xml:id="tla3RIHQ7RXGFF67H7ZUMPK6GEDWE">
+                      <catDesc>Fondation Bodmer</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaBYMJUU4VNNFI7E5PCPL4TSUOMU">
+                    <catDesc>Brissago</catDesc>
+                    <category xml:id="tlaZZE4AUUHZFEZZDJL7GK24TLKSQ">
+                      <catDesc>Municipalité</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaC3QUWQZFWBHEFNAUCGP5W6XOAM">
+                    <catDesc>Burgdorf</catDesc>
+                    <category xml:id="tla4TEIGMBT2FG4DK6D7WSD65F3ME">
+                      <catDesc>Museum für Völkerkunde</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaFWMJZREC6NGR5LKE5NG5Z3ATAI">
+                    <catDesc>Genf</catDesc>
+                    <category xml:id="tlaAKQYRURTZJEOJIHR7OI6VMPN6A">
+                      <catDesc>Musée d'Art et d'Histoire</catDesc>
+                    </category>
+                    <category xml:id="tlaCHJCPB7RIBDMHDKDYRQLNTAQQE">
+                      <catDesc>Musée Barbier-Muller</catDesc>
+                    </category>
+                    <category xml:id="tlaFTAAHSL4WVHH5COW67SIXIHI7Y">
+                      <catDesc>Musée Historique de la Réformation et Musée Jean-Jacques Rousseau</catDesc>
+                    </category>
+                    <category xml:id="tlaGFDTQSLFYVEYVAOR7VF37HUPPE">
+                      <catDesc>Fondation M. Bodmer</catDesc>
+                    </category>
+                    <category xml:id="tlaJFRBJ4OEANFYDAQV22IMMZGCUY">
+                      <catDesc>Bibliothèque Publique et Universitaire</catDesc>
+                    </category>
+                    <category xml:id="tlaWESKCSPLAVGQTPCHA6MEOLRMVM">
+                      <catDesc>Musée d'Ethnographie</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaFWXTWMRRAFD3VKIV26A5RXBICM">
+                    <catDesc>Frauenfeld</catDesc>
+                    <category xml:id="tlaEAEN42MSUBEEDKAAYQXAOAPDWA">
+                      <catDesc>Museum des Kantons Thurgau</catDesc>
+                    </category>
+                    <category xml:id="tlaLTP3BNNO6NGLDCEJL3VEE4UQLY">
+                      <catDesc>Historisches Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaG7E4AKCSZZFXFE6PI4E5Y3TJUI">
+                    <catDesc>Bellinzona</catDesc>
+                    <category xml:id="tlaSAA3EV4NBZH4FFSJAL2ZRECEAU">
+                      <catDesc>Museo Civico</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaGYWBHJMFDJADXAELH53ZXJ57CI">
+                    <catDesc>Binn</catDesc>
+                    <category xml:id="tlaHGYUSNMSANGSFOD7YP7C5DQUW4">
+                      <catDesc>Regionalmuseum Graeser-Andenmatten</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaHSMNBEGOCFHUFJASQCYTJYTHAU">
+                    <catDesc>Appenzell</catDesc>
+                    <category xml:id="tlaWYZVUX364FGLRPBIZPKL765YPM">
+                      <catDesc>Museum Appenzell</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaNH7TFE5PTBEHRIUXSVCKRPXZU4">
+                    <catDesc>Brugg</catDesc>
+                    <category xml:id="tlaEI3Q2WEZAVBTJAFWBE73GQCFTY">
+                      <catDesc>Vindonissa-Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaTNSGMX6UOBFN7MBJF7SMPNRRBE">
+                    <catDesc>Chambésy</catDesc>
+                    <category xml:id="tla5AQHXY3K3NEBLMJEPRW4IXFSWA">
+                      <catDesc>Musée des Suisses</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaVNOHGYPO4ZFSTD747AXDQRP3TM">
+                    <catDesc>Bern</catDesc>
+                    <category xml:id="tlaHKFUA2X7KBASJPZ6VCMZHR6YZQ">
+                      <catDesc>Historisches Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaW3EUJYBTLNBWRIZT2TJMDPNRG4">
+                    <catDesc>Basel</catDesc>
+                    <category xml:id="tla26KAT7KXABA3RBUMT53CYQHUWU">
+                      <catDesc>Historisches Museum</catDesc>
+                    </category>
+                    <category xml:id="tla4MMERKR2TREI5IPKUDMMNEL334">
+                      <catDesc>Schweizerisches Sportmuseum</catDesc>
+                    </category>
+                    <category xml:id="tlaAXEQBTP3OJA3LOVYLUN73LSW54">
+                      <catDesc>Museum der Kulturen</catDesc>
+                    </category>
+                    <category xml:id="tlaDOBOPJ5ZQND6NMYKXDZKQBGTAI">
+                      <catDesc>Antikenmuseum</catDesc>
+                    </category>
+                    <category xml:id="tlaK7ZLDPXOKRCQBCD7EYZPEHHOO4">
+                      <catDesc>Ägyptologisches Seminar</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaWRAOEBQIONABRNYFY77T3U74TM">
+                    <catDesc>Avenches</catDesc>
+                    <category xml:id="tla2CCASUSKQBC55IXIX2JBDLSTJM">
+                      <catDesc>Musée Romain d'Avenches</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaXBYWHTQCXREMFATPO6FOUEI4TM">
+                    <catDesc>Herisau</catDesc>
+                    <category xml:id="tlaM5ZJSUWXSNBCZPLVONX4ZFKPA4">
+                      <catDesc>Historisches Museum</catDesc>
+                    </category>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaD7ZO3GF7QJCXBH32UVUNUSVBJQ">
+                <catDesc>Österreich</catDesc>
+                <category xml:id="tla2LUNK54PZRBITJTLGHX2AB44ZY">
+                  <catDesc>Wien</catDesc>
+                  <category xml:id="tla7AFQFIQLZBGKLDFREJCVYIWEAU">
+                    <catDesc>Kunsthistorisches Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaGVQEIIVN4BBTHLNRIB25URIY5U">
+                    <catDesc>Museum für Völkerkunde</catDesc>
+                  </category>
+                  <category xml:id="tlaIMWDV7E4KRD2POO6HI3QBOOACE">
+                    <catDesc>Theresianische Akademie</catDesc>
+                  </category>
+                  <category xml:id="tlaMIJE6VYTD5BULLBWPYAZGSDSCU">
+                    <catDesc>Papyrusmuseum</catDesc>
+                  </category>
+                  <category xml:id="tlaYVNQORT5NNE5JFT4WDYMWXTF2M">
+                    <catDesc>S. Freud-Haus</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla3CLBHWFCLFCNVPPBCL6N5S5VWA">
+                  <catDesc>Graz</catDesc>
+                  <category xml:id="tlaLM4NBUYXHJHR5GTW6W6VABKIUI">
+                    <catDesc>Steiermärkisches Landesmuseum Joanneum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla3GTKC2FSJVAMHEHB244DUJBOSQ">
+                  <catDesc>Innsbruck</catDesc>
+                  <category xml:id="tlaCY5JRTL2DNEG3MI2YA6DVHQV3Q">
+                    <catDesc>Tiroler Landesmuseum Ferdinandeum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla5OIMHA3JXBACDHGSJXLT2XVA5Y">
+                  <catDesc>Linz</catDesc>
+                  <category xml:id="tla2JCS6H2M4ZA67NU3OQDSOZRIS4">
+                    <catDesc>Stadtmuseum Nordico</catDesc>
+                  </category>
+                  <category xml:id="tlaLRCK3EV5KZF23PZOEENQEWGTSM">
+                    <catDesc>Oberösterreichisches Landesmuseum Francisco-Carolinum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla5V7APDEQ3VGNTDQP6IRSS7XUWY">
+                  <catDesc>Kremsmünster</catDesc>
+                  <category xml:id="tlaPU3IQTL2IBF4NKPJNTM5HWZGSE">
+                    <catDesc>Benediktinerstift</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla7VSATVGONVCWFNZAUNZRDP6K5A">
+                  <catDesc>Klagenfurt</catDesc>
+                  <category xml:id="tla2NCRDS6GMFGSFFZUJ46G6DIVFQ">
+                    <catDesc>Kärntner Landesmuseum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaH4GXYW5AYVD7FFBVFSIN7CF4SY">
+                  <catDesc>Obertraun am Hallstättersee</catDesc>
+                  <category xml:id="tlaDCJP5NVOWBFS3PLMZPQNZ2JOP4">
+                    <catDesc>Dachsteinmuseum (Höhlenmuseum)</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaQPCUAM4BGJA7LH66WMKALKGQ2I">
+                  <catDesc>Baden (bei Wien)</catDesc>
+                  <category xml:id="tlaTPAXV2OPKVETRLT2UL3L33KIU4">
+                    <catDesc>Rolettmuseum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaUNGFYUKJQBB4XIDXA5RT7T5JXM">
+                  <catDesc>Bad Deutsch-Altenburg</catDesc>
+                  <category xml:id="tlaHQVX4GHSUVHHFPNEPY3MGXXMDY">
+                    <catDesc>Museum Carnuntinum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaYBTKWUAB2NCJHDYLSBAGZQ6T2Q">
+                  <catDesc>Hallstatt</catDesc>
+                  <category xml:id="tlaVVYHNG7LPJDKBHBTUDUNM6IM7I">
+                    <catDesc>Prähistorisches Museum / Heimathaus</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaE4RVNBDYJFCK5K5OZJ66CTGYTA">
+                <catDesc>Kroatien</catDesc>
+                <category xml:id="tla2EZIWRFNENDBBK7BOCOVCUKNAQ">
+                  <catDesc>Varazdin</catDesc>
+                  <category xml:id="tlaXZ5YVBGWWFFMJPX5DD4N7ZU2RA">
+                    <catDesc>Ägyptische Sammlung</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaEEJSNJ5RAJARVJAYOZGXSSO6VQ">
+                  <catDesc>Osijek</catDesc>
+                  <category xml:id="tlaB3ASSJSSYZARNCDQLFKY4RIQ2A">
+                    <catDesc>Ägyptische Sammlung</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaJ54KHDMX4BCB5H6EQMB3YIOQAI">
+                  <catDesc>Pula</catDesc>
+                  <category xml:id="tlaSDJ2B2QKONESFFAY4ARALLFDBE">
+                    <catDesc>Arheoloski Muzej Istre</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaK4ZL3X6DOFDOVA2XEZYN2Z34PY">
+                  <catDesc>Split</catDesc>
+                  <category xml:id="tlaLKR4BWWLNBF2XJUEF6SAK53WU4">
+                    <catDesc>Ägyptische Sammlung</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaY5TEAWFPOZDGNBM7YVUWJSAS74">
+                  <catDesc>Zagreb</catDesc>
+                  <category xml:id="tlaBPTMUR64FNGB7FDANZ7EA4LANQ">
+                    <catDesc>Arheoloski Muzei</catDesc>
+                  </category>
+                  <category xml:id="tlaHMYPPLQF5ZADJA3ZFHZSNGK2VI">
+                    <catDesc>Muzej Mimara</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaISBVIZAHLZAAZHXKTYYS5ISAIA">
+                <catDesc>Vatikan</catDesc>
+                <category xml:id="tlaVUCVXRSCINADZJQHITJQKYJ7VE">
+                  <catDesc>Vaticanstadt</catDesc>
+                  <category xml:id="tla72OFJF74IBC4XDLVCB5WN4QT7Y">
+                    <catDesc>Museo Gregoriano Egizio</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaK2HUMC6E2RGP7DUT6FLV6LKSHI">
+                <catDesc>Rumänien</catDesc>
+                <category xml:id="tla3AI4VEYAEVF3HECRKKCHPGVMA4">
+                  <catDesc>Bukarest</catDesc>
+                  <category xml:id="tlaHI2ITBZT3BDPBAPNO4MZGU5U7I">
+                    <catDesc>Muzeul National de Antichitatí</catDesc>
+                  </category>
+                  <category xml:id="tlaQSOKFRSVIBD3XGMMJEPQY7PX3U">
+                    <catDesc>Museum of History</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla4KUGR2PLKJD4LBGQCHNDJ6EEUY">
+                  <catDesc>Iasi</catDesc>
+                  <category xml:id="tlaYBFDYCY4QFGR7GTM6QJTYWIHGE">
+                    <catDesc>Historical and Archaeological Institute</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaGNS2OUBKZRBQRMVTOQCTLLP674">
+                  <catDesc>Oradea</catDesc>
+                  <category xml:id="tlaP3QHMCBANZGJVNGA7VD33WZA34">
+                    <catDesc>Muzeul Tarii Crisurilor</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaIHW6JCI5EBFO7M7UEQK3QROWXA">
+                  <catDesc>Cluj-Napoca</catDesc>
+                  <category xml:id="tla4CQ4MOKMA5EZVLZWVZN2AGWXWQ">
+                    <catDesc>Muzeul de Istorie al Transilvaniei</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaKPHLVU2DQ5HEJDGBEBKS6DDCLI">
+                <catDesc>Gibraltar</catDesc>
+                <category xml:id="tla5BIKTQRFQBHYLC23MHGTDW476U">
+                  <catDesc>Gibraltar</catDesc>
+                  <category xml:id="tlaARBUCRCLRBHU3BTKUNG74OR2FE">
+                    <catDesc>Gibraltar Museum</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaL4HM5COZSVEW5NOJOOJWRZGTMU">
+                <catDesc>Polen</catDesc>
+                <category xml:id="tla2AKPM2P7DFD3JIGWMNCNTNJGDA">
+                  <catDesc>Warschau</catDesc>
+                  <category xml:id="tlaXGKCTTRAGVDJPB6RDU62JI5AMQ">
+                    <catDesc>Muzeum Narodowe</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaACW7IA36ZRG6ZLQHF4TKNIC2UY">
+                  <catDesc>Goluchow</catDesc>
+                  <category xml:id="tla7HA3JFOOPBHBXE4L5NB5L32J24">
+                    <catDesc>Muzeum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaDMLWBVDOZZBWDECVFEZ4RK37JY">
+                  <catDesc>Raciborz</catDesc>
+                  <category xml:id="tla7JYJAZXD7FECDP447DLSY2CERU">
+                    <catDesc>Muzeum w Raciborzu</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaHCY4KWPDRVFIZOBSHHTBUBMLKY">
+                  <catDesc>Poznan</catDesc>
+                  <category xml:id="tla2AV2LYGFZBGIVI374AP2DTJWYM">
+                    <catDesc>Muzeum Archeologiczne</catDesc>
+                  </category>
+                  <category xml:id="tlaXD2Y6GVGPRHTXGE44QSRT24VZE">
+                    <catDesc>Muzeum Narodowe w Poznaniu</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaKN5SJXTZ4FB4DEJFF5SUUUKR3M">
+                  <catDesc>Krakau</catDesc>
+                  <category xml:id="tlaEZOEUUO7U5HRPFNO663SWM463M">
+                    <catDesc>Katedra Archeologii Srodziemnomorskiej Uniwersystetu Jagiellonskiego</catDesc>
+                  </category>
+                  <category xml:id="tlaLCVIA7MNIFDUVADPPJHCH6RU24">
+                    <catDesc>Muzeum Archeologiczne w Krakowie</catDesc>
+                  </category>
+                  <category xml:id="tlaMUZAUBPY6FBUHM3PJ2ZJPDMMDA">
+                    <catDesc>Muzeum Narodowe w Krakowie (Muzeum Czartoryskich)</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaO2DJLRV72NEKRLKTQOBOW26E7A">
+                  <catDesc>Bielsko Biala</catDesc>
+                  <category xml:id="tlaUXKM5RICOFDGZENPO7OYAEUOO4">
+                    <catDesc>Muzeum Okregowe</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaLDK6YGSMAJEWFESCY56W6OGVMQ">
+                <catDesc>Slowakei</catDesc>
+                <category xml:id="tla5JRKTDPLAZBMZMYKB3MPKCQPFA">
+                  <catDesc>Buchlov</catDesc>
+                  <category xml:id="tla74PZR7J7ZRHQFJ4EJSFI2JEV6A">
+                    <catDesc>Státní Hrad</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaMLUIJSSJ3VBQPJJJHGYLWKZGIM">
+                  <catDesc>Rimavská Sobota</catDesc>
+                  <category xml:id="tla2JVRBV4FQNDNPKKFNBOPXWZZSI">
+                    <catDesc>Gemerské Muzeum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaNYUASDMZHFHSPGLZUE4SEYBWXM">
+                  <catDesc>Betliar</catDesc>
+                  <category xml:id="tlaFK4JFLV64RFMRO5GARXAWD5F3Q">
+                    <catDesc>Státny Kultúrny Majetok</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaSSHXE7EC5NFH7N6J6HJPT7SY6Q">
+                  <catDesc>Bratislava</catDesc>
+                  <category xml:id="tlaVVS3V25BCVAHHDZSC247MP2SAA">
+                    <catDesc>Slovenské Národné Muzeum, Prírodovedecky Ustav</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaM5FWTACXIFHZXK3QHQGJVCQYEA">
+                <catDesc>Portugal</catDesc>
+                <category xml:id="tla3GYD2QRZ5RCATDJMMXFU2YELDA">
+                  <catDesc>Cascais</catDesc>
+                  <category xml:id="tlaQE75IWW2IJDP3EPT6WQ2WJJNTY">
+                    <catDesc>Museu Condes de Castro Guimaraes</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaI42ED2QRQFHWRFTMVBRI2VK6WU">
+                  <catDesc>Vila Viçosa</catDesc>
+                  <category xml:id="tlaFRWVEDOQOFD6XDH43PKWMSVJVQ">
+                    <catDesc>Casa de Bragança</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaJYMLAQCNKFDUVAJ6D25SC2OO7I">
+                  <catDesc>Porto</catDesc>
+                  <category xml:id="tlaZFZU4PWKJBG7DIGCV56ADVDDBA">
+                    <catDesc>Museu Nacional</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaPSTNV7S45BGG7NB5AB4UX3KY2Y">
+                  <catDesc>Caramulo</catDesc>
+                  <category xml:id="tlaPCEBWVYS35FQRCY7PU5AKJR4QI">
+                    <catDesc>Museu</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaSEBAFUVEYVFPZHGXAHXJ4ZRHVU">
+                  <catDesc>Lissabon</catDesc>
+                  <category xml:id="tlaA2R6NGXAEJCYRDLV2WE5545F4A">
+                    <catDesc>Sociedade de Geografia</catDesc>
+                  </category>
+                  <category xml:id="tlaKBY6TFZUCJFULMEMFF2HSEWI5Q">
+                    <catDesc>Museu Nac. de Arte Antiga</catDesc>
+                  </category>
+                  <category xml:id="tlaLJIGPTQ225B4TGJO5E5LRKPOLQ">
+                    <catDesc>Museu Nac. de Arqueologia, Museu Etnológico do Ultramar</catDesc>
+                  </category>
+                  <category xml:id="tlaVROYEIGGEFD2ZFPDOOC27KAZZQ">
+                    <catDesc>Museu Calouste Gulbenkian</catDesc>
+                  </category>
+                  <category xml:id="tlaXUI5Z2BZ3ZDHZMSQNPNNLRKP4Y">
+                    <catDesc>Museu Arqueológico</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaWKBR5KY5XJC4JOHIWFJIOELVPA">
+                  <catDesc>Alenquer</catDesc>
+                  <category xml:id="tlaHW3VBRV7BNAOZAMXGX7HLYZTIM">
+                    <catDesc>Museu H. Cabaço</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaNHYYWK2VKRFDLCHPWC7ZZCDLPA">
+                <catDesc>Estland</catDesc>
+                <category xml:id="tlaSUQWT6KAYVBFLPOVFEDT45ITHY">
+                  <catDesc>Tallin</catDesc>
+                  <category xml:id="tla2NIDW5JIOFAR3FEL4WTREMILXU">
+                    <catDesc>Museum of History of Estonia</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaYATZQV7YYZFK7BXWODSYV5TVPQ">
+                  <catDesc>Tartu</catDesc>
+                  <category xml:id="tlaO3XEVTB5FVD6VAA4P4R3UOZHQQ">
+                    <catDesc>Tartu University Museum of Classical Antiquities</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaNIQ5LRVEXVFSZMOTLAE5KCLK64">
+                <catDesc>Frankreich</catDesc>
+                <category xml:id="tla2BDOFKIH2NB6JHSC7GOL7K2NGU">
+                  <catDesc>(Städte M-P)</catDesc>
+                  <category xml:id="tla3ATAT65MORBOHBFIUA4SCYWP2U">
+                    <catDesc>Mülhausen (Muhouse)</catDesc>
+                    <category xml:id="tlaK2H74IJIQZBZRO2CRJNGDE6DNQ">
+                      <catDesc>Musée Historique</catDesc>
+                    </category>
+                    <category xml:id="tlaNGGUKMHVWFEV7HT5O6VYNKCD24">
+                      <catDesc>Musée de la Chapelle Saint-Jean</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla5T2YIUE5JBDUXIXTK2JAMP35PU">
+                    <catDesc>Provins</catDesc>
+                    <category xml:id="tlaPYWMRTSEL5HJRIJPQKPRQS46QA">
+                      <catDesc>Bibliothèque Municipal</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla6QESVROOSRCKJET3ZSA4A36CJA">
+                    <catDesc>Meudon</catDesc>
+                    <category xml:id="tla5PH5OTPQUZEYVIEXWKO6GC55EM">
+                      <catDesc>Musée d'Art et d'Histoire</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaCRKL5Y562ZHBJHDLCV5PHJUNXM">
+                    <catDesc>Paris</catDesc>
+                    <category xml:id="tla4KU3JRSY4BBVJFOH3FB57I3Y6Y">
+                      <catDesc>Musée Guimet</catDesc>
+                    </category>
+                    <category xml:id="tlaBTWIPDBCP5DVBI4WM7DOKUC2N4">
+                      <catDesc>Musée du Louvre</catDesc>
+                    </category>
+                    <category xml:id="tlaDG64QZYUV5F6LNZ5L7B2XM656E">
+                      <catDesc>École Pratique des Hautes Études, 5ème Section, Sciences Religieuses</catDesc>
+                    </category>
+                    <category xml:id="tlaEBJFFB3SJRD4DK2SKMNDBNNJDU">
+                      <catDesc>Musée du Théâtre National de l'Opéra</catDesc>
+                    </category>
+                    <category xml:id="tlaFYVLU536IZBOXFOJQWJUZAFOBQ">
+                      <catDesc>Musée Auguste Rodin</catDesc>
+                    </category>
+                    <category xml:id="tlaIBB52CZLFJHCZIRU7ZOY7SWDDY">
+                      <catDesc>Musée Jacquemart-André</catDesc>
+                    </category>
+                    <category xml:id="tlaMDXWG5HUFJHHXN5NP2DLBMIDIY">
+                      <catDesc>Fondation Custodia</catDesc>
+                    </category>
+                    <category xml:id="tlaOQR6AIYX5FFJ7BW7EQIUBIEL6E">
+                      <catDesc>Musée du Petit Palais</catDesc>
+                    </category>
+                    <category xml:id="tlaUIMFZ7SGL5FKFJCKKDR5K3AFFM">
+                      <catDesc>Museum National d'Histoire Naturelle, Musée de l'Homme</catDesc>
+                    </category>
+                    <category xml:id="tlaYAP2DV4PVBBITNRDUTZU7UZTOU">
+                      <catDesc>Bibliothèque Nationale, Cabinet des Médailles</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaFF7GAHFIGBHSZK43753XXJ476I">
+                    <catDesc>Mâcon</catDesc>
+                    <category xml:id="tla2UNCY5AAXFFHHDCVT5DCJALXUU">
+                      <catDesc>Musée Municipal des Ursulines</catDesc>
+                    </category>
+                    <category xml:id="tlaXMGUWJF36ZHITNWGBZB5KHC244">
+                      <catDesc>Musée Lamartine</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaFTJDINOA5ZHPDAWFFPPQFEHOGI">
+                    <catDesc>Nîmes</catDesc>
+                    <category xml:id="tlaJHZSXEQ7HBE3NNG4UP6FMBXENI">
+                      <catDesc>Musée des Antiques, Musée Archéologique</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaIBGUJSR7ONE3BFSVXQB3YI7I5Y">
+                    <catDesc>Narbonne</catDesc>
+                    <category xml:id="tlaFMFLGKEMSFENTECPWNSY776TKA">
+                      <catDesc>Musée d'Archéologie et de Préhistoire</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaKKIOU2KO7JDFZFLL26C56N7IUQ">
+                    <catDesc>Nantes</catDesc>
+                    <category xml:id="tla5T73WFP7WRHIZJO5EKTLX2GX7Y">
+                      <catDesc>Musée Dobrée</catDesc>
+                    </category>
+                    <category xml:id="tlaZAQQVYHC5ZBMFBAXTRSVH3TDN4">
+                      <catDesc>Musée du Château, Musée des Arts Décoratifs et d'Art Populaire</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaKMTS72KBHZGWLBQP4N63KC4U5Y">
+                    <catDesc>Périgueux</catDesc>
+                    <category xml:id="tlaAIL6UEAEZJGO5BMS44ZAEGVHKI">
+                      <catDesc>Musée du Périgord</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaLTF3FVLBZRAB5A4F7OF43LA7YU">
+                    <catDesc>Moûtiers</catDesc>
+                    <category xml:id="tlaDKTVKCZT6BHSBDERQCPL3D7P2Q">
+                      <catDesc>Musée de l'Académie</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaNNX5RWFRZJAHRPCUDBX3Q4PHU4">
+                    <catDesc>Morlaix</catDesc>
+                    <category xml:id="tla6ENT5TYNYZEGZN36Y5YHTUZ2CM">
+                      <catDesc>Musée des Jacobines</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaP65IVL6MZBFJBHMAI5VYOONAYY">
+                    <catDesc>Marseille</catDesc>
+                    <category xml:id="tlaRHVGLZMZZRASTKOBEC4IT7QVPM">
+                      <catDesc>Musée d'Archéologie Mediterranéenne</catDesc>
+                    </category>
+                    <category xml:id="tlaZGMJESBWQRGBTDX4YAVOMA5X7I">
+                      <catDesc>Musée de la Vieille Charité</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaPJGOFMSSMRDBROFHAQ66A3Z2IA">
+                    <catDesc>Nancy</catDesc>
+                    <category xml:id="tlaGIKQ2JE4PRFNXER3IECRPZWNDI">
+                      <catDesc>Musée Historique Lorrain</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaQMJ3GP2RWZD35E7Q7RM2F46BYA">
+                    <catDesc>Paray-le-Monial</catDesc>
+                    <category xml:id="tlaJGSYSWT3HVB35DHWFEFPITOKFM">
+                      <catDesc>Musée Municipal, Musée d'Art Sacré le Hiéron</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaQPBDPJRQ2VHDBO2JNMDW6QHTPE">
+                    <catDesc>Malmaison (Rueil-Malmaison)</catDesc>
+                    <category xml:id="tla3JWUCBL5B5AV3BZTO2RU6T5P3M">
+                      <catDesc>Châteaux de Malmaison</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaR5QC36FC6ZBRZJWEFFI362MCNI">
+                    <catDesc>Pau</catDesc>
+                    <category xml:id="tlaYGC2OBP5PVGBDE22TH7JFSPJII">
+                      <catDesc>Musée des Beaux-Arts</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaSGS7KCYJJNEK5HTHWT66JYRI3A">
+                    <catDesc>Montbrison</catDesc>
+                    <category xml:id="tlaRBD6NQFSBFEGFNBPGKWZ5QEZSQ">
+                      <catDesc>Musée d'Allard</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaTQDHU76W55BYHEL5LDU6KKCNJQ">
+                    <catDesc>Montargis</catDesc>
+                    <category xml:id="tlaZIX5N3P3QRCAJPCWB2TCWRZ66Y">
+                      <catDesc>Musée du Gâtinais</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaTVBNTFROSZBFNLL6O3CHDUZLMM">
+                    <catDesc>Orléans</catDesc>
+                    <category xml:id="tlaXAI5V5CGH5EFZMLF5PQIMSL26Q">
+                      <catDesc>Musée d'Histoire</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaUKPK4LCCW5HWRP6MXL6COVJQXI">
+                    <catDesc>Poitiers</catDesc>
+                    <category xml:id="tla5DQ3CF7KWNCNRJNITFRCX77N2E">
+                      <catDesc>Musée de l'Hypogée des Dunes</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tlaCXFNJ3BHZ5FOVLW5UP5SFSMBUY">
+                  <catDesc>(Städte C)</catDesc>
+                  <category xml:id="tla3AYQZKQOLFAWVBOLQPW6GCZ5BY">
+                    <catDesc>Carpentras</catDesc>
+                    <category xml:id="tlaZHUOA2BOQVDQHLENIHBJALPYAU">
+                      <catDesc>Musée Lapidaire</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla4M52RKA74JFL7BSQ6WZ4MRCBCI">
+                    <catDesc>Clamécy</catDesc>
+                    <category xml:id="tlaOTHTCMGAX5DRLMM3IE3X4AF22Q">
+                      <catDesc>Musée Romain Rolland</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla6X4KSDEIKVGDBIYSLFIKCXJWMY">
+                    <catDesc>Chartres</catDesc>
+                    <category xml:id="tlaNIBA7SCA7VBF3KLEETCNLIKNBY">
+                      <catDesc>Musée Municipal</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla7U7AHKDKBZBUVAEIOTF67IUTIY">
+                    <catDesc>Colmar</catDesc>
+                    <category xml:id="tlaJXN4OSLUIJALVCS5Q43C5DWUJ4">
+                      <catDesc>Musée d'Histoire Naturelle</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaAGALNC42UZFP5JFYLP6OUQB6RA">
+                    <catDesc>Caen</catDesc>
+                    <category xml:id="tla7CMXRITPEBDTJHPWYGFHOB6QQI">
+                      <catDesc>Musée Langlois</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaB5W4NQRIQJA2PEYYL65MHEED2M">
+                    <catDesc>Chateau-Gontier</catDesc>
+                    <category xml:id="tlaU6PWETSDYVCY7MXIGTKG33HMKU">
+                      <catDesc>Musée Municipal</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaDAK4KVQRWRCVRIMWYXYO4NESHU">
+                    <catDesc>Cognac</catDesc>
+                    <category xml:id="tla4NSQ7OOCJJAXXAPKK5N6DSFKXE">
+                      <catDesc>Musée de Cognac</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaGNGN2PIYEVFALE766YIH5SHIMA">
+                    <catDesc>Châteauneuf-sur-Loire</catDesc>
+                    <category xml:id="tlaVGAP6FKWFRDKJF4H5U63C5VJRE">
+                      <catDesc>Ägyptische Sammlung</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaMSWKV5SNGNG3FBTFVWKK25SP7I">
+                    <catDesc>Chateaudun</catDesc>
+                    <category xml:id="tlaZZLZSQHCFJAYBFVAGMLHWQLONM">
+                      <catDesc>Musée Municipal</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaNYC43X53RFA2LCRNHXGQZOHVXA">
+                    <catDesc>Calais</catDesc>
+                    <category xml:id="tla3QO4PTAGKNA5BENINLPDRWW3DU">
+                      <catDesc>Musée des Beaux-Arts</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaPDBC4YCEQRGHZJJ7FFTLEJRHNQ">
+                    <catDesc>Chalon-sur-Saône</catDesc>
+                    <category xml:id="tlaTSRPSFRMANEIHCCLEG2AFFBIEA">
+                      <catDesc>Musée Denon</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaPEI4BO52JZHIDM4V5BXWPGZUN4">
+                    <catDesc>Clermont-Ferrand</catDesc>
+                    <category xml:id="tlaEF3FUGUJ6NC5LGWJLYL47M353Q">
+                      <catDesc>Musée des Beaux-Arts</catDesc>
+                    </category>
+                    <category xml:id="tlaQEZ72H6S7RD2FGFVGIDZG7YR5A">
+                      <catDesc>Musées Municipaux</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaPGEZO2NRARE7RAOM2ZSBYVMJLY">
+                    <catDesc>Cannes</catDesc>
+                    <category xml:id="tla4SXYS4TMWVBVZFZNWV4JH7MKDI">
+                      <catDesc>Musée de la Castre</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaPOUN7TGZYZCJ7DCM6YBKR5JA7A">
+                    <catDesc>Chateauroux</catDesc>
+                    <category xml:id="tlaKG6C7UEL7RBLNOY35XA7LMAUGI">
+                      <catDesc>Musée Bertrand</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaRDD4FHZRSVCG3M4DLDSYUUZBNI">
+                    <catDesc>Cherbourg</catDesc>
+                    <category xml:id="tlaIMUBR7Z3CNF4VDSGKILUYPOAMM">
+                      <catDesc>Ägyptische Sammlung</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaS6ROZ6MX3FBBHEC4ZCBY2V3ZTE">
+                    <catDesc>Cahors</catDesc>
+                    <category xml:id="tlaGI2RL67MONB6LJBOBQ6NQ5X6PE">
+                      <catDesc>Musée Municipal</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaYBWBNVGCLVEADBDAPF2UAO5PJU">
+                    <catDesc>Cluny</catDesc>
+                    <category xml:id="tlaWFEY5OQTP5HI3L4OPNCNQQN33Q">
+                      <catDesc>Musée Ochier</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaYYQG4PUCQRBNBN2VKQ5V5TNZV4">
+                    <catDesc>Chambéry</catDesc>
+                    <category xml:id="tlaVXLKI3X3SND4PLCD4CSBZG3YTI">
+                      <catDesc>Musée Savoisien</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaZ5TVRLTOFZFWTBSAPXZKRM3RSU">
+                    <catDesc>Compiègne</catDesc>
+                    <category xml:id="tlaWHXNO6B6K5BJFADNGOL3GTOTXE">
+                      <catDesc>Musée Municipal Antoine Vivenel</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tlaOX66QGQOTFHFJG4ZFSPB6XYWFU">
+                  <catDesc>(Städte Q-Z)</catDesc>
+                  <category xml:id="tla3BZIFME2EJE45PLKFYUBRKNWHY">
+                    <catDesc>Varzy</catDesc>
+                    <category xml:id="tlaEM3NKIOKOBBEXGYI6UAXA4D3RA">
+                      <catDesc>Musée Municipal</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla3X4IRKLGZVF7XNTGQHD4MY4UZU">
+                    <catDesc>Troyes</catDesc>
+                    <category xml:id="tlaT5LZPEE5CRBZHIGSSV2KEBW7SU">
+                      <catDesc>Musée des Beaux-Arts et d'Archéologie</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla53TYR2JZVZHABP7RMGZFHKRP2Y">
+                    <catDesc>Toulon</catDesc>
+                    <category xml:id="tla46XFFO2E4NAJBBCFJFIVNZXWWM">
+                      <catDesc>Musées de Toulon, Musée d'Art et d'Histoire</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla62WCAHWOQBEQRH7FGGOCFN36ZY">
+                    <catDesc>Saint-Omer</catDesc>
+                    <category xml:id="tlaIDZUARBCUVEXFBUUO4HOXVXCAY">
+                      <catDesc>Musée Sandelin et Musée Henri-Dupuis</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla6OQTJ67DEVH5VPHLBP3IF7FRNI">
+                    <catDesc>Verdun</catDesc>
+                    <category xml:id="tlaUNCRPVLPCZEWVIW7TTMSCIRI6M">
+                      <catDesc>Musée de la Princerie</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaCBGVXVQVEVFW5KJTEWBF44FDXM">
+                    <catDesc>Vienne</catDesc>
+                    <category xml:id="tlaQNG4FOCUTZDXHHO4OOWMGR53LQ">
+                      <catDesc>Musée des Beaux-Arts et d'Archéologie</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaFOE2MNJF2ZDPLCVUI5Z6OVPQDE">
+                    <catDesc>Vendôme</catDesc>
+                    <category xml:id="tla22DL5YQQL5BU7ILVNE7CIBHL5A">
+                      <catDesc>Musée Municipal</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaGXCHJMAMLNGUJFRLDQ63KJC66Q">
+                    <catDesc>Vannes</catDesc>
+                    <category xml:id="tlaUWTQPGDETBESXP2DWAB7EJOWMI">
+                      <catDesc>Musée de la Société Polymathique du Morbihan</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaJAP32FUWWFCPZADHS32KZ6P5C4">
+                    <catDesc>Sault</catDesc>
+                    <category xml:id="tlaNWTMJYGO5FCR7JLDBESX5MBBXE">
+                      <catDesc>Musée Municipal</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaJCT33SYM6RB3BEIXRALAKHTN7M">
+                    <catDesc>Vitre</catDesc>
+                    <category xml:id="tlaB3BI5LCZLFGJPOXY62ZVNPQTMM">
+                      <catDesc>Musée d'Arte d'Histoire</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaN5OCZG2IYRG3DHM6F2NZ6I7OAM">
+                    <catDesc>Sèvres</catDesc>
+                    <category xml:id="tla3QGBVITKEZDRLGE2O6EG2XFFXI">
+                      <catDesc>Musée de Céramique</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaNX64K5XCL5BJ3PVP7QAXTMSRIE">
+                    <catDesc>Soissons</catDesc>
+                    <category xml:id="tlaPBRHID6CBJFHLL32LT5SHZ2JBQ">
+                      <catDesc>Musée Municipal</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaQT34GO2UPBHLZDQGEOFUCEKJOY">
+                    <catDesc>Tours</catDesc>
+                    <category xml:id="tlaTWSAQ5DM7NFYDEMO4ZPFSKLZNU">
+                      <catDesc>Musée des Beaux-Arts</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaRZ7KBAAUDBGJXOQMF2MB62XNAE">
+                    <catDesc>Saint-Germain-en-Laye</catDesc>
+                    <category xml:id="tlaRLDFYFP6DFHHHCJJ2USM5WPY4A">
+                      <catDesc>(Seine-et-Oise), Musée des Antiquités Nationales</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaS2I33R7OUJBLDADPO6LCROIBLM">
+                    <catDesc>Strasbourg</catDesc>
+                    <category xml:id="tlaKP646R3SN5HRROIQAKCCUMCERU">
+                      <catDesc>Château des Rohan, Musée des Arts Décoratifs</catDesc>
+                    </category>
+                    <category xml:id="tlaXV3LUKW7GNE2HMPRKGCPKL3G2Y">
+                      <catDesc>Institut d'Égyptologie</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaU6REAHIN6FCF7D5D2X5O7SGCOU">
+                    <catDesc>Toulouse</catDesc>
+                    <category xml:id="tlaGALWZ2YYLFCY5KFEVQ7ZFR6MJE">
+                      <catDesc>Musée Georges Labit</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaUR5IA7GG6VG7BMWBRN4QXOMOMQ">
+                    <catDesc>Sens</catDesc>
+                    <category xml:id="tlaTF7YJBM3WRB3JHKQLP4JEFGZUA">
+                      <catDesc>Musée Municipal</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaVSDXPP3NDNGLTGL2ZI5TE27D6U">
+                    <catDesc>Quimper</catDesc>
+                    <category xml:id="tlaJJYL5TE72NHRXOODFEJS46DDEI">
+                      <catDesc>Musée des Beaux-Arts</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaXGXJO7XFXBBBHCJJK63OZ4EKAA">
+                    <catDesc>Vesoul</catDesc>
+                    <category xml:id="tlaPN5HUH7YQBAEBHAWBFQJ3Q4NXY">
+                      <catDesc>Musée Georges-Garret</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaYDSTTX2FIJDR5HJ7MGDLK4U4QU">
+                    <catDesc>Rodez</catDesc>
+                    <category xml:id="tlaLRNQIDGTLNDPNERE4KECDLXMQ4">
+                      <catDesc>Musée Fenaille</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaYEFM6NKHY5BANFZCACHJ2YAARU">
+                    <catDesc>Rouen</catDesc>
+                    <category xml:id="tlaQVWIOZDQMRAEDFW5VXO3VM5DHU">
+                      <catDesc>Musée Départemental des Antiquités de la Seine-Maritime</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaYX6SJUAI2VE4PC226NIBIB342E">
+                    <catDesc>Rennes</catDesc>
+                    <category xml:id="tlaBDOBWALADJGFZJI4ZIUBM7Q454">
+                      <catDesc>Musée des Beaux-Arts</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaZFP2P4K26NCQFP7I5NSSQFEYRE">
+                    <catDesc>Saint-Rambert-sur-Loire</catDesc>
+                    <category xml:id="tlaSX6F4OTTK5FFDBFCAJFAENZLKI">
+                      <catDesc>Musée de Saint-Rambert-sur-Loire</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tlaVXGF6WZHQZENDHMTA5DHYHOX3U">
+                  <catDesc>(Städte D-L)</catDesc>
+                  <category xml:id="tla2DHUP22VYREQ7LBYKUVI6AJMYE">
+                    <catDesc>Lunéville</catDesc>
+                    <category xml:id="tlaBIZ6NNNRTZGEPCE55E6PJFW64I">
+                      <catDesc>Musée du Château</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla2QVVYXUSGRGPPMYBL5NTU3YYGY">
+                    <catDesc>Figeac</catDesc>
+                    <category xml:id="tlaTCIN3363MFFIHKSMOTLZZRDS4U">
+                      <catDesc>Musée Champollion</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla3GMMTM3WBBCORJDQB6ZEQ2PPKA">
+                    <catDesc>Dijon</catDesc>
+                    <category xml:id="tlaLUX6YKVLKBHG7I5JDFPTGZA3IU">
+                      <catDesc>Musée des Beaux Arts</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla3IYB3LQFTNGSZLKFFHQBGIPSME">
+                    <catDesc>Langres</catDesc>
+                    <category xml:id="tlaBQHZ5PVEONH5JI3AMDDXR35ZHE">
+                      <catDesc>Musée Hotel du Breuil de Saint Germain</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla4NL4BRNUUJEKPLIT5RGQ2MW324">
+                    <catDesc>Lille</catDesc>
+                    <category xml:id="tlaAN3XA7UQWZDW7JFYVMKS6EIS2Y">
+                      <catDesc>Institut de Papyrologie et d'Égyptologie, Université de Lillle III</catDesc>
+                    </category>
+                    <category xml:id="tlaDUKL6MXVZRHWVFULFD6OZBGQ2A">
+                      <catDesc>Musée des Beaux Arts</catDesc>
+                    </category>
+                    <category xml:id="tlaGKIOCXAYBJFY5F3EAGMXXF2XZI">
+                      <catDesc>Université, Faculté des Lettres et des Sciences Humaines</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaAT5B7NQPNZGUBNM2GOEAGFDJRU">
+                    <catDesc>Fécamp</catDesc>
+                    <category xml:id="tlaDKT6LXZVVFDOBPORTDTI2LDMUU">
+                      <catDesc>Musée Centre des Arts</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaCA47DC42JNDDFGMZ3I6MQDJODY">
+                    <catDesc>Loudun</catDesc>
+                    <category xml:id="tlaTPIDXAN5X5BO3LPXGNMJO2XPMA">
+                      <catDesc>Musée Louis Charbonneau-Lassay</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaCDAYNCMS3BAH7BMCW5JT5AAOA4">
+                    <catDesc>Le-Puy-en-Velay</catDesc>
+                    <category xml:id="tlaNNXNTZ5ZUVAVTATEXOJWW7CNJQ">
+                      <catDesc>Musée Crozatier</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaDDWPGBLFOVEH5O3XC4YAPLTRXA">
+                    <catDesc>Gap</catDesc>
+                    <category xml:id="tla7HFEWCOOZVFCNIUCBHCWHUE3MY">
+                      <catDesc>Musée Dépt. des Hautes Alpes</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaEG5F3TM27BAZDMRYH7SZYV6SWU">
+                    <catDesc>Laôn</catDesc>
+                    <category xml:id="tlaKMS5HFKV7BGZPF5OL2UQ55UWTY">
+                      <catDesc>Musée Archéologique</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaERE2RZ2XXFDHZHWOVGZIESNQB4">
+                    <catDesc>Die</catDesc>
+                    <category xml:id="tlaLISFVTFD2JEPVPSDI4DB5E6W7I">
+                      <catDesc>Musée Municipal</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaJJAEJZUUDZDERASH4GN7NOB7WY">
+                    <catDesc>Guéret</catDesc>
+                    <category xml:id="tla5K2L6KETUJF5FPHP2YHPBLKH3I">
+                      <catDesc>Musée de Guéret</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaL4AB5ZWNPZE3TGEXP6RCUUXRLM">
+                    <catDesc>Louviers</catDesc>
+                    <category xml:id="tlaHYQKJVAGINCY3FL3Q4D2RZIWQA">
+                      <catDesc>Musée Municipal</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaLBD4K6ERTBDDHCJEIHTAIVOXY4">
+                    <catDesc>Dôle</catDesc>
+                    <category xml:id="tlaDKCETGUN6BHDBGA3Y77WE4ETQM">
+                      <catDesc>Musée des Beaux-Arts</catDesc>
+                    </category>
+                    <category xml:id="tlaR6MJR22LEZGITDTG7A3XQUVYAU">
+                      <catDesc>Musée Municipal</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaMWFVDBQOCZFR3IYH4RMCNTTR2I">
+                    <catDesc>Limoges</catDesc>
+                    <category xml:id="tlaPLCLHRL3JFED5BFQIB3Q4PDEZ4">
+                      <catDesc>Musée de l'Evêche</catDesc>
+                    </category>
+                    <category xml:id="tlaRRNMILK6FBARBONDKRDPIXVINA">
+                      <catDesc>Musée Municipal</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaNAKWLGJOOZEUDED5OYMFJ3HJ2A">
+                    <catDesc>Lons-le-Saunier</catDesc>
+                    <category xml:id="tla4XAWYF7SPRDRVPRYBNSJIAITAE">
+                      <catDesc>Musée Municipal</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaOLH7KI6IFJC5LNFOXEHOO72NM4">
+                    <catDesc>Laval</catDesc>
+                    <category xml:id="tla3NJIWT34BRESJBQIXTFQNAWWZE">
+                      <catDesc>Musée du Vieux-Château</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaPNA62SL3MNDUPKGJIKQ2VE6YCE">
+                    <catDesc>Le Havre</catDesc>
+                    <category xml:id="tlaCMK4D2OECNADPJ2AEFXQSF7EKQ">
+                      <catDesc>Musées de l'Ancien Havre</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaT4AQ4ID7DNB3PJNGWUUCQNTNAY">
+                    <catDesc>Issoudun</catDesc>
+                    <category xml:id="tla6K5TC22OGNCBRBGBZMA2XURPAQ">
+                      <catDesc>Musée de l'Ancien Hospice Saint Roch</catDesc>
+                    </category>
+                    <category xml:id="tla7S4O4HQIMFHJ7GXCPJZKIZ2UFY">
+                      <catDesc>Musée d'Art et d'Archéologie (Musée de Moulins)</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaW3GM543SPVHU3LMVLDNB2KLGKI">
+                    <catDesc>Fontaine-Chaalis</catDesc>
+                    <category xml:id="tlaUHALYBFJJJBV5IBMWKTZVZPSUQ">
+                      <catDesc>Musée Jacquemart-André</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaWE43IHP5JRE7RLPBPVKZOZNV6Y">
+                    <catDesc>Hyères</catDesc>
+                    <category xml:id="tlaUY3UAC7LQ5BWBIQAEJMBZ77JNE">
+                      <catDesc>Musée d'Art et d'Archéologie</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaWPOXBKNLN5BDROASSV5OPID4BM">
+                    <catDesc>Louhans</catDesc>
+                    <category xml:id="tlaSY3DNUOH3BA7HNNMBCGMUNJEGU">
+                      <catDesc>Ägyptische Sammlung</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaWYO46CPDXRHMLNGKWRFJJKZYZU">
+                    <catDesc>Lyon</catDesc>
+                    <category xml:id="tla54F3MNSPMJHQZPICTJ4LRIO2AE">
+                      <catDesc>Musée d'Histoire Naturelle</catDesc>
+                    </category>
+                    <category xml:id="tlaOEFCR3G2ABFSFPNNTNI6ESJ7R4">
+                      <catDesc>Institut d'Égyptologie Victor Loret, Université Lyon II</catDesc>
+                    </category>
+                    <category xml:id="tlaOXEWIOPO3BD2TEKFJUTYFJLSDI">
+                      <catDesc>Musée Guimet</catDesc>
+                    </category>
+                    <category xml:id="tlaP5FXI3YRBZG4NDWXXQ26ZASRZI">
+                      <catDesc>Musée des Beaux-Arts, Palais Saint-Pierre</catDesc>
+                    </category>
+                    <category xml:id="tlaSJS6PKU4ERC4TAKGCUEC753354">
+                      <catDesc>Musée des Frères des Écoles Chrétiennes</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaXPR5AEVAXNCHPMYX77DHK522DI">
+                    <catDesc>Grenoble</catDesc>
+                    <category xml:id="tlaGAZ6MYYKNNG6VB7YEWPFVP3TCA">
+                      <catDesc>Musée de Peinture et de Sculpture</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tlaW6F4NVVPHVFEPNSXBSSVH6GCYQ">
+                  <catDesc>(Städte A-B)</catDesc>
+                  <category xml:id="tla4FVME7EXWBCWDKFNVK7N6FW63E">
+                    <catDesc>Avignon</catDesc>
+                    <category xml:id="tlaPYGJNJLOIBEZHG6RBWX37WJJSY">
+                      <catDesc>Musée Calvet</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla4NJ2I26ZNBDNRMX5UM5C23JE44">
+                    <catDesc>Avallon</catDesc>
+                    <category xml:id="tlaT5UO4R3KKRA4HA44QFJATAPIQI">
+                      <catDesc>Musée de l'Avallonais</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla57D5R2AOBVDY7PPZAOUXKUBA2E">
+                    <catDesc>Auch</catDesc>
+                    <category xml:id="tlaWHC2RNLQSVE3RPBMUABZNYQPEA">
+                      <catDesc>Musée d'Art et d'Archéologie</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla5FU4FS3HIBA27B2AKRYMBHCSFI">
+                    <catDesc>Boulogne-sur-Mer</catDesc>
+                    <category xml:id="tlaNA7XYAQAKNCTRFN3GE62LLATE4">
+                      <catDesc>Musée des Beaux-Arts et d'Archéologie</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla6VY2XFZTG5GNJMYHSBSLPY5B7M">
+                    <catDesc>Bessines-sur-Gartempe</catDesc>
+                    <category xml:id="tla4O4CAW4OLBCATD7CVZYRIWGQ2E">
+                      <catDesc>Ägyptische Sammlung</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaA7GZR4NPOFBVBNVUVXTYCYKSEA">
+                    <catDesc>Bayonne</catDesc>
+                    <category xml:id="tlaIH2CI3KWEJBE7E4EC37LYQ342M">
+                      <catDesc>Musée Bonnat</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaAPUZJ2SANNC6FLPKT5UFTKRHMA">
+                    <catDesc>Bar-le-Duc</catDesc>
+                    <category xml:id="tla7U63AYPXABARPPFBSVVWXLIIQ4">
+                      <catDesc>Musée Barrois</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaCWDKMMM4RFBCTMR3HYUOP3UO4M">
+                    <catDesc>Angers</catDesc>
+                    <category xml:id="tla3W3O3QWKR5F67MQRPJFBQYR74U">
+                      <catDesc>Musée Turpin de Crisse, Musée Pincé</catDesc>
+                    </category>
+                    <category xml:id="tla6XJB7XKDQRA7DC5JGRUPGCTQ7I">
+                      <catDesc>Musée des Beaux-Arts</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaF7Z62AHX2ZFBNNWEVOM3PZQYR4">
+                    <catDesc>Beaufort-en-Vallée</catDesc>
+                    <category xml:id="tlaO5V4W4EVLBEC3G4FH2WZEKJPC4">
+                      <catDesc>Musée Joseph-Denais</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaHWVPAG7JVZGALHJZAHQL6UUESY">
+                    <catDesc>Annécy</catDesc>
+                    <category xml:id="tla7HWS5AUBFZE5XO5WWQOHBSPBUE">
+                      <catDesc>Musée-Chateau d'Annécy</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaI7F34UO7OVHRJJ6OOG3VQJUV7U">
+                    <catDesc>Beaune</catDesc>
+                    <category xml:id="tla43BXUOSOSFEZHHHHWOZHSXKDEY">
+                      <catDesc>Musée des Beaux-Arts et Marey</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaL4L7ESLLQFEN3INONTKLCRZAVA">
+                    <catDesc>Bourges</catDesc>
+                    <category xml:id="tlaVBRN2CGOHZGGZNJXT6UJ4TIGF4">
+                      <catDesc>Musée du Berry</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaM5E6E56IOJDWRGDORZWIRMKIZQ">
+                    <catDesc>Bordeaux</catDesc>
+                    <category xml:id="tlaAIUH62EVKFFM3M2VVYG2SPLJZY">
+                      <catDesc>Musée des Beaux-Arts</catDesc>
+                    </category>
+                    <category xml:id="tlaDGDMWPA66VGUZBBLTSYACDVYYA">
+                      <catDesc>Musée d'Aquitaine</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaMIO23EUMQBAY3GOXY4D3LEUVBM">
+                    <catDesc>Albi</catDesc>
+                    <category xml:id="tlaULJP3U7335DLTHMCDPV4MWDWBU">
+                      <catDesc>Musée Toulouse-Lautrec</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaMLHJ3GJK2NBZ7OFT5X3NGZ7PPM">
+                    <catDesc>Bernay</catDesc>
+                    <category xml:id="tlaAV7I6ISCHNADHNUGQQXADU6WNQ">
+                      <catDesc>Musée Municipal</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaNOVVIYVFOBF5NMTQVABFCIISIM">
+                    <catDesc>Autun</catDesc>
+                    <category xml:id="tlaBW6EQCCKMFA3DBWXFF5VFSMITY">
+                      <catDesc>Musée Rolin</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaOW5MDHUEEJE2LHRQ6EOJUP3QUE">
+                    <catDesc>Bourg-en-Bresse</catDesc>
+                    <category xml:id="tlaECGYKE3MBVGWLBXLTDKA4XXLB4">
+                      <catDesc>Musée de l'Ain</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaQLQXZUXISFAWHPLIMP7DZN4Z7U">
+                    <catDesc>Amiens</catDesc>
+                    <category xml:id="tlaWX4BPPATVNAVFJGSEWYD5AN77I">
+                      <catDesc>Musée de Picardie</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaQQLCDKCX6BD3POWTR45RWVAOL4">
+                    <catDesc>Auxerre</catDesc>
+                    <category xml:id="tlaBCFUUVCFDZH6BGHE2GY7BIG5NA">
+                      <catDesc>Ancien Abbaye St.-Germain</catDesc>
+                    </category>
+                    <category xml:id="tlaVJYH7GEYHVDRFC6KWTCZCCNL64">
+                      <catDesc>Musée d'Art et d'Histoire</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaRJ3GVDQJ7NE5ZM4Y4RMMUWRTK4">
+                    <catDesc>Brest</catDesc>
+                    <category xml:id="tlaU3KTKPM5RVHQ3EWUOWHCVR245M">
+                      <catDesc>Musée des Beaux-Arts</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaSHEQMIM5PJGFLJ4KUCRQ2UAKAM">
+                    <catDesc>Brou</catDesc>
+                    <category xml:id="tlaNOJIKWMCFBHCJEHCWIZOAVTX3Q">
+                      <catDesc>Musée de Brou (Chateau des Allymes)</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaT3QS6RRM5ZE3RLVTVSNWQF6J5U">
+                    <catDesc>Besançon</catDesc>
+                    <category xml:id="tla5FCLLEXI2VDRVDV5JGOQMJZ7DE">
+                      <catDesc>Musée des Beaux-Arts</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaTNWSGJG65ZGNBFKA77IJHYKHUU">
+                    <catDesc>Aix-les-Bains</catDesc>
+                    <category xml:id="tla3M25SFJQDVGO3CUNXNY2TSDD74">
+                      <catDesc>Musée Archéologique</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaVOAGIVINXZBZVPLWJFLYEBOGGQ">
+                    <catDesc>Angoulême</catDesc>
+                    <category xml:id="tlaKN42EA2YO5BRBG22EAJAWFPUPE">
+                      <catDesc>Societé Archéologique</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaW4BIX6EILVB5DNE6GFGF7OT3G4">
+                    <catDesc>Aix-en-Provence</catDesc>
+                    <category xml:id="tlaUN2KLBABMJCMDCY5BP3H2M7FYY">
+                      <catDesc>Musée Granet</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaXATJZ3X6QJB23EG4FGYHHRCVIM">
+                    <catDesc>Avranches</catDesc>
+                    <category xml:id="tlaYO3J23ZV6RCZ5A7QPHAM5EQQ2Y">
+                      <catDesc>Musée de l'Avranchin</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaXSNELPTTNBGDDOVETKFX3W6TJY">
+                    <catDesc>Barcelonnette</catDesc>
+                    <category xml:id="tlaNRFDUBN6YFHRPPHJSSUNERQNFQ">
+                      <catDesc>Musée de la Ville</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaYEZWD45O6RBXNHAC6FJYHGQDE4">
+                    <catDesc>Arles</catDesc>
+                    <category xml:id="tlaL4WYOLCC4ZFT5JXYQIFRSGPI2Q">
+                      <catDesc>Musée Lapidaire d'Art Pasen</catDesc>
+                    </category>
+                    <category xml:id="tlaUTQAD3737JDMZHHPEHETVCDS6I">
+                      <catDesc>Musée de l'Arles Antique</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaYMYPMRGS7NAVFETQX43DYBIYKI">
+                    <catDesc>Bagnols-sur-Cèze</catDesc>
+                    <category xml:id="tlaHP4LDQNERNDX3J6MJIK7I67XK4">
+                      <catDesc>Fond. Léon Alègre</catDesc>
+                    </category>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaNS3AU3HLWZAOPPM5HJKHRE6CJ4">
+                <catDesc>Italien</catDesc>
+                <category xml:id="tlaPUUVVBSUOBAARBLNNMXNP3NOMM">
+                  <catDesc>(Städte Q-Z)</catDesc>
+                  <category xml:id="tla36MN6AEUDJEY7FU4M5C4KVTOSI">
+                    <catDesc>Sassari</catDesc>
+                    <category xml:id="tlaKH3ZMRUZDZCM7HS4NCL5RBCJCU">
+                      <catDesc>Museo Nazionale G.A. Sanna, Museo Archeologico</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla3P76PWKAHNBOHJCOQMC7SSYDLY">
+                    <catDesc>Trient</catDesc>
+                    <category xml:id="tlaXX6QMTNSKVBC7MMUMB3K4SDQGY">
+                      <catDesc>Museo Provinciale d'Arte</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla54BGO4QVWFH7PGDM32J5INSLPU">
+                    <catDesc>Syrakus</catDesc>
+                    <category xml:id="tlaA4BTEKEGXZEYTMJ654LKA37BWU">
+                      <catDesc>Museo Archeologico Regionale</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla5XMEL2K27JFBPOFU4HDGO3YXSI">
+                    <catDesc>Triest</catDesc>
+                    <category xml:id="tla2IL3KH2EGNAINE4IWA6LNSJPSM">
+                      <catDesc>Civico Museo 'Revoltella' e Galleria d'Arte Moderna</catDesc>
+                    </category>
+                    <category xml:id="tlaALXELVY5YNH2DI5WH7GZTIK2UQ">
+                      <catDesc>Museo Storico del Castello di Miramar</catDesc>
+                    </category>
+                    <category xml:id="tlaTW2WMXAUEJGKBBWFO367XNVW4I">
+                      <catDesc>Museo Civico di Storia ed Arte di Trieste</catDesc>
+                    </category>
+                    <category xml:id="tlaYKMEB6727VAULIYORNYRHJDY2E">
+                      <catDesc>Museo Civico di Storia Naturale</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaAKSJTSTJZRCLLLM3JEZPUCAXEA">
+                    <catDesc>Rovigo</catDesc>
+                    <category xml:id="tlaS5EXKM7AJJBVHKDWOWCLSSFTEI">
+                      <catDesc>Museo dell'Accademia dei Concordi</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaJ7JAWOYU7NGJHG7RFSID7PTQP4">
+                    <catDesc>Turin</catDesc>
+                    <category xml:id="tlaFKUH2YNGFZEDBDX3NMLWNU4EBA">
+                      <catDesc>Palazzo Reale</catDesc>
+                    </category>
+                    <category xml:id="tlaFS47WR3XHJD2FJ2NUC4OLS3CIY">
+                      <catDesc>Museo Egizio</catDesc>
+                    </category>
+                    <category xml:id="tlaZJFDMG4QJZFOTL52RFU6P27ZT4">
+                      <catDesc>Galleria Sabauda</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaLIC7HZPYHBDALJWVXKGZ4YLZ2U">
+                    <catDesc>Rolandi</catDesc>
+                    <category xml:id="tlaFVO4AFICBJCF7DMPGDHK2ZADPU">
+                      <catDesc>Ägyptische Sammlung</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaN5YFA6II3RE2TKX62HOTWA4PK4">
+                    <catDesc>Vercelli</catDesc>
+                    <category xml:id="tlaO2GFQXDOGJH7BDY775NG5KEFAE">
+                      <catDesc>Museo Camillo Leone</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaNO4HOUA27VBYNC556RI5GKPNLU">
+                    <catDesc>Regio Emilia</catDesc>
+                    <category xml:id="tlaQVLD7VUUEREC5IGPRE3SR2FL7A">
+                      <catDesc>Museo Civico</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaOWHYA22FLNHGLPNEGSEVXBM5MI">
+                    <catDesc>Volterra</catDesc>
+                    <category xml:id="tlaRKQO33WISBBRHDAAAE2XYRZ5ZE">
+                      <catDesc>Museo Etrusco</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaQV7URQTH4FF4FF2HLAC4AVASRU">
+                    <catDesc>Venedig</catDesc>
+                    <category xml:id="tlaB4BAOB2RDZGVNGG7HVMOML3EHY">
+                      <catDesc>Tesoro di San Marco</catDesc>
+                    </category>
+                    <category xml:id="tlaCZ3UWAHSTFAA3NSKUE2DSYYVBY">
+                      <catDesc>Museo Archeologico del Palazzo Reale di Venezia</catDesc>
+                    </category>
+                    <category xml:id="tlaGIWTNKK5JZFKDPMALCMJII6GBE">
+                      <catDesc>Museo Storico Navale</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaRINIKV235ZFAHK3YGDG2FUOZOA">
+                    <catDesc>Verona</catDesc>
+                    <category xml:id="tla2FWA26TDABCNVEV3VR6VD5OGLY">
+                      <catDesc>Museo Calceolari</catDesc>
+                    </category>
+                    <category xml:id="tla3MPFFN77RZHKHBYITBAF65U7ZE">
+                      <catDesc>Museo Lapidario Maffeiana</catDesc>
+                    </category>
+                    <category xml:id="tlaG4JJQJFTHNF4VLPR2W6TEZO6P4">
+                      <catDesc>Museo de Castel Vecchio</catDesc>
+                    </category>
+                    <category xml:id="tlaY4YL72XANJCDVGIIF7MTGMITDQ">
+                      <catDesc>Museo Archeologico al Teatro Romano</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaTXQ7EHZXENAQLF2Z4ESFEZSWD4">
+                    <catDesc>Rom</catDesc>
+                    <category xml:id="tla2JXJ4SDY5VGTNLZDKRNFJCRRFM">
+                      <catDesc>Museo Lapidario Paoliano</catDesc>
+                    </category>
+                    <category xml:id="tla6IIEQMLTLBGE5GJ4AEHWYIQ63Y">
+                      <catDesc>Museo Nazionale di Villa Giulia</catDesc>
+                    </category>
+                    <category xml:id="tlaEM5RWDBWUFB3TGIPJH3W4HZS6E">
+                      <catDesc>Villa Albani</catDesc>
+                    </category>
+                    <category xml:id="tlaKOW352DCXNHU5GF64YVU5PLTGA">
+                      <catDesc>Villa Ludovisi</catDesc>
+                    </category>
+                    <category xml:id="tlaMIMTIDYJCNHM5LAAUMWPTKM7T4">
+                      <catDesc>Università, Museo del Vicino Oriente Antico</catDesc>
+                    </category>
+                    <category xml:id="tlaO3BHF3B6DZEG7BEWRQOBNOLOEI">
+                      <catDesc>Museo Nazionale Romano</catDesc>
+                    </category>
+                    <category xml:id="tlaT7ZBSJHPNZDJRAGWEWIK66R44U">
+                      <catDesc>Museo Torlonia</catDesc>
+                    </category>
+                    <category xml:id="tlaTF7SKMFH35CC5JG2AUICE3ZOUE">
+                      <catDesc>Museo dei Conservatori</catDesc>
+                    </category>
+                    <category xml:id="tlaTSTTLG64WVGMRCTGOK54GQZYDY">
+                      <catDesc>Museo Capitolino</catDesc>
+                    </category>
+                    <category xml:id="tlaTZEA5KEWZFE23LORV7T2FTSEQI">
+                      <catDesc>Museo Barracco</catDesc>
+                    </category>
+                    <category xml:id="tlaXIFWTIKLNBDGVJ4JN2EHK4VSIE">
+                      <catDesc>Collegio Romano</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaV6FIWMSOFJEGFFSDBIL3MOVDQI">
+                    <catDesc>Taranto</catDesc>
+                    <category xml:id="tlaNTM7BPDPIVBP7NYXFHUDQZJ7WY">
+                      <catDesc>Museo Nazionale, Museo Archeologico</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaXS2EJZQDZ5GIXIOMSMRIA3NYB4">
+                    <catDesc>Sorrento</catDesc>
+                    <category xml:id="tlaZKDKINXXGFBWFD52TIVFMX7M7Y">
+                      <catDesc>Museo Correale di Terranova</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tlaU2PPBYY5AVGDRCMXMT6ZGUQCEQ">
+                  <catDesc>(Städte A-C)</catDesc>
+                  <category xml:id="tla274EBRTPFFDNVJGRRPIFINJCVU">
+                    <catDesc>Bologna</catDesc>
+                    <category xml:id="tlaK7XLLNZYINAGLPV3K67N2HBVXI">
+                      <catDesc>Museo Civico Archeologico</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla3LDEQNANFNF7RL7F7BAHEP4RMY">
+                    <catDesc>Aquileia</catDesc>
+                    <category xml:id="tlaJSHJHX6FCRAZNAQPCGOLPGEWFI">
+                      <catDesc>Museo Archeologico</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla4EYJJNIZX5CAVATMIXZZEL3GRI">
+                    <catDesc>Asti</catDesc>
+                    <category xml:id="tlaLRFCLXX4A5B3XK7C2I3O76FDGU">
+                      <catDesc>Museo Archeologico e Paleontologico</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla4VOZWF7VWVEABNEMPXQXLI3BGY">
+                    <catDesc>Cortona</catDesc>
+                    <category xml:id="tlaIV2YNHJRQ5AYDIW4XLEYV47CPQ">
+                      <catDesc>Museo dell'Accademia Etrusca</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla6LDV52CG7ZDHNPAXPRSCPB3PLY">
+                    <catDesc>Brescia</catDesc>
+                    <category xml:id="tlaCAIPFUNW4NEZ3EZOGWD5ANCFGU">
+                      <catDesc>Museo Romano</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaCN4JO257SBGUNHVZVFPHUO3AUU">
+                    <catDesc>Albenga</catDesc>
+                    <category xml:id="tlaSZ5XANG5RJFZNNPUEVVR27RDPE">
+                      <catDesc>Civico Museo Ingauno</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaEG4DR67NAJHB5FVPLSKAKR7PRQ">
+                    <catDesc>Corneto</catDesc>
+                    <category xml:id="tlaFLOACCSI4BEPTLHVT4L5RK67GY">
+                      <catDesc>Municipal Museo Nazionale Tarquiniese (Botti)</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaGEMD6EGJMBA7ZKQFBLHBTUAMPQ">
+                    <catDesc>Cagliari</catDesc>
+                    <category xml:id="tlaIOVOPG6BBFAADKXM3N2CWKTJVQ">
+                      <catDesc>Museo Archeologico Nazionale</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaKZNUOIRYUNDQJLYH2MP7MUFNHY">
+                    <catDesc>Biella</catDesc>
+                    <category xml:id="tlaPHONYD7I6FBPBIVB6TA3T52KMQ">
+                      <catDesc>Museo Archeologico</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaNEC6YEPBNZECTIA6XJYBWTMKJY">
+                    <catDesc>Adrano</catDesc>
+                    <category xml:id="tlaJZQE3NTXQVGPHLHGKQHO36GH5Q">
+                      <catDesc>Museo Archeologico Etneo</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaNZTR3H6SIVG4HIDW5QIN52H5DU">
+                    <catDesc>Agrigent</catDesc>
+                    <category xml:id="tla4ZAM623VGFFGXL47FFMXUY5AB4">
+                      <catDesc>Museo Nazionale Archeologico</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaOXZ6KOEJJZCHTOV5H65TRIQWUY">
+                    <catDesc>Assisi</catDesc>
+                    <category xml:id="tlaQCJZ7GS2VNGIFDRJS4TIB76VAE">
+                      <catDesc>Biblioteca Comunale</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaRBY3ORCV2VF53PEEX57L2MKFX4">
+                    <catDesc>Aquila</catDesc>
+                    <category xml:id="tlaC65TOHVADRHF3P5KBE5N7LFWKY">
+                      <catDesc>Museo di Convento Francescano di S. Giuliano</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaRGGR43HZXBEFFHVMGY5DG32YTI">
+                    <catDesc>Chieti</catDesc>
+                    <category xml:id="tla5L33EEYZO5D4JOQNAIABX4MECM">
+                      <catDesc>Museo Nazionale di Antichità</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaRMGKHRERSJCLZJ5RFF7M3F5QFI">
+                    <catDesc>Ancona</catDesc>
+                    <category xml:id="tlaAT52UYSXHVDQ3HHBY7AITEF54I">
+                      <catDesc>Museo Archeologico Nazionale delle Marche</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaTKWM75E5IFCRLFYVOGQTIM5CQE">
+                    <catDesc>Como</catDesc>
+                    <category xml:id="tlaBHHUJHKSBRFAJOWG5NDEMFBOUQ">
+                      <catDesc>Museo Civico Archeologico P. Giovio</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaUMGWENNIVNELJGAGID5ALAN7HM">
+                    <catDesc>Catania</catDesc>
+                    <category xml:id="tla25MU6266ZNA3THETKDXJAKFS2Q">
+                      <catDesc>Museo Civico Castello Ursino</catDesc>
+                    </category>
+                    <category xml:id="tlaGD4M6EJDO5DNRCIIKB73O2E2HU">
+                      <catDesc>Museo Biscari</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaVR7G3ADASRFUVLZSJVXSTKE56U">
+                    <catDesc>Asola</catDesc>
+                    <category xml:id="tlaK24S7EGCNFHSDPBZHTBOPE354Q">
+                      <catDesc>Museo Civico</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaWD2USWWX4ZGRTJJ2YH7OC3RMOQ">
+                    <catDesc>Cremona</catDesc>
+                    <category xml:id="tlaZBVKC4CTVRGN3KDDGKYUQWI47M">
+                      <catDesc>Museo Civico</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaWO7FOUBGXNHWZAPNGVS2YKE4VE">
+                    <catDesc>Bergamo</catDesc>
+                    <category xml:id="tlaKLHLDH7RIBDBJDFE64L52SPAPY">
+                      <catDesc>Civico Museo Archeologico</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaXAXPQMJAMNCMRHF5CZVNUAWBMI">
+                    <catDesc>Benevent</catDesc>
+                    <category xml:id="tlaLAFLQZJLQBFVNOLUYFWRR656Y4">
+                      <catDesc>Museo del Sannio</catDesc>
+                    </category>
+                    <category xml:id="tlaLVJKHB6R2ZD4TM4AVXXY63JE5I">
+                      <catDesc>Museo Provinciale</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tlaWJAQ33CUFVDQDHCH5AI2ILMXUI">
+                  <catDesc>(Städte D-P)</catDesc>
+                  <category xml:id="tla4ACPAMYQD5CI3B2SMTPFJQLD7I">
+                    <catDesc>Florenz</catDesc>
+                    <category xml:id="tla7FMGIO5SCBGW5PVONNAOZFEZLU">
+                      <catDesc>Istituto Papirologico G. Vitelli</catDesc>
+                    </category>
+                    <category xml:id="tlaHDCQBURZ3VFV5NBRX2FZXTSJ2U">
+                      <catDesc>Museo Civico Archeologico</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla6R4XQIBMOZE7NATT5623UAD6JI">
+                    <catDesc>Domodossola</catDesc>
+                    <category xml:id="tlaYAWUXBEPJVAAJNRQZDT5B6BXLM">
+                      <catDesc>Museo di Palazzo Silva</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaAGSHU4KD2NFSRJ5ZT3XOKTNLHQ">
+                    <catDesc>Parma</catDesc>
+                    <category xml:id="tlaOU4YCHALU5DPLF5QTOBDYYWGJM">
+                      <catDesc>Museo Archeologico Nazionale</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaAJIADQV2KRAN7GDLPMVG72YAKY">
+                    <catDesc>Orbetello</catDesc>
+                    <category xml:id="tlaW355DG4GXJDK7I62LTDO2WJ6MM">
+                      <catDesc>Museo Archeologico</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaATT65PA5EJEKRM6AO5IFMRG6V4">
+                    <catDesc>Grottaferrata</catDesc>
+                    <category xml:id="tlaSFJVGPDOKRD4VE4NQTKZFYEP64">
+                      <catDesc>Museo dell'Abbazia</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaB6YW7ADXCFAXXPFXDAFWWTFIEE">
+                    <catDesc>Pisa</catDesc>
+                    <category xml:id="tlaFLAT4EZU7ZHFFF2CKV3AZX7P4A">
+                      <catDesc>Instituto d'Archeologia</catDesc>
+                    </category>
+                    <category xml:id="tlaWXPAZEUMLJGSRN5KPB2IIBHBPM">
+                      <catDesc>Museo dell'Opera della Primaziale</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaDD2F5U5XCVATJDGS3OXIV2UTNY">
+                    <catDesc>Pegli</catDesc>
+                    <category xml:id="tla23ACQIRA4JAXXMMGCYAWI4TNQE">
+                      <catDesc>Museo Civico di Archeologico Ligure, Villa Durazzo Pallavicini</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaFZC6IXOJYRGWRLH2EXF62L3TBA">
+                    <catDesc>Ostia Antica</catDesc>
+                    <category xml:id="tlaPCSCHTWOGBFL7DNYS7LZJI7AWE">
+                      <catDesc>Museo Ostiense</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaJGHBXNK2GZACXNAFNXULOA2NTM">
+                    <catDesc>Mailand</catDesc>
+                    <category xml:id="tlaJ2LJQEC7IJCEJEJJNOFSFCUERM">
+                      <catDesc>La Civica Raccolta Egizia, Castello Sforzesco</catDesc>
+                    </category>
+                    <category xml:id="tlaZO5PAPE7ABAVBGPCTPA6K3YUKY">
+                      <catDesc>Raccolte d'Arte</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaMF3LR5LBONA55JVTCCUTNBY3C4">
+                    <catDesc>Genova-Pegli</catDesc>
+                    <category xml:id="tla6IKZI7ZEY5HYNM6BPQRFVJTTDQ">
+                      <catDesc>Museo Civico</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaMXH2TP6MXZCPLILJBCGUN5CF3Q">
+                    <catDesc>Fiesole</catDesc>
+                    <category xml:id="tlaUWP465DBCJAN7CI4C6JK5LDGUQ">
+                      <catDesc>Museo Etnologico Missionario di San Francesco</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaNUG7IW6BOVGYBIY72BMFWRHMIU">
+                    <catDesc>Pavia</catDesc>
+                    <category xml:id="tlaO6ZDAQXANRAN3G34SYTCDOBXBY">
+                      <catDesc>Museo Civico</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaNUTQHL4WHRCUPBSL2HYNMQOJDA">
+                    <catDesc>Ischia di Castro, Isola di</catDesc>
+                    <category xml:id="tla555BUOXMT5C7VKRO73IZL5VNU4">
+                      <catDesc>Museo Civico 'Pietro Lotti'</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaO3ECQKPMJJEXHAICTBMITH3UHM">
+                    <catDesc>Palermo</catDesc>
+                    <category xml:id="tlaFKPELVJATBDJLADL5CFV4KUQJA">
+                      <catDesc>Museo Archeologica Regionale</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaRYTGNENPSRCD7PTW4L73ALEDAM">
+                    <catDesc>Modena</catDesc>
+                    <category xml:id="tla2W46J3OED5ACLGODKN2WQ2GF5M">
+                      <catDesc>Soprintendenza ai Beni Artistici e Storici per le Province de Modenae Reg</catDesc>
+                    </category>
+                    <category xml:id="tlaWY7KWDG36ZE5JHJI6NQT25ILBI">
+                      <catDesc>Museo Civico Archeologico e Etnologico</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaTBQKLPOBD5CFTHFLX2TYCEB5JM">
+                    <catDesc>Ferrara</catDesc>
+                    <category xml:id="tla7UCVCBM6WVFEBM22WLFTPV453U">
+                      <catDesc>Museo Civico di Schifanoia</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaTOEZF4RXKJFWBH7HMSBWLYH3SQ">
+                    <catDesc>Mantua</catDesc>
+                    <category xml:id="tlaDO5ETBDG2BGIXFM2LNIRBHPIR4">
+                      <catDesc>Galleria e Museo di Palazzo Ducale</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaUZPF4YSB4VETBLKQK5B7YSDXXM">
+                    <catDesc>Neapel</catDesc>
+                    <category xml:id="tlaG7VZG6DL6ZEGNF46WUC74XX7ZQ">
+                      <catDesc>Museo Archeologico Nazionale &amp; Coll. Borbonica, Museo Real &amp; Collborgia</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaV23362RJOJHA5IMPBYUCZJX7MY">
+                    <catDesc>Faenza</catDesc>
+                    <category xml:id="tla7RQOE7FUSZETNDR43TPOJ3QXBE">
+                      <catDesc>Museo Internazionale delle Ceramiche</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaVG7MSOMRMFDC5K7KTOWL36XVO4">
+                    <catDesc>Messina</catDesc>
+                    <category xml:id="tla2MKKLYM75NCP7O7GNMRLZJUAOM">
+                      <catDesc>Museo Nazionale</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaYSTPTI2N6VGRBKJ4WLNMM4YATM">
+                    <catDesc>Padua</catDesc>
+                    <category xml:id="tlaKSTJ4XIMZNFBBHAJCVB2YZDNGE">
+                      <catDesc>Palazzo della Ragione</catDesc>
+                    </category>
+                    <category xml:id="tlaUD4C77M27JGBROZ6ZMPW727UPE">
+                      <catDesc>Museo Civico di Padova, Museo Archeologico</catDesc>
+                    </category>
+                    <category xml:id="tlaWQGOLMGQOZBQDGIOOK7UYJWUDM">
+                      <catDesc>Museo di Storia Naturale dell'Università</catDesc>
+                    </category>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaOTDMR4T63BCJTDHOITFLHT46AA">
+                <catDesc>Slowenien</catDesc>
+                <category xml:id="tlaBCBAU7VN2VDJRFK232ADTBZ4KE">
+                  <catDesc>Ljubljana</catDesc>
+                  <category xml:id="tla6UUXC6HR5NC4JILMAYOMQBBGD4">
+                    <catDesc>Narodni Muzei</catDesc>
+                  </category>
+                  <category xml:id="tlaZUGV6IOSV5G45F5EUHHZDMB6Q4">
+                    <catDesc>Slovenski Etnografski Muzej</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaFSX372KGINDEHJZWDSSG3B46XA">
+                  <catDesc>Ptui</catDesc>
+                  <category xml:id="tlaK6GMEWNR4JBB7CVNTHGLNR6CN4">
+                    <catDesc>Pokrajinski Muzej</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaUDGWV64BNVB77C5753QN4PVQKA">
+                  <catDesc>Maribor</catDesc>
+                  <category xml:id="tlaST2UVZOMYRAXLFR2DTNWMZSCOM">
+                    <catDesc>Pokrajinski Muzej</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaRWBYFEPBKNGRFGMCM7RMGRQ4RE">
+                <catDesc>Ukraine</catDesc>
+                <category xml:id="tla3DXPJMFHQRHUPE7JKRDIHRTOBU">
+                  <catDesc>Nikolajew</catDesc>
+                  <category xml:id="tlaQ4GXP2AKFFELRIKFW3E6KZTQKE">
+                    <catDesc>Nikolayev Regional Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla5YSOHXEW6BC47CYBICODRDE24E">
+                  <catDesc>Simferopol</catDesc>
+                  <category xml:id="tlaD4RPQWAWRNA3ZI33SPM33WUXBM">
+                    <catDesc>Crimea Regional Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaAGTDDVJYNFDEDO4JIHY4ALPUY4">
+                  <catDesc>Poltawa</catDesc>
+                  <category xml:id="tlaVMVDRKAZCZGWRDR5GA7K2R4HOU">
+                    <catDesc>Poltava Regional Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaBMUDDYUJNBEWHFM5LI5THDCF5Y">
+                  <catDesc>Lwow</catDesc>
+                  <category xml:id="tla3J74CLCLCVB7PGOGCWWUVBV6LY">
+                    <catDesc>Museum of Ethnography and Handicraft of Ukraine</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaHEEDDQOH2VHGREDCFIUHHCTYKQ">
+                  <catDesc>Odessa</catDesc>
+                  <category xml:id="tlaBNEFNJ3WGZEEJEXRQR64MI3IZA">
+                    <catDesc>Odessa Archaeological Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaP6L6PYHBFBD5RPUHTVY5MOGWI4">
+                  <catDesc>Sewastopol</catDesc>
+                  <category xml:id="tla2ZCJWLOCTVCTHIFT4UGK4ZETBU">
+                    <catDesc>Khersones State Collection of History and Archaeology</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaPVCLCJUY2FARRNSNMWLIY2AIGU">
+                  <catDesc>Bachtschisarai</catDesc>
+                  <category xml:id="tlaOBWAOI7CS5EWRJ2W7LBFM3N34Y">
+                    <catDesc>Bakhchisarai Museum of History and Archaeology</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaTZF2UJTFHZBUNKFIQF4XBPGEMA">
+                  <catDesc>Kiew</catDesc>
+                  <category xml:id="tla4V6GMPBD7BADZE3WNPJZA23COM">
+                    <catDesc>State Historical Museum of Ukraine</catDesc>
+                  </category>
+                  <category xml:id="tlaMQOD6ZP2GZGEHJMKCV5VYHM5TY">
+                    <catDesc>Kiev Lavra Monastery</catDesc>
+                  </category>
+                  <category xml:id="tlaS2WLNJWNJBBTXDYIYHYJW6MKTU">
+                    <catDesc>Archaeological Museum of St. Vladimir University</catDesc>
+                  </category>
+                  <category xml:id="tlaW5PFQY3RZFHFHC4JAMEOZ76FRE">
+                    <catDesc>Kiev Museum of Western and Eastern Art</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaW63FSRTBXJFY7AXPKTZIWBDT5Q">
+                  <catDesc>Jewpatoria</catDesc>
+                  <category xml:id="tlaEWWQ2VPW4ZBHDHLVTWNYXZOFMM">
+                    <catDesc>Evpatoria Regional Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaWWGVXI6RENBDDLQ5NCJABMP2ZI">
+                  <catDesc>Dnapropetrowsk</catDesc>
+                  <category xml:id="tlaQNZKL5WU2JA4PIWDGVNBA2VU54">
+                    <catDesc>Dnapropetrovsk Museum of History</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaSBDBXMJRGFARHA5WQGMRJ7CAFY">
+                <catDesc>Lettland</catDesc>
+                <category xml:id="tlaPBMJT2RAXZFQDKUZZFPSO7PZGE">
+                  <catDesc>Jelgava</catDesc>
+                  <category xml:id="tlaQOBA554BWNE73JAWALWDGBZOHI">
+                    <catDesc>Kurländisches Provinzialmuseum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaUEDQAYQY6VFATFC5XYKWPMPDPI">
+                  <catDesc>Riga</catDesc>
+                  <category xml:id="tlaDYMQ2LG4AREPXNN7KUQBFDTMLI">
+                    <catDesc>Museum of Foreign Art</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaT3COBVD2SBGUHEOFKXAHVDXOPY">
+                <catDesc>Malta</catDesc>
+                <category xml:id="tlaY4WHXCUKGBDKBFK6ACK5N2W33Q">
+                  <catDesc>La Valetta</catDesc>
+                  <category xml:id="tla62SVAYTRH5GI5PWTGG6ALAPHZY">
+                    <catDesc>National Museum</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaTHUMNW4C2RDLRA5AGOOQZYJXHU">
+                <catDesc>Großbritannien</catDesc>
+                <category xml:id="tlaA2PMDEWNEZE4RNSKMGIAKMAPUY">
+                  <catDesc>(Städte D-J)</catDesc>
+                  <category xml:id="tla5NNWA5BOUNF5DBBE5QUJ43GDK4">
+                    <catDesc>Dundee</catDesc>
+                    <category xml:id="tla5FP7MGXYCRGBFMJILOF4CWPMKU">
+                      <catDesc>Central Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla5RDTTOE42JF7XA7BDRYEDVUEKA">
+                    <catDesc>Greenock</catDesc>
+                    <category xml:id="tlaC4FE7UDBJ5GSJBC2WVA345TSCA">
+                      <catDesc>MacLean Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla6Y5MYBFUPZG7PMMLJ5IEATPRKQ">
+                    <catDesc>Durham</catDesc>
+                    <category xml:id="tlaUJEYOIKSORHGTMNQ5CA2LFFPMQ">
+                      <catDesc>University Oriental Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaAOQA7KCT4RF2HKZA7CXBZ2O2LQ">
+                    <catDesc>Dorchester</catDesc>
+                    <category xml:id="tlaSCXHTJJBEZHF3CHJQXP3VRBT4M">
+                      <catDesc>Dorset Country Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaVFIHCJTF55BH3OBG6DA22ZIGCQ">
+                      <catDesc>Tutankhamun Exhibition</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaAVWMIIJ7HRBUPBXUPII6AKNCCQ">
+                    <catDesc>Harrow</catDesc>
+                    <category xml:id="tlaFKJHY6ZDGFHZRCQCBTEASHHRL4">
+                      <catDesc>School Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaCJ7DF3TJFBDTBGNBPMLQ4Y5MTY">
+                    <catDesc>Derby</catDesc>
+                    <category xml:id="tlaBLVIHNIS55E5RNV2263TVWYA64">
+                      <catDesc>Museums and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaCJHGE55MUZFU7JGR3MA5AC7WOU">
+                    <catDesc>Dewsbury</catDesc>
+                    <category xml:id="tlaZHYM4KHV7NFQXHLVWGJPOIYTSQ">
+                      <catDesc>Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaH6J4OXHCIBH4JF2CCHVXKKPPEU">
+                    <catDesc>Harrogate</catDesc>
+                    <category xml:id="tlaWXMVVOAIRNH2NHEZO2P3WTE3PE">
+                      <catDesc>Royal Pump Room Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaHHV66POYGZBYHOM2WFL5MY7HPA">
+                    <catDesc>Gloucester</catDesc>
+                    <category xml:id="tla4MQQUNVWGVBFTBBGQVLBOYS7JM">
+                      <catDesc>City Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaK7UZ2ZLWWNGAXA4H5GIASAIBDU">
+                    <catDesc>Haslemere</catDesc>
+                    <category xml:id="tlaDHUO2V6YCBGPTI2ZSYX5ZHHL6Y">
+                      <catDesc>Educational Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaKQFUOSSRBRFNHC6TNGIPOPOSTE">
+                    <catDesc>Godalming</catDesc>
+                    <category xml:id="tlaMCOPXKVSDBDIZEIKH5ZKK4IXQE">
+                      <catDesc>Charterhouse School Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaLIT6R454JBE3VAVDIW35I5CTIE">
+                    <catDesc>Ipswich</catDesc>
+                    <category xml:id="tlaXDH6WYS7F5APTHRZYKJDN6UY2I">
+                      <catDesc>Ägyptische Sammlung</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaLQXTJLRVLBHS7GW6CEHPAKGYIM">
+                    <catDesc>Edinburgh</catDesc>
+                    <category xml:id="tla6DVDOLKUJVE2RO3KN77EVGMADQ">
+                      <catDesc>National Museums of Scotland, The Royal Museum of Scotland</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaN32BSIXINVADTEA62SEEQZE2SI">
+                    <catDesc>Hastings</catDesc>
+                    <category xml:id="tlaUQR4WQVNORBOHGNS7L3AHQTOMU">
+                      <catDesc>Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaPYG6I3CXQNHS7CCPO5YRJZOCYI">
+                    <catDesc>Enfield</catDesc>
+                    <category xml:id="tla555TFXGZFBABZJOUJ6PCJI5GWA">
+                      <catDesc>Forty Hall Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaQ35CCGARSBGLRO4HS62PGQ4YSU">
+                    <catDesc>Jersey</catDesc>
+                    <category xml:id="tla44YJNJ6FFFGI5MQNS6MNXGNBNM">
+                      <catDesc>Ägyptische Sammlung</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaS34IMLWVIJECXI4T6RZQYE4WWQ">
+                    <catDesc>Eton</catDesc>
+                    <category xml:id="tlaFUNCXVMZBFEARGARKXRKOXXZNI">
+                      <catDesc>Myers Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaU2K5SMHVENDHHNKTQA7VUB35JA">
+                    <catDesc>Glasgow</catDesc>
+                    <category xml:id="tla54WF4I6QCNBR7LKEAOBFU6UWCQ">
+                      <catDesc>Hunterian Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaF2IPWKXUIJAU7AFVUSJPQ5BHLU">
+                      <catDesc>Art Gallery and Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaYKVROYHE4VGQHDJR53RHKCPGDQ">
+                      <catDesc>Burrell Collection</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaVVEECOLWCZF2JJNXUTJGUGL2MI">
+                    <catDesc>Grantham</catDesc>
+                    <category xml:id="tlaTI36WFQBWJDUVEC6YYDK6NZ75I">
+                      <catDesc>Ägyptische Sammlung</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaX2IQWO4G2JDJHFID5CMQ47E2HY">
+                    <catDesc>Exeter</catDesc>
+                    <category xml:id="tla37W2IPMDFNFEFPNYYO5XOZOD7E">
+                      <catDesc>Royal Albert Memorial Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaQIKJIV6HN5HNVCR3EYVG2HUDX4">
+                      <catDesc>Rougemont House</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaY55GLGXZ5RG63ASNKPVEVDBRDQ">
+                    <catDesc>Halifax</catDesc>
+                    <category xml:id="tlaO2CPYABZC5BDZKG4KVF7BFNX3Y">
+                      <catDesc>Bankfield Museum</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tlaBOMGVJHJWJC4ZPU4UEDSND7T3M">
+                  <catDesc>(Städte T-Z)</catDesc>
+                  <category xml:id="tla42ANXGDCHFD3TOA2PKLKNOT2JQ">
+                    <catDesc>Wimborne</catDesc>
+                    <category xml:id="tlaUT22S2P5DNBR3H7IH55VXNZ36I">
+                      <catDesc>Bankes Collections</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla6JU2NYWQRZG2DNKXZRPQCWBM4U">
+                    <catDesc>Wells</catDesc>
+                    <category xml:id="tlaA4NV6PEACNCYZKH7TGUCGYQKZU">
+                      <catDesc>City Library</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaCQKHRIJSRVHAJOOQUM3YEFKWQA">
+                    <catDesc>Welshpool</catDesc>
+                    <category xml:id="tlaWIF25CFV4JFHFPM6YF5F2CEWLM">
+                      <catDesc>Powysland Museum and Montgomery Canal Centre</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaDYZ64IGSYBABDCX5BZ7ZUJ4INE">
+                    <catDesc>Wakefield</catDesc>
+                    <category xml:id="tlaPQNQUIP3JBAHDIHKYUS5UARHDI">
+                      <catDesc>City Museum, Metropolitan District Council Art Galleries</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaEJMFK7UPTBHQRN4JXCYIMTQUP4">
+                    <catDesc>Walsall</catDesc>
+                    <category xml:id="tlaCZDUVULZKZAWVCACO2EX2NNESI">
+                      <catDesc>Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaGETNONVCPJBVZGFNMRCMLZFKXU">
+                    <catDesc>York</catDesc>
+                    <category xml:id="tlaP5NCRXCV2NEKNCL3KDROYNNUJM">
+                      <catDesc>Yorkshire Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaJD4NAMK7MFGE3BXNRKJQCT7Y5U">
+                    <catDesc>Whitby</catDesc>
+                    <category xml:id="tlaB5I5BAUCG5GNBPOWXLOUNQ24NA">
+                      <catDesc>Whitby Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaJHCJE7ZAQJAQZC54HGC5QXJNHE">
+                    <catDesc>Truro</catDesc>
+                    <category xml:id="tlaIXA6W6JCUFBIJBQLJLRDH35CGM">
+                      <catDesc>The Royal Cornwall Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaKHEJFZ3KPZBUNGOB4FKHT6AGM4">
+                    <catDesc>Warwick</catDesc>
+                    <category xml:id="tla7SLCJVGJ75A2FNVOHFTVO4JRGQ">
+                      <catDesc>Warwickshire Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaKJ4SD4NJMVAARPEVSNFZ3PPZHA">
+                    <catDesc>Windsor</catDesc>
+                    <category xml:id="tla7FY6FSUEAVB7DMN4EJ3IEJRQWA">
+                      <catDesc>Myers Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaZAGQKE6NSNFJXEDV6RAXFVYW74">
+                      <catDesc>Eton College</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaLBTHCSWTJVABBM6CXJ3SWMXQNA">
+                    <catDesc>Wisbech</catDesc>
+                    <category xml:id="tlaLRBJSDY3LRCPJGWTR7Y6RW4GFU">
+                      <catDesc>Wisbech and Fenland Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaMOSI2DCY4VBOVMLZQUIK2LLIFI">
+                    <catDesc>Warrington</catDesc>
+                    <category xml:id="tla62UGNHDUYRAGHBZ55Y4UFHHP6Q">
+                      <catDesc>Ägyptische Sammlung</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaMRUF7VQHHZCCXDNILM5OTM5ZVM">
+                    <catDesc>Tunbridge Wells</catDesc>
+                    <category xml:id="tlaY3QIS7XB5NHXZFUSUAJPX36Q4E">
+                      <catDesc>Municipal Museum, Tunbridge Wells Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaQF6TZI6RSNGUPAGV2WIC5WP244">
+                    <catDesc>Wigan</catDesc>
+                    <category xml:id="tlaYXP7XEA6KVC6JNZVM76SR3XFPY">
+                      <catDesc>Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaR65UF7OCVNDN7KBB76UUHTJ7WI">
+                    <catDesc>Tamworth</catDesc>
+                    <category xml:id="tlaR6RIVALSP5F6NHLHBGQ5DF45GM">
+                      <catDesc>Tamworth Castle and Museum Service</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaT2EVZGN2QFE5HLKB47FFC3GJAU">
+                    <catDesc>Torquay</catDesc>
+                    <category xml:id="tla4SMRWM7QZZHJXBPVE23EMDWC5M">
+                      <catDesc>Torquay Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaVJDKPYQ2IBFWJLZBWHTLMPFCX4">
+                      <catDesc>Natural Hist. Society Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaTDENTTRPCVDMNNOUE6KS2RVCPA">
+                    <catDesc>Winchester</catDesc>
+                    <category xml:id="tlaB5LPMC2BYBERZF4UVWOS3656SU">
+                      <catDesc>Winchester City Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaMEIMBMI6O5GOFDMC4NO54R6L4M">
+                      <catDesc>Winchester College Treasury</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tlaBUY467R3CVAKXKL7SYE222OYTA">
+                  <catDesc>(Städte A-C)</catDesc>
+                  <category xml:id="tla42AVITFYCBDI3OCAPKJVUNS2XE">
+                    <catDesc>Alton</catDesc>
+                    <category xml:id="tlaRJZKDSD7MBE6VLHW74U3TFXHUE">
+                      <catDesc>The Curtis Museum and Allen Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla4JMFPSBKARG2TEJA5K7KUG75G4">
+                    <catDesc>Belfast</catDesc>
+                    <category xml:id="tla26TKRY4O5VGJVPNPMZK5NLSR2Q">
+                      <catDesc>Ulster Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla67XSE7BISNEOJO7FYAHO4BVXBA">
+                    <catDesc>Blackburn</catDesc>
+                    <category xml:id="tlaLN46JGGGEFFRBBANSWJ6HEMMK4">
+                      <catDesc>Blackburn Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaBSFNVAN7BZCQDFCVLP46FX5UYA">
+                    <catDesc>Bolton</catDesc>
+                    <category xml:id="tlaIZEQ7UAZDZDVNGHGKSUJB3BHVU">
+                      <catDesc>Bolton Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaCDSYSRR2OFBFBA74HNQ4NXPM44">
+                    <catDesc>Brighton</catDesc>
+                    <category xml:id="tlaDCAEPZ74S5DTLJ45YBAVTQ4DCI">
+                      <catDesc>Art Gallery and Museum, North Gate House</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaDP4NJTLYRNHONDNTJTE3WR5VXE">
+                    <catDesc>Bath</catDesc>
+                    <category xml:id="tla2TJ6VHHUANCTNOHJVBAWIZMNUE">
+                      <catDesc>Royal Literary and Scientific Institute</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaDSVSDUZMENADRLR3ZAK4GSQ7GE">
+                    <catDesc>Croydon</catDesc>
+                    <category xml:id="tlaPV25V2OK6NCWNDHICYG4ZBTH7Q">
+                      <catDesc>Central Library</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaG3VNZJCCL5BAPHAXFD4F5JGSME">
+                    <catDesc>Batley</catDesc>
+                    <category xml:id="tla6MUJKMB3WRBVLGUCGTZ5QSZVCY">
+                      <catDesc>Bagshaw Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaHUCDUJITPZFZNBO7KJ2ZSHVO64">
+                    <catDesc>Cheltenham</catDesc>
+                  </category>
+                  <category xml:id="tlaIT3QYO4N3JGFXPPVCQPBRTALJE">
+                    <catDesc>Birkenhead</catDesc>
+                    <category xml:id="tla7NQROYPFXVAKTK2S3OKLHQJSBA">
+                      <catDesc>Williamson Art Gallery and Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaIXX6ORFDRNHJBAUQAW5C6KPG6U">
+                    <catDesc>Aberdeen</catDesc>
+                    <category xml:id="tlaIZRUH7NIAZCJZDUAEJT265KH4Y">
+                      <catDesc>Anthropological Museum, University of Aberdeen</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaKW6YT2QPBNCRJM7BHTUTEVEQWA">
+                    <catDesc>Chester</catDesc>
+                    <category xml:id="tlaKVEW4GNE2ZHU7HSGZOP6VP6NEQ">
+                      <catDesc>Grosvenor Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaLXKBND7HUZGUFJE4NHHYBHH6RY">
+                    <catDesc>Colchester</catDesc>
+                    <category xml:id="tla5VF7PZU3HRDCNJWMYRUFJ4NL2M">
+                      <catDesc>Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaGHLL254DHNHGFHDJ742Z33MHQI">
+                      <catDesc>Castle Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaYD47LDEI2NFOHCJV6EQZS3MQRU">
+                      <catDesc>The Hollytrees Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaM3VU3TDSS5FMHBMN7GQ4M62GJE">
+                    <catDesc>Caerleon</catDesc>
+                    <category xml:id="tlaWMMUP2CUJBEQXMEUQ33BIOWFZA">
+                      <catDesc>The Roman Legionary Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaMIEJZ36CLBFFJKZIM6YSN26LRE">
+                    <catDesc>Cardiff</catDesc>
+                    <category xml:id="tlaD3VF5NJ73NGAVNMOCSURNX46Q4">
+                      <catDesc>National Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaMM7GXB2E75FNVGSRG2CTHNM57U">
+                    <catDesc>Chelmsford</catDesc>
+                    <category xml:id="tlaK4NICS6F5RCFNOTZ3W4TVP6HVY">
+                      <catDesc>Chelmsford and Essex Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaPENH3LDTVNAK5AVBZYDLUER6QQ">
+                    <catDesc>Bristol</catDesc>
+                    <category xml:id="tlaTEPFXVCIWFEV5MUB5WEUUJAPSU">
+                      <catDesc>City of Bristol Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaPHJFJ6YSDZFF5ERIY4MPHTY4TA">
+                    <catDesc>Cambridge</catDesc>
+                    <category xml:id="tlaIXYNLNU7JJEWLA7MLMVNYB4TIU">
+                      <catDesc>Fitzwilliam Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaJSGGBZO7C5BKPI577L3HOAF5XY">
+                      <catDesc>University Museum of Archaeology and Ethnology</catDesc>
+                    </category>
+                    <category xml:id="tlaXCP522QXOZCZTDTG4ULQS27M34">
+                      <catDesc>Faculty of Oriental Studies</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaRVRDHS3Z2JC53JKUTZOVO2M234">
+                    <catDesc>Carmarthen</catDesc>
+                    <category xml:id="tlaOHU4MT5POVAU3P3WUXLQY7A2LU">
+                      <catDesc>Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaRWJMMZHEHRHT5IGG5ORMA43BSY">
+                    <catDesc>Canterbury</catDesc>
+                    <category xml:id="tlaITQZJW3V4FGDREFJGNQ3ZW5LFY">
+                      <catDesc>The Royal Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaVAH2NJQKAVHMFBHHLIDY4PB37E">
+                    <catDesc>Burnley</catDesc>
+                    <category xml:id="tlaDYIVY6YFANC4LMENMKDEZZ2FDY">
+                      <catDesc>Towneley Hall Art Gallery and Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaWN2NLYESVVEAJBPRWDGGME5V5Q">
+                    <catDesc>Bournemouth</catDesc>
+                    <category xml:id="tlaTE365A4USVBD5A6GKDGFT5V55I">
+                      <catDesc>Natural Science Society Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaXRJ2QNBJGVFTTHXAF2RVTSMH24">
+                      <catDesc>Russell-Cotes Art Gallery and Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaX26CZWGT2ZFKFHTYQ63NMTZXPA">
+                    <catDesc>Birmingham</catDesc>
+                    <category xml:id="tlaEOQASVTOMNDELOEV2INULXYNH4">
+                      <catDesc>Barber Institute of Fine Arts</catDesc>
+                    </category>
+                    <category xml:id="tlaHS2YVTOGBZD47EH53KXMJMJ7JA">
+                      <catDesc>City Museum and Art Gallery</catDesc>
+                    </category>
+                    <category xml:id="tlaRNOADGWASZFPFHKBIKWTOAWN6I">
+                      <catDesc>The University of Birmingham, Dept. of Ancient History &amp; Archaeology</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tlaD4QRV6XXR5HBDOYZ5F3QNPSZ2U">
+                  <catDesc>(Städte K-N)</catDesc>
+                  <category xml:id="tla235O2Q6OKFGBNGI6RE6MMIOKGA">
+                    <catDesc>London</catDesc>
+                    <category xml:id="tla54J2LBSPDFEYNPDHB4255KWQGA">
+                      <catDesc>Petrie Museum of Egyptian Archaeology</catDesc>
+                    </category>
+                    <category xml:id="tla7R4DWJSS4VDOZNTYIRVXUZA7KE">
+                      <catDesc>St. Paul's School Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaD2UE7L6FKBAE7ELORSK6HSYWFE">
+                      <catDesc>Central School of Arts and Crafts</catDesc>
+                    </category>
+                    <category xml:id="tlaDIONYIRZW5HCFBUV345KN2I554">
+                      <catDesc>Science Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaDNGIODWZN5DLFHQOWPOUB2UJ6I">
+                      <catDesc>Victoria and Albert Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaIASFUJ4OLZGHLGVHKKMMOTAFLM">
+                      <catDesc>Sir John Soane's Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaJ63RJ2T7KBDTNA3T5464FRWGQI">
+                      <catDesc>Wellcome Historical Medical Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaJDWCUPP66VA6PAUUEUAVFYHH5I">
+                      <catDesc>Royal College of Surgeons Museums</catDesc>
+                    </category>
+                    <category xml:id="tlaJMEAGLJDGJHLDJCXGLFGQ6FEFQ">
+                      <catDesc>British Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaKULXLMADCRC4PJTMUKYTH5T5EA">
+                      <catDesc>Islington Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaL7772UQX7ZBPTLMU647JL2772M">
+                      <catDesc>Royal Asiatic Society</catDesc>
+                    </category>
+                    <category xml:id="tlaMQ2UWWAUPZHJTM5YH6VMID5IDM">
+                      <catDesc>Royal College of Physicians</catDesc>
+                    </category>
+                    <category xml:id="tlaMYOFWWDOJBANVKG4JLPUA7ZWKI">
+                      <catDesc>Raleigh (NC)</catDesc>
+                      <category xml:id="tlaLL4GMMX2PFB27PZKSLERCDAHRA">
+                        <catDesc>North Carolina Museum of Art</catDesc>
+                      </category>
+                    </category>
+                    <category xml:id="tlaQG2Z3AIT2VENXOSERGHZN77MCU">
+                      <catDesc>United Services Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaST2RDLTL7FDZLJGKPOLBWUZT3E">
+                      <catDesc>Cuming Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaTJQAQ67ECZBERN2M3QKCAG47MU">
+                      <catDesc>Horniman Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaU4LKJOTX6RH7BKCPPMIYEUYYVQ">
+                      <catDesc>British Library</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla44TYEJ5JKNFNLIVK6VM22JYINQ">
+                    <catDesc>Keighley</catDesc>
+                    <category xml:id="tlaV2SIFIDLLNBQLKT33WW6YQ7JQ4">
+                      <catDesc>Cliffe Castle</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla7752G3FTTRAY3JQUBK65KR3UQA">
+                    <catDesc>Leeds</catDesc>
+                    <category xml:id="tlaXGTMNELYBZCAHEBZG2C77SCVE4">
+                      <catDesc>City Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla7AFEZ45E4FFN7EA3LWJEXMP3YI">
+                    <catDesc>Montrose</catDesc>
+                    <category xml:id="tlaYFR2T7G2SBHBLMI53YBPWL5A3E">
+                      <catDesc>Montrose Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaBWIYTYPE2RDSFFSXHBHT35NYJY">
+                    <catDesc>Northampton</catDesc>
+                    <category xml:id="tlaAULINLDBPJE3NCJPCEMQNHXSZI">
+                      <catDesc>Central Museum and Art Gallery</catDesc>
+                    </category>
+                    <category xml:id="tlaL3MUN3U4UVC3RL2XQLEXHAK64Q">
+                      <catDesc>Abington Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaEXUTKERJMBHHXIWD6CQSY53BVY">
+                    <catDesc>Kirkcudbright</catDesc>
+                    <category xml:id="tlaLHHFO4BMPRHRZBLMNNK5URDWVE">
+                      <catDesc>Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaGH5HXT2TXBD7LMFYWXVDR7FAAE">
+                    <catDesc>Lancing</catDesc>
+                    <category xml:id="tlaSJAXZZWZEFE7BFYXOFMSWMBFGI">
+                      <catDesc>Lancing College</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaIG47JRKPLRD4ZIIQAJKBFHY47Y">
+                    <catDesc>Newcastle-upon-Tyne</catDesc>
+                    <category xml:id="tlaITS2VGPIYBFOXKBCS7Q5KSYH6U">
+                      <catDesc>Museum of Antiquities of the University and the Society of Antiquaries</catDesc>
+                    </category>
+                    <category xml:id="tlaZ5UUMVCXCZG3ZCFFC7YQWIVELY">
+                      <catDesc>Hancock Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaJQNJUQE4QNCG3J3G3JDSYXEBVE">
+                    <catDesc>Norwich</catDesc>
+                    <category xml:id="tla3REOK3OYRFBGPEGHNHVCA53EEM">
+                      <catDesc>Castle Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaYEGNRNG7TVGLJHL57LYUKVKBJA">
+                      <catDesc>Sainsbury Centre for Visual Arts</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaKDSWHXFVVJCIBGVDACGVMNO7EM">
+                    <catDesc>Macclesfield</catDesc>
+                    <category xml:id="tlaNSAJ2XACUZAUFFPPFLPACIJZUA">
+                      <catDesc>West Park Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaKJ2FFFNTH5HDRKZ5TB7TZ5KOZU">
+                    <catDesc>Littlehampton</catDesc>
+                    <category xml:id="tlaIMIVA3C5WRD3XJW3HNE2YLNNOU">
+                      <catDesc>Ägyptische Sammlung</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaP6MRQAVMNVGP5JCBOXLYNBP23A">
+                    <catDesc>King's Lynn</catDesc>
+                    <category xml:id="tlaOWQPGF6HKNEJ7JIGOZPPZ2COGA">
+                      <catDesc>Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaQ4WZYTCR55DENLFTRT3P7BDZXU">
+                    <catDesc>Leicester</catDesc>
+                    <category xml:id="tla5FJMDRBKQBHYJM7WTKZSLMWTOU">
+                      <catDesc>Leicestershire Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaQOMXP3ZDRFFUFPP3HDUI3BFWCA">
+                    <catDesc>Manchester</catDesc>
+                    <category xml:id="tla6577VYEY3JGELDEJBWEFCAJVPI">
+                      <catDesc>Manchester Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaSDKSUD5ICJE43N7DP3ZSBEGXGA">
+                    <catDesc>Middlesborough</catDesc>
+                    <category xml:id="tlaWY52CKFF4FAGVKNBC575T4FXDQ">
+                      <catDesc>Dorman Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaSVN2DR2FTNBXLCB57XJT5UIIJA">
+                    <catDesc>Lincoln</catDesc>
+                    <category xml:id="tla4BZWIOJGABB3ZAKDPSCCPGG3I4">
+                      <catDesc>City and County Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaTOZJ7UUDHND2PALFVUYXEANXNY">
+                    <catDesc>Liverpool</catDesc>
+                    <category xml:id="tlaDHUZEDCKTFEQDNY2YE7AXVCMPU">
+                      <catDesc>School of Archaeology and Oriental Studies</catDesc>
+                    </category>
+                    <category xml:id="tlaN6F2Q4EMWVFVHNCIH2ZHABJQKE">
+                      <catDesc>Liverpool Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaUIWXMEFEAFH75NKSY52EZVDRWQ">
+                    <catDesc>Leamington Spa</catDesc>
+                    <category xml:id="tlaWXGQ7D4N3FFVZHRZU4NO2VNGQ4">
+                      <catDesc>Warwick District Council Art Gallery and Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaVU4STYW2ZBGFLGIMMM4C2LFYC4">
+                    <catDesc>Newport</catDesc>
+                    <category xml:id="tlaV6Z6CUOQVJAEZEFD3GJMTHEIYA">
+                      <catDesc>Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaWITA5P3A4FBB3AEMHCZMXNXMC4">
+                    <catDesc>Kendal</catDesc>
+                    <category xml:id="tlaRZKHKUCLN5HYFH2PXB43UEOJYE">
+                      <catDesc>Ägyptische Sammlung</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaX3P7EJKJV5FBTMSSBJDC5U5WLI">
+                    <catDesc>Maidstone</catDesc>
+                    <category xml:id="tlaCPIE25V4X5HUFFTR4EWLJPZNJE">
+                      <catDesc>Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaXHXQF3PJTVGPLDRKVYAS674S2E">
+                    <catDesc>Nottingham</catDesc>
+                    <category xml:id="tla2KMO65F2EJEQXEBA32WT7GS6CY">
+                      <catDesc>Castle Museum, City Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaY5BZW3RCGNHJBHNFGEOGWTE67E">
+                    <catDesc>Newbury</catDesc>
+                    <category xml:id="tlaDQUJG64EONF6DIGARKZ2UHCEK4">
+                      <catDesc>District Museum</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tlaPJI7AYL67RF27K4ZXU3CTUWZ44">
+                  <catDesc>(Städte O-S)</catDesc>
+                  <category xml:id="tla2TLHF3CCENERRB44E7BKE5FTUU">
+                    <catDesc>Saffron Walden</catDesc>
+                    <category xml:id="tlaTS4XIQE2LBABZHA6NE5GRG554Y">
+                      <catDesc>Saffron Walden Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla7KGDHE6BV5BDFBO54CJNOTY4GM">
+                    <catDesc>Port Sunlight</catDesc>
+                    <category xml:id="tlaFIAJVU32DZAJLK5OQ3PD4UTHYY">
+                      <catDesc>Lady Lever Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaA5POSSN2PZGUBEP2UVWF7D7KKY">
+                    <catDesc>Rotherham</catDesc>
+                    <category xml:id="tlaEUHVCMJYQRGLHH27LGXA5V4RN4">
+                      <catDesc>Rotherham Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaBDQGIII3MRDENFPMDPRVDOT624">
+                    <catDesc>Stockport</catDesc>
+                    <category xml:id="tla2NHW5NHZ4ZEN7AJXHRYOWXD75E">
+                      <catDesc>Stockport Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaWWDTC5LN6VEMFMK5CZJUHBQYIQ">
+                      <catDesc>Vernon Park Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaBGKMKBIGLRDCVPYVLQBPKLPRI4">
+                    <catDesc>St. Helens</catDesc>
+                    <category xml:id="tlaMGWGOLG655A67OGBPJSLE46ZCQ">
+                      <catDesc>St. Helens Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaCMLLNHYETNBM7BXKZG3IP5DV7Y">
+                    <catDesc>Scarborough</catDesc>
+                    <category xml:id="tlaLXJZWFYWQZBYDDGOMJBGXQDQT4">
+                      <catDesc>Woodend Museum, King Richard II House</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaDPTTPR6PVBCQBHDWXPKZTGQ67A">
+                    <catDesc>Stirling</catDesc>
+                    <category xml:id="tlaXMCXUB5ZIJE7VN3QBIXBXOUISQ">
+                      <catDesc>Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaDS4ILOU5CRBOFC4JFL7XEQ7TBY">
+                    <catDesc>Salford</catDesc>
+                    <category xml:id="tlaRPTEWV5WGNCEHNS57ASUNPH6MQ">
+                      <catDesc>Salford Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaEFGNXBLMBJDKPAJ6EXIBT5ELO4">
+                    <catDesc>St. Albans</catDesc>
+                    <category xml:id="tlaZCDE3ZUM2VDXLIUHBFT6X6OSF4">
+                      <catDesc>Museum of St. Albans</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaF6TQNH5TQFGATBEPIZKDE6U3LA">
+                    <catDesc>Penzance</catDesc>
+                    <category xml:id="tlaSCPFKLXPMBHBRNRBIJFBYFFJLE">
+                      <catDesc>Penlee House Museum, Museum of Natural History and Antiquarian Society</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaGGXCDWGDBZHUNISYW6FOTLCTLY">
+                    <catDesc>Rossendale</catDesc>
+                    <category xml:id="tlaHJW7NLU2JFAKLNDH6RBIL22FEE">
+                      <catDesc>Ägyptische Sammlung</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaJ65XJPPBTVBKHELFKQFBM6FNSM">
+                    <catDesc>Reading</catDesc>
+                    <category xml:id="tla7UCDZ75BS5FH7NYVCUKHJLL26Q">
+                      <catDesc>Museum and Art Gallery</catDesc>
+                    </category>
+                    <category xml:id="tlaFFNLXQ6S5ZEVNCJRXYM34KFHOI">
+                      <catDesc>The Ure Museum of Greek Archaeology</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaKOKNYOM7TFHQ3E6QSL3PIVG63Q">
+                    <catDesc>Rochdale</catDesc>
+                    <category xml:id="tla4XX3ZT3QZJFGHNRHBY4WWRBVJ4">
+                      <catDesc>Rochdale Museum, Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaLXMXXB7LJBERVOXVLPUMYZYMNQ">
+                    <catDesc>Salisbury</catDesc>
+                    <category xml:id="tlaV6LFKTCS6ZB57FGTEIU4BET6G4">
+                      <catDesc>Salisbury and South Wiltshire Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaNQTTSL4NXBE2DOTKIGHJ7I3G6E">
+                    <catDesc>Stoke-on-Trent</catDesc>
+                    <category xml:id="tlaAIJRX6XMJRDGVJ3JAYEEQIMKCQ">
+                      <catDesc>City Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaPBWDEWSFSFGLTNPFHCZCQM5BMU">
+                    <catDesc>Rugby</catDesc>
+                    <category xml:id="tlaKIZHKN2P5BEUXGBNHFUWLGHKMQ">
+                      <catDesc>Rugby School, Art Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaSVFFOO4VWZCUBLUBK34VG46NDE">
+                    <catDesc>Plymouth</catDesc>
+                    <category xml:id="tla5K6XX3EJOJDBDNLRT6S5QS3AQU">
+                      <catDesc>City Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaSWRSNV4DXVCDDP244KLSJZY2PM">
+                    <catDesc>Oxford</catDesc>
+                    <category xml:id="tlaG3JB6H4CTBFB5JFWVB4TSJNNO4">
+                      <catDesc>Ashmolean Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaJKU5XYFQCNB77ABOPVTNUWYTYQ">
+                      <catDesc>Bodleian Library</catDesc>
+                    </category>
+                    <category xml:id="tlaKELVMG6SERHCZG62UTQZWNSNOU">
+                      <catDesc>Queen's College</catDesc>
+                    </category>
+                    <category xml:id="tlaXWF3O3ZLHVEVRO6ZJOUYY67LC4">
+                      <catDesc>Pitt Rivers Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaVFV4M35B5BB4RF56FGL55BUZF4">
+                    <catDesc>Sunderland</catDesc>
+                    <category xml:id="tlaSKXNSUVPJJFV7E3WLAOJPZK3UY">
+                      <catDesc>Sunderland Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaVWC7LZBAB5DODEBY75ENDIEMJ4">
+                    <catDesc>Swansea</catDesc>
+                    <category xml:id="tla442QDMG43JDHBMW4HD2VAFDR5A">
+                      <catDesc>Wellcome Museum of Egyptian and Graeco-Roman Antiquities</catDesc>
+                    </category>
+                    <category xml:id="tlaVOYX55H74VHI5OHLEOCBDE2SBU">
+                      <catDesc>Royal Institution</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaW7JZEN7ND5FYFCLT3J2ZPYSI7I">
+                    <catDesc>Swindon</catDesc>
+                    <category xml:id="tlaG4C7S6S6YZBKFBZK3X7MWM4D6Q">
+                      <catDesc>Swindon Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaWBMQXIEWG5AQPLB3MF2K6B4JRA">
+                    <catDesc>Sheffield</catDesc>
+                    <category xml:id="tla5PBUP7WIMFHZRECRBNBH3QQBFI">
+                      <catDesc>Sheffield City Museum</catDesc>
+                    </category>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaTS6BPNNB7ZHGPEH22FVPDNC7K4">
+                <catDesc>Finnland</catDesc>
+                <category xml:id="tlaFSLEVDWBAJD7NLVAOYYHVWUMYQ">
+                  <catDesc>Helsinki</catDesc>
+                  <category xml:id="tlaB2C3TCUTHRCIVLU7GBPMEHW54A">
+                    <catDesc>Suomen Kansallismuseo, Ägyptische Sammlung</catDesc>
+                  </category>
+                  <category xml:id="tlaGWNQXGPZPRCUTLIMUKEWDO65R4">
+                    <catDesc>Didrichsenin Taidemuseo</catDesc>
+                  </category>
+                  <category xml:id="tlaRQWXHHKZPJDLJKJ7DMOB42GANQ">
+                    <catDesc>Ateneum</catDesc>
+                  </category>
+                  <category xml:id="tlaTTBQ47G7QVGRLCQLZLWTZXWOQY">
+                    <catDesc>Suomen Egypt. Seura</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaUT5VRBAZ4BDQLMMNNPJD3KWNVE">
+                <catDesc>Litauen</catDesc>
+                <category xml:id="tlaSF3RIRHEDBGUBNH54FC5BV5HUE">
+                  <catDesc>Vilnus</catDesc>
+                  <category xml:id="tla5OASW5AUHZEU7KD7TA4G6X4K6Y">
+                    <catDesc>Museum of History and Ethnography of Lithuania</catDesc>
+                  </category>
+                  <category xml:id="tla5QVSUJI43BB6VDCZV3SGCSWFQ4">
+                    <catDesc>Museum of Fine Arts of Lithuania</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaUC5SMEY2UZGBBO5I4ISYS2QUNQ">
+                  <catDesc>Kaunas</catDesc>
+                  <category xml:id="tlaY42R4YUI7RAUHCYELHDPJFHGCI">
+                    <catDesc>Kaunas Ciurlionis Museum of Art</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaUXZQRO4ONZHN3MXM3LS552Q45U">
+                <catDesc>Belgien</catDesc>
+                <category xml:id="tla5D3NPPGWPFGAXF3PS46BKVVF4Y">
+                  <catDesc>Leuven</catDesc>
+                  <category xml:id="tlaKZPH6DYU5ZBEZAXPZPJANMYDF4">
+                    <catDesc>Musée de Louvain-la-Neuve</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaAGMJAGAR3BDSFATXO427AHCRG4">
+                  <catDesc>Antwerpen</catDesc>
+                  <category xml:id="tlaMOGGUOQUJFEZFBZB6VSZHW64HI">
+                    <catDesc>Museum Vleeshuis</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaALX7T23SIREOTCDITQM6Q5PEUI">
+                  <catDesc>Mariemont</catDesc>
+                  <category xml:id="tla2CMY3FB6NBAY7J2DBWL3MYANEA">
+                    <catDesc>Musée Royal et Domaine de Mariemont</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaQXJ6XEVPJJENLEWXSZYNARSCWU">
+                  <catDesc>Brüssel</catDesc>
+                  <category xml:id="tla43UUYLI4Z5DRPDY4OZNXVJXE6Y">
+                    <catDesc>Fondation Égyptologique Reine Élisabeth</catDesc>
+                  </category>
+                  <category xml:id="tlaCFIJHEZAW5ELTGLIBBW3PZYGAQ">
+                    <catDesc>Archives et Musée de la Littérature, Bibliothèque Royale Albert</catDesc>
+                  </category>
+                  <category xml:id="tlaHCXUROQTOBFNDE4EDHPT6AQ4QA">
+                    <catDesc>Museum of Musical Instruments</catDesc>
+                  </category>
+                  <category xml:id="tlaM65RACJXWNEYRH7CRPDZLWOJ6E">
+                    <catDesc>Palais Royal</catDesc>
+                  </category>
+                  <category xml:id="tlaSG7YXFWZHVG75GTHDEME3KTCSM">
+                    <catDesc>Musées Royaux d'Art et d'Histoire</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaV6UASPO3ZJBNZG6G7NUGZAXOOA">
+                  <catDesc>Liège</catDesc>
+                  <category xml:id="tlaMIU5QNBQWNFV7PZ5INPI6CCUYA">
+                    <catDesc>Musée Curtius</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaWBI4D7P56FD4RN2SOJU4V4MUCU">
+                  <catDesc>Arlon</catDesc>
+                  <category xml:id="tlaHH6GHV4NW5DALINCKC33XRYTJM">
+                    <catDesc>Musée Luxembourgeois</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaVQ7YET4FMBDIBCCTXJW7KYCI3I">
+                <catDesc>Niederlande</catDesc>
+                <category xml:id="tla2N7B6I5R4JELRF7EZUDF2P3DS4">
+                  <catDesc>Bilthoven</catDesc>
+                  <category xml:id="tlaU3BUNYAVMNGANNDK5KBA5IEI4A">
+                    <catDesc>Werkplaats Kindergemeenschap</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla3LEYCONHJFEMDB3H2KJRLIPOFE">
+                  <catDesc>Amsterdam</catDesc>
+                  <category xml:id="tlaBLCE5ODUYBDUNOXSWGHLGPJK3A">
+                    <catDesc>Bijbels Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaMHV6YRXZLVDFHN5547UQE7NWNU">
+                    <catDesc>NESARONE</catDesc>
+                  </category>
+                  <category xml:id="tlaMUCJFXIHABDCFHCANVXVKMSSVA">
+                    <catDesc>Allard Pierson Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaDD64Z6W6RNHLPBD5HUBHAY52JE">
+                  <catDesc>Leiden</catDesc>
+                  <category xml:id="tlaASJFDNBGLNHCZPUR7AAGPKVNJE">
+                    <catDesc>Rijksmuseum van Oudheden</catDesc>
+                  </category>
+                  <category xml:id="tlaWXJFLUH6SZFCNKNQTR6DMHC6Y4">
+                    <catDesc>Papyrologisch Instituut</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaDJBXT7OKVBCXDMXRAKXXDLBQ34">
+                  <catDesc>Gravenhage / Den Haag</catDesc>
+                  <category xml:id="tla3XTIYHVKWFCSDH5D7ELXIDSYNI">
+                    <catDesc>Carnegie Museum</catDesc>
+                  </category>
+                  <category xml:id="tla7QGME3V2XZDN3IJKDWHZJWHEWU">
+                    <catDesc>Haags Gemeentemuseum</catDesc>
+                  </category>
+                  <category xml:id="tlaOWMHWBXVX5EZ7KK64ANKMKS3FE">
+                    <catDesc>Rijksmuseum Meermanno-Westreenianum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaI6SOPG64HBH4XLSXV5P4MLRPAY">
+                  <catDesc>Otterlo</catDesc>
+                  <category xml:id="tlaDSKEC62LBNCRPGQPUDPYKKV454">
+                    <catDesc>Rijksmuseum Kröller-Muller</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaJWQQY4UUXRE2RHEFPTCHVHKQXU">
+                  <catDesc>Nijmegen</catDesc>
+                  <category xml:id="tla57T6UJPE3RFRTOUCVUQULFATGI">
+                    <catDesc>Instituut Jozef M.A. Janssen Katholieke Universiteit</catDesc>
+                  </category>
+                  <category xml:id="tlaSOVWHWBCNNGMXHUU5TY4TQ73O4">
+                    <catDesc>Rijksmuseum G.M. Kam</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaLNZZ7LEYCRE37NJELL52YHZVHU">
+                  <catDesc>Utrecht</catDesc>
+                  <category xml:id="tlaJHYW3FEMANALRN625CZOJZO45Q">
+                    <catDesc>Rijksuniversiteit</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaMEGRYNU5KZHE7PCKNDNKHOXIPY">
+                  <catDesc>Groningen</catDesc>
+                  <category xml:id="tlaNEXD4OGSDZFYDKSX4QTG3WBHA4">
+                    <catDesc>Groninger Museum, Naturrmuseum</catDesc>
+                  </category>
+                  <category xml:id="tlaPWVY65MJQJBMPOQ7DP3L6LRWAQ">
+                    <catDesc>Universiteit</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaU4OQHCN3FFCA7HBUW3GUI2TWW4">
+                  <catDesc>Dordrecht</catDesc>
+                  <category xml:id="tlaGV342VZLHRCM5GHONFGZOSUZO4">
+                    <catDesc>Lips Slotenmuseum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaZ5RFCVDSVJAGZH5DYKY3TNU45Y">
+                  <catDesc>Leeuwarden</catDesc>
+                  <category xml:id="tlaKB5BHCNKFZFGRNWOJ7BHVETRDE">
+                    <catDesc>Gemeentelijk Museum het Princessehof</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaWZ4MSUNHB5ARZA6Z7D6R64WPZ4">
+                <catDesc>Spanien</catDesc>
+                <category xml:id="tla357OIA72EZCWBLMAIVFPWAR3CQ">
+                  <catDesc>Malaga</catDesc>
+                  <category xml:id="tlaGOZM67X42FCSNIWIB6NSUTSTYQ">
+                    <catDesc>Museo Arqueológico Provincial</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla43M35ELXZZDGTK7OXTADRJBW3A">
+                  <catDesc>Montserrat</catDesc>
+                  <category xml:id="tlaNXVE3ZPFHZHWNHNEO3P4K5TVHA">
+                    <catDesc>Museo del Oriente Biblico</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla67GGDHWTKNGLBC2T2RXX2MRWD4">
+                  <catDesc>Mairena del Alcor</catDesc>
+                  <category xml:id="tlaS4RFTSP44NAAFERV5LQKBTGNTU">
+                    <catDesc>Casa de Bonsor</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla7N7RPAXATJHG3FQMFE72W3JBMI">
+                  <catDesc>Jaén</catDesc>
+                  <category xml:id="tlaDVKF7ZOK6ZBZDHESPPL23UAXW4">
+                    <catDesc>Museo Provincial</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla7TDL3BMQFZCWZH6WLHTEB6NRLY">
+                  <catDesc>Sitges</catDesc>
+                  <category xml:id="tlaIOBXESF5Y5HMFAGT76A44QKJRY">
+                    <catDesc>Museo Cau Ferrat</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaCG5KOPUWIFHPVOONDMMAXIBBUI">
+                  <catDesc>El Vendrell</catDesc>
+                  <category xml:id="tlaKHVEA6EOJJBOPJSQHEWK7OY554">
+                    <catDesc>Museo Municipal, Museo Arqueológic</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaEDNOKMAFEBBYBCWGBBH4GH5LV4">
+                  <catDesc>Palma</catDesc>
+                  <category xml:id="tlaTSG6F5BJKZFNZAMXV6XFDRTJPM">
+                    <catDesc>Museo Biblico del Seminario Diocesano</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaENKGNRLVBBCZLFH7KJWP3IL7GQ">
+                  <catDesc>Vich</catDesc>
+                  <category xml:id="tla7XLQJ2L5M5CM7PQBNE2YNNOB7Q">
+                    <catDesc>Museo Arqueológico Artistic Episcopal</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaEXAEQZCG2FDDRHZXSTNK3B3V4M">
+                  <catDesc>Ibiza</catDesc>
+                  <category xml:id="tlaQLO6KABF6VCWRE7SAECEHZXMPQ">
+                    <catDesc>Museo Arqueológico</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaEYMDDKQE3BCANJE3Q6FAQNJXM4">
+                  <catDesc>Sevilla</catDesc>
+                  <category xml:id="tlaQCZZTOVGNFDITHRJKHNC24XINQ">
+                    <catDesc>Museo Arqueológico</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaHFD2O2WTBNCZBBWVTFAAV3EERY">
+                  <catDesc>Almeria</catDesc>
+                  <category xml:id="tlaMDFSIIPMENH4DBIXFG25YX7N7Y">
+                    <catDesc>Museo Arqueológico</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaHNYJWWTCGNBXNGVJWIDNT7I7PA">
+                  <catDesc>Badajoz</catDesc>
+                  <category xml:id="tlaW3TUFXFTVJBE7NGQL7HION3FUQ">
+                    <catDesc>Museo Arqueológico</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaI56AA4MP2FCG7JRKEALFSGTIFA">
+                  <catDesc>Girona</catDesc>
+                  <category xml:id="tlaTZHWBCPB6BCIVOCALNG2O2MMME">
+                    <catDesc>Museo Arqueológico</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaJCLQSZ4GCNA2PJYETU5RDNQUNE">
+                  <catDesc>Cádiz</catDesc>
+                  <category xml:id="tla6YULXXKSUBCBZEBDWE3L2ZO5MY">
+                    <catDesc>Museo Arqueológico</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaJVFG5FYQNFH4BHFV5XEAB2GFGY">
+                  <catDesc>Valencia</catDesc>
+                  <category xml:id="tlaCVKTJRUOGJCJLGAO6BFBNY5M7Y">
+                    <catDesc>Museo de Prehistoria</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaKUEMPDDO6BD3TIZKJGOVFBN2BQ">
+                  <catDesc>Alicante</catDesc>
+                  <category xml:id="tla3SQSCSQUU5E6PHSLQRXAT2VTSU">
+                    <catDesc>Museo Arqueológico</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaKVR4MTA2XJHAFAYBSRPPBAGOP4">
+                  <catDesc>Huelva</catDesc>
+                  <category xml:id="tlaNBJS7ZSEVRAAPMMO3C2LEPIYXE">
+                    <catDesc>Museo Provincial</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaN5WSMVOQWBFKTMWEN6SQE3FN3I">
+                  <catDesc>Madrid</catDesc>
+                  <category xml:id="tlaAOSSV3CNFFDPJOZZOXPMJGD4M4">
+                    <catDesc>Museo Arqueológico Nacional del Prado</catDesc>
+                  </category>
+                  <category xml:id="tlaNPLLLD2IONGPBLJOQ6JH5JUVQQ">
+                    <catDesc>Inst. de Valencia</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaNBLTDPTA3NGNZNP2Z7ABD3VFGE">
+                  <catDesc>Puerto Real</catDesc>
+                  <category xml:id="tlaPU5FGQ6BNVBY7GKUHKRGVHYBGA">
+                    <catDesc>Museo Municipal</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaRFRGSJTTP5G4RCTCVX45NK63GE">
+                  <catDesc>Vilanova i la Geltru</catDesc>
+                  <category xml:id="tlaTFYSYWBES5ERJDLQEJQHDWVWOU">
+                    <catDesc>Museo Biblioteca Victor Balaguer</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaRQNAX7PIRNF5TIVZWTRHTCMGWU">
+                  <catDesc>Murcia</catDesc>
+                  <category xml:id="tlaYCI4CC3QDBH25FF6Q6CARUK5CQ">
+                    <catDesc>Sección Arqueologia</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaTWUPIAH7RJC5PN3Q3UQT7Z2Y2A">
+                  <catDesc>Amposta</catDesc>
+                  <category xml:id="tlaDVO6IU2UUJBQ5JKCP4VWXFXSAE">
+                    <catDesc>Museo Municipal</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaW5HSSKJV4ZCLTKSIROJJEHVUFQ">
+                  <catDesc>Granada</catDesc>
+                  <category xml:id="tla4F2TEZLNH5A4POI5IE7CWM2PCQ">
+                    <catDesc>Museo Arqueológico Provincial</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaXQIWEV3DM5DJ5OXFGTMDPVUQIM">
+                  <catDesc>Barcelona</catDesc>
+                  <category xml:id="tla4BMT7XTA6FAR3BCT3YDLLMPVVU">
+                    <catDesc>Museo Arqueológico</catDesc>
+                  </category>
+                  <category xml:id="tla7A2KUGI6EJGD7OMW43N7GNSSD4">
+                    <catDesc>Museo de Artes Decorativas in Palacaio Virreina</catDesc>
+                  </category>
+                  <category xml:id="tlaOWKPW5NCMNAR5NYH6W5IKPWF5M">
+                    <catDesc>Instituto Amatller</catDesc>
+                  </category>
+                  <category xml:id="tlaPUBS46CS25DJ5OMVAJHP2AEVBQ">
+                    <catDesc>Institute of Archaeology and Prehistory in the University of Barcelona</catDesc>
+                  </category>
+                  <category xml:id="tlaYLYOZGVOOFFANFS6NTZS7GY3BI">
+                    <catDesc>Fundació Arqueològica Clos</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaYF2UJCO2XVEM3GUI5UMFHA7GUY">
+                <catDesc>Norwegen</catDesc>
+                <category xml:id="tlaCP5MLH5QHBGOLBINQ6H6SEO7RM">
+                  <catDesc>Oslo</catDesc>
+                  <category xml:id="tlaCDHRWRCGLNGKNNLMCJVALBZWPI">
+                    <catDesc>Ethnographical Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaGJBWPQHJNNARJDIHQIY37HWDUE">
+                  <catDesc>Elverum</catDesc>
+                  <category xml:id="tlaTJZXOMEJHRFTPBKRJJF2EKSDAI">
+                    <catDesc>Glomdalsmuseet</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaZQIZXRY5LVD7PPNESZJUVQ7KQA">
+                  <catDesc>Bergen</catDesc>
+                  <category xml:id="tlaRBMKN6PQH5CM7LHG4W3535RLLA">
+                    <catDesc>Historisk Museum, Ägyptische Sammlung</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaYZQDJLLFXRE6HFGT5P5FF55OMU">
+                <catDesc>Deutschland</catDesc>
+                <category xml:id="tla6BRPTNYBRNHIPM4OOUMPFMXUCA">
+                  <catDesc>(Städte N-Z)</catDesc>
+                  <category xml:id="tla5BVEDTRESZEH3HN46PUHRL4JO4">
+                    <catDesc>Pforzheim</catDesc>
+                    <category xml:id="tla7QVFZXSTYJHORITNC6LFLL6JNU">
+                      <catDesc>Schmuckmuseum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla7HR324GMORCTJEXMGT2YSYZGCM">
+                    <catDesc>Werl</catDesc>
+                    <category xml:id="tlaG467T4ENJFDWPJQR4RN25CZQQM">
+                      <catDesc>Forum der Völker. Völkerkundemuseum der Franziskaner</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaA623H7XSHRB5NFKPBAGLHFZD5E">
+                    <catDesc>Würzburg</catDesc>
+                    <category xml:id="tla4EYCPNDXCBBNHF7PYOCS75IHRA">
+                      <catDesc>Martin-von-Wagner-Museum, Antikensammlung</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaDOCQXKB5FFBZBIJJMQ2QIL5ZS4">
+                    <catDesc>Trier</catDesc>
+                    <category xml:id="tla4YMWL6C3IRCWHBFNPBNXHPWVRA">
+                      <catDesc>Simeonstift</catDesc>
+                    </category>
+                    <category xml:id="tlaKCU77MSS2NAMRDT4RS5LSODJJI">
+                      <catDesc>Rheinisches Landesmuseum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaE7ZMMU5GFZBFFDHMDI4RLOVLFE">
+                    <catDesc>Recklinghausen</catDesc>
+                    <category xml:id="tlaCTYN62YJTNET7KU5GVTFE62IVA">
+                      <catDesc>Ikonenmuseum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaGENNNEBKLVBOFEXQEPPW2KJOPE">
+                    <catDesc>Offenbach</catDesc>
+                    <category xml:id="tlaWMH4PJ6BUFHOFNMQMUCZL5WLHE">
+                      <catDesc>Deutsches Ledermuseum mit Deutschem Schuhmuseum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaI6KCBJPXSJG3HJ26JMZ4DPDOTM">
+                    <catDesc>Osnabrück</catDesc>
+                    <category xml:id="tlaM6R2QMF6RVFG3FNOEDRGKWD6JA">
+                      <catDesc>Kulturgeschichtliches Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaKD54XVCJQZG2DKZ6AIPBYHTQUM">
+                    <catDesc>Wiesbaden</catDesc>
+                    <category xml:id="tlaOOI3E7NCXVBTZFQSXXR3V56BGI">
+                      <catDesc>Museum Wiesbaden, Sammlung Nassauischer Altertümer</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaM26VL2ZQQREVVASQNL2KQTJLOQ">
+                    <catDesc>Nürnberg</catDesc>
+                    <category xml:id="tla7RKIPNUZL5AKVJ56HZR2SWL52U">
+                      <catDesc>Gewerbemuseum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaN5MPTMSO6JB4DLW332IR6NZ3VY">
+                    <catDesc>Solingen</catDesc>
+                    <category xml:id="tlaFLLEPFU7MBEUREITXONNTJXPQU">
+                      <catDesc>Klingenmuseum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaNRRDOUJHNZDG5GJ4RW7GASQTXI">
+                    <catDesc>Ulm</catDesc>
+                    <category xml:id="tlaVRVXPTWRPJAYDK5HLNAPV45H3U">
+                      <catDesc>Das Deutsche Brotmuseum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaOB2NPZTBDFA2DEFEAASCGCRBXM">
+                    <catDesc>Stuttgart</catDesc>
+                    <category xml:id="tlaWUQA5WWJIJE6JFETH62K74QUG4">
+                      <catDesc>Württembergisches Landesmuseum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaOOJEZSFYEVC3DJQUOYVEAHDML4">
+                    <catDesc>Tübingen</catDesc>
+                    <category xml:id="tlaASI4YFJLRNDJDOEHRYH3FVGNCA">
+                      <catDesc>Sammlung des Ägyptologischen Instituts der Universität</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaQSZW2XICXNACVEW6CHXQZY7VIE">
+                    <catDesc>Römhild</catDesc>
+                    <category xml:id="tlaLTNGSXYM55EAHO4J6ZIGL3ONFU">
+                      <catDesc>Steinsburg Museum, Ägyptische Sammlung</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaR5U2TTKKCFCW5KZX3A23EC4ICE">
+                    <catDesc>Weimar</catDesc>
+                    <category xml:id="tlaUK5FZPAQWNHNVGN3V2V2EQAFPE">
+                      <catDesc>Goethe-Nationalmuseum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaRR3ULLDWPVGTTGO3442X6PUXG4">
+                    <catDesc>Oldenburg</catDesc>
+                    <category xml:id="tla6ZYSLKPE5JAWNHV5IRUHFLI5LY">
+                      <catDesc>Landesmuseum für Kunst und Kulturgeschichte</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaSPWFAPZYGRBHRB76PCR2HRASZU">
+                    <catDesc>Rostock</catDesc>
+                    <category xml:id="tlaPVABCEUI25GQRIC7JIVXMLMIR4">
+                      <catDesc>Museum der Stadt Rostock</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaUB4GJB4S3NBZ7O2HXA5RC6S4VA">
+                    <catDesc>Wuppertal</catDesc>
+                    <category xml:id="tlaOCGTVN24SVDWXKLMXJW6LMSFOM">
+                      <catDesc>Von der Heydt-Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaQXX2K3ZSQRGJJJJQOEBIOPPLHE">
+                      <catDesc>Wuppertaler Uhrenmuseum K. Abel</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tlaDZE367XTXJCS7AY7HGEMQ3GZBY">
+                  <catDesc>(Städte H-M)</catDesc>
+                  <category xml:id="tla23GZ56GUGZFQLKZPHZZPLUG4SE">
+                    <catDesc>Heidelberg</catDesc>
+                    <category xml:id="tlaUJC4V7EVX5B5NEEM6JE3GDDM2Q">
+                      <catDesc>Sammlung des Ägyptologischen Instituts der Universität Heidelberg</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla3VS4WHPBNJECREEVDJYDCHZNR4">
+                    <catDesc>Kassel</catDesc>
+                    <category xml:id="tla2M365MPSSFGYZEXCZDPGXAGTC4">
+                      <catDesc>Staatliche Kunstsammlungen Schloss Wilhelmshöhe</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla52DUGWSNJVEDNLRLMBYHJ2WD2I">
+                    <catDesc>Mainz</catDesc>
+                    <category xml:id="tla4ZCR6UZCEJCGFAGCPIVNDLWRVM">
+                      <catDesc>Landesmuseum Mainz</catDesc>
+                    </category>
+                    <category xml:id="tlaFXQ72RGNIFA5FG2T53OWOVSNKE">
+                      <catDesc>Prinz-Johann-Georg-Sammlung</catDesc>
+                    </category>
+                    <category xml:id="tlaPXTVOZ7D35H4JFZUCVJDLCHEEI">
+                      <catDesc>Römisch-Germanisches Zentralmuseum</catDesc>
+                    </category>
+                    <category xml:id="tlaZA5IHW6DIBE6VNOUP2VIAAE7AU">
+                      <catDesc>Gutenberg-Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla5IKOLHCGXFAWFPL2F464TXOBDU">
+                    <catDesc>Leipzig</catDesc>
+                    <category xml:id="tlaSH4JZCUG6RC67ISNT5JY54F3JA">
+                      <catDesc>Ägyptisches Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla5TGRMEGTNVD77A5RGPX7GTJBJY">
+                    <catDesc>Marburg</catDesc>
+                    <category xml:id="tlaMXFOEAFEDZAQVBSPHQELMN6GYI">
+                      <catDesc>Religionskundliche Sammlung</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla6M34N6GZ7RDBFP2JKAZ7A6WV6I">
+                    <catDesc>Kaiserswerth</catDesc>
+                    <category xml:id="tlaHRN2EHJUWRF2BKH3PFCRG6V2RU">
+                      <catDesc>Diakonie-Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaBMX6BBCNB5AA7PHI3B4DTNKYDM">
+                    <catDesc>Lübeck</catDesc>
+                    <category xml:id="tlaDMOVL22LQZHFFOUDN7VJVPURRU">
+                      <catDesc>St. Annen-Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaDLEOHKWRTRDG5CSKE45KN2F2A4">
+                    <catDesc>Mühlheim</catDesc>
+                    <category xml:id="tlaV367GLK4SNELRLSNDXBV6GHOCA">
+                      <catDesc>Konrad-Ziegler-Schule</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaG4WPLJNNIZDZBPJF3OLD3TB7SY">
+                    <catDesc>Karlsruhe</catDesc>
+                    <category xml:id="tlaIUIA3EESGFHBLFCE34TUDFNBDA">
+                      <catDesc>Badisches Landesmuseum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaIWXCGYF3MJDIFDNI2AAJS7WLLM">
+                    <catDesc>Hildesheim</catDesc>
+                    <category xml:id="tlaNM3QUYNOMVDOBD2JX4WCD76QY4">
+                      <catDesc>Pelizaeus-Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaLK7FEY3N4BHVHB2YRC2ZJBSRAE">
+                    <catDesc>Halle</catDesc>
+                    <category xml:id="tla77AFQGNNIRESBMOLM7IVZFIQS4">
+                      <catDesc>Moritzburg</catDesc>
+                    </category>
+                    <category xml:id="tlaDACZ7EZ35BB5BFRK2TZ74HCU54">
+                      <catDesc>Landesmuseum für Vorgeschichte</catDesc>
+                    </category>
+                    <category xml:id="tlaDFIT5MSMKJFB7JTP4ZFDMKANRU">
+                      <catDesc>Archäologisches Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaLRIATOLCTBHYPAN2OIS5JM2XAU">
+                    <catDesc>Hamburg</catDesc>
+                    <category xml:id="tlaGQUFHNFL3REO7FUE7RBTXP2OPI">
+                      <catDesc>Museum für Kunst und Gewerbe</catDesc>
+                    </category>
+                    <category xml:id="tlaIAVPF4XRCFD6FDDO6X4MITLUDE">
+                      <catDesc>Hamburgisches Museum für Völkerkunde</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaO3N32QI6NFGU3LPK466ER5W7N4">
+                    <catDesc>Münster</catDesc>
+                    <category xml:id="tlaLAMGPIDR4RGYBGAK3CLVTE6ZFY">
+                      <catDesc>Archäologisches Museum der Universität</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaOWCO7KEXAZEFZCU56I45MROJOI">
+                    <catDesc>Mönchengladbach</catDesc>
+                    <category xml:id="tlaPFJ473TPABACDABOV2T2KX2YHE">
+                      <catDesc>Schloß Rheydt</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaRQ4EZXMWENFN3L5TFTAFMCXBVY">
+                    <catDesc>Köln</catDesc>
+                    <category xml:id="tla3P4J4LHZ7NBZXKTE5KSMH2Z4RM">
+                      <catDesc>Rautenstrauch-Jost-Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaK42CSR3EQ5BLTNK4A6M76AMH74">
+                      <catDesc>Seminar für Ägyptologie der Universität zu Köln</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaUMPX6PFLRJC6PEGONWS4FA3AAQ">
+                    <catDesc>Hamm</catDesc>
+                    <category xml:id="tla6VYBY2TGXNG4HK7PX67FYW3XDA">
+                      <catDesc>Gustav-Lübcke-Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaVI75P3AEMVFOVFIVG4VYPJ37YM">
+                    <catDesc>Hannover</catDesc>
+                    <category xml:id="tlaGQRQZDDBJ5G7LNRJBS5FJX5TCM">
+                      <catDesc>Kestner-Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaYSZQPS5XLNAHHLHEWCBVXFYQX4">
+                    <catDesc>München</catDesc>
+                    <category xml:id="tlaGCVEOGEZLFGH5D6UPBWNXZCUMQ">
+                      <catDesc>Prähistorische Staatssammlung, Museum für Vor- und Frühgeschichte</catDesc>
+                    </category>
+                    <category xml:id="tlaPVYF5IRKY5GQXFHDUG3SWP5M2U">
+                      <catDesc>Nationalmuseum</catDesc>
+                    </category>
+                    <category xml:id="tlaZHJRWTBLB5GHLKVDW5XEVKUAKY">
+                      <catDesc>Staatliche Antikensammlung und Glyptothek</catDesc>
+                    </category>
+                    <category xml:id="tlaZN4QSMUSP5FVJBCD6TECD35MCE">
+                      <catDesc>Staatliche Sammlung Ägyptischer Kunst</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tlaTIC7Y3F6HVABVKXMYHPBMIZINM">
+                  <catDesc>(Städte A-G)</catDesc>
+                  <category xml:id="tla2MJMMGFLINASXN4CG7X4X6QYZY">
+                    <catDesc>Gotha</catDesc>
+                    <category xml:id="tlaGYQI5IYO3BGP3DN2KCEPDWWVMQ">
+                      <catDesc>Schloßmuseum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla33EA2OCMHNGOXDMK4GLPP4ERRA">
+                    <catDesc>Banz</catDesc>
+                    <category xml:id="tlaIRUS4ZB4GRGE7P2PHPOZIDGLNQ">
+                      <catDesc>Petrefakten- und Orientalische Sammlung Banz</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla4JELCY42ZNDLBISRS6O5RSH7JI">
+                    <catDesc>Gießen</catDesc>
+                    <category xml:id="tlaBNPKT4DI7VDAPFUSSES7JDWNYQ">
+                      <catDesc>Oberhessisches Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaOWQZPI6XCNFJ7OHNMUPSGWGUUQ">
+                      <catDesc>Universitätsbibliothek</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla5O73ZODJMJDH5ETRHZQR2QJTNE">
+                    <catDesc>Bonn</catDesc>
+                    <category xml:id="tla35Z27YQHENBUZMSKLWQAOLREOU">
+                      <catDesc>Ägyptologisches Seminar der Universität</catDesc>
+                    </category>
+                    <category xml:id="tla5ZQL6AHS7NGY5JBGLPJN6LNATQ">
+                      <catDesc>Archäologische Sammlung des Lyceum Hosianum</catDesc>
+                    </category>
+                    <category xml:id="tlaXZDLM7WKRJDFLKHTVBHX36F7RY">
+                      <catDesc>Akademisches Kunstmuseum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla7W7AKXWCRNCMFHGLI4LOHTIWU4">
+                    <catDesc>Greifswald</catDesc>
+                    <category xml:id="tlaRLWRUKLOMBE7TPLIMHF6BXBHVM">
+                      <catDesc>Archäologische Sammlung der Universität</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaBBVF7WEX3VBNPOVL325XZOVZ6Q">
+                    <catDesc>Aachen</catDesc>
+                    <category xml:id="tlaHAYG7WDAFRH5NFRAO4UC66R3WY">
+                      <catDesc>Suermondt-Ludwig-Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaIWPSCDLU6NGI7KDL6CNSWXF3LQ">
+                    <catDesc>Essen</catDesc>
+                    <category xml:id="tla4ISE4KXQ5RFBHKFH5Q7HKVIH6U">
+                      <catDesc>Folkwang Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaJ4ACS5PS45BKRCVEI243KE7ONM">
+                    <catDesc>Braunschweig</catDesc>
+                    <category xml:id="tlaN7FBZXDYBVAKJLLGUZPHTIPLQQ">
+                      <catDesc>Herzog Anton Ulrich Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaJ6KBPK4DORFTXJR3QEKM4SAQ24">
+                    <catDesc>Dresden</catDesc>
+                    <category xml:id="tlaAPWIPVDEM5EYBBU3TLGIKQIZ6M">
+                      <catDesc>Albertinum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaK2UDH3BCGZDKZNNHP4FRNJYIFE">
+                    <catDesc>Düsseldorf</catDesc>
+                    <category xml:id="tlaR2AOJUK7RVDCPFBWW5N7VFLAWY">
+                      <catDesc>Hetjens-Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaKHYOWHNSJFCODFUVCEM4C3BDO4">
+                    <catDesc>Bielefeld</catDesc>
+                    <category xml:id="tlaSR5SXDHNOFGTLBYR4ORZOQKIDE">
+                      <catDesc>Kulturhistorisches Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaO24H7CHJRVDRDFCVUNZM5NVQEU">
+                    <catDesc>Detmold</catDesc>
+                    <category xml:id="tlaHWHDLZO3GNAEVINBFS5VCCILVM">
+                      <catDesc>Lippisches Landesmuseum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaPO3DLRWC2BBZFGHQT6STIUHJYY">
+                    <catDesc>Augsburg</catDesc>
+                    <category xml:id="tlaF5KWMYXKKZGK7IA7S3EFORRBD4">
+                      <catDesc>Römisches Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaRH4XITZOPBBG3DA3E7U6MBMIGI">
+                    <catDesc>Freiburg im Breisgau</catDesc>
+                    <category xml:id="tla54DWWWZMPFCYTID76WL2AMAPGQ">
+                      <catDesc>Museum für Völkerkunde</catDesc>
+                    </category>
+                    <category xml:id="tlaWCC44EJOY5D6DG6NJYRO4KQ3DY">
+                      <catDesc>Archäologische Sammlung der Universität</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaS2JXZIV3ENBWVNQKUC3NSBVRQY">
+                    <catDesc>Frankfurt am Main</catDesc>
+                    <category xml:id="tla3R7UCEDFF5D77I5656LC4GZ2CI">
+                      <catDesc>Senckenberg Museum</catDesc>
+                    </category>
+                    <category xml:id="tla5V2DYXNOGVAFBJFU72MOXOXWUA">
+                      <catDesc>Kunsthandwerk</catDesc>
+                    </category>
+                    <category xml:id="tlaLQUHNEUXRRES7JEMCM6YALFT2U">
+                      <catDesc>Liebieghaus, Museum Alter Plastik</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaTFGFHY6MWFEWPF2UTDXJRPIGLA">
+                    <catDesc>Erlangen</catDesc>
+                    <category xml:id="tla7DRY6GXQFFEK7F3IHEBR2PME4M">
+                      <catDesc>Kunstsammlung (Archäologische Sammlung) der Universität</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaV7PROYGBXZH57PKYK7BGR6E2EA">
+                    <catDesc>Berlin</catDesc>
+                    <category xml:id="tlaGOUD7BQ5DBCENBWBR4KFWDW5SI">
+                      <catDesc>Ägyptisches Museum und Papyrussammlung</catDesc>
+                    </category>
+                    <category xml:id="tlaUVQQXLR3O5BGZAXXRJTQHEUTVU">
+                      <catDesc>Museum für Kommunikation</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaWLKLYSXCLJBX3CSZGGTMUAXEVY">
+                    <catDesc>Darmstadt</catDesc>
+                    <category xml:id="tlaTZMNSDK3XFAQ7BFG6A4BSFH6B4">
+                      <catDesc>Hessisches Landesmuseum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaXG7GB2EBNFHNDCVQWNYI5N74KU">
+                    <catDesc>Cottbus</catDesc>
+                    <category xml:id="tla4D3M7K4TNVH5VDFOJXFYLRFLCI">
+                      <catDesc>Pückler Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaXPVERXNUQBGFZMNHJTESYPEZSY">
+                    <catDesc>Bochum</catDesc>
+                    <category xml:id="tlaGZEGJN3TTVGB5F6GG2F3AK6AS4">
+                      <catDesc>Antikenmuseum Kunstsammlungen der Ruhr-Universität Bochum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaZC4P5FN5JJFDTKL3ESA2V2ZS6Q">
+                    <catDesc>Bremen</catDesc>
+                    <category xml:id="tlaUZ4NYSJFB5CG7KDHNLLOXZATQI">
+                      <catDesc>Überseemuseum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaZHYNNO267BE5LLL23X46GWAAXI">
+                    <catDesc>Göttingen</catDesc>
+                    <category xml:id="tla2U7DNWSYZBC37LVZSIAE7CSSBY">
+                      <catDesc>Sammlung des Archäologischen Instituts der Universität</catDesc>
+                    </category>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaYZZ4RR3EXZAN3PKCQF2NRYVDWY">
+                <catDesc>Tschechien</catDesc>
+                <category xml:id="tla564FDBDANRECJHT23EFPXBMRC4">
+                  <catDesc>Prag</catDesc>
+                  <category xml:id="tla6AMDAG3E7NGEXEOKZWPWU7ZVKU">
+                    <catDesc>Náprstkovo Muzeum</catDesc>
+                  </category>
+                  <category xml:id="tlaCKGY7QSWBZB37EQX4JD35LDQKQ">
+                    <catDesc>Národní Galerie</catDesc>
+                  </category>
+                  <category xml:id="tlaKNEZ4I4ABBAF7PH2MRJSIIYCTA">
+                    <catDesc>Národní Muzeum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla5IA4UHWUNBCWFAHNDRKNSHQ7FM">
+                  <catDesc>Zleby</catDesc>
+                  <category xml:id="tlaVKKMXWGLSNEWHEJ37446PKYZOU">
+                    <catDesc>Státní Zámek</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaIYGQG3OKJZF3HMI7KWEA6XIWDA">
+                  <catDesc>Olomouc</catDesc>
+                  <category xml:id="tlaOMOBNSQHFJHVTPQS3UKS3ALFVI">
+                    <catDesc>Oblastní Galerie</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaU6CVG63WMFDZBPAY57TNJJL6DQ">
+                  <catDesc>Lázne Kynzwart</catDesc>
+                  <category xml:id="tla7T3GVMUIAZDOBANO2BBRWSCZ6M">
+                    <catDesc>Státní Zámek</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaW6W25WNBAVF3XEFUYBHRLHQGFQ">
+                  <catDesc>Moravská Trebová</catDesc>
+                  <category xml:id="tlaLA3COPTLNJHS3MTGHLA2MPFDVM">
+                    <catDesc>Mestské Muzeum</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaZSVAEOLGMFHAXH4OGCCJRX4OWM">
+                <catDesc>Dänemark</catDesc>
+                <category xml:id="tlaARKYG2YELNGCXHV5AJAHSRB6MQ">
+                  <catDesc>Klampenborg</catDesc>
+                  <category xml:id="tlaWRMJB4S6S5DQRPIE5XXEZ4UY4M">
+                    <catDesc>Ordrupgaard Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaO3I6QT6FJFET3JFA5GIDBPIXP4">
+                  <catDesc>Kopenhagen</catDesc>
+                  <category xml:id="tla73Z6YQ3VWRH3BJIOTAMO3KHMEU">
+                    <catDesc>Thorvaldsen Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaGWDDUG7C3VEX3LTZSNW6ZYNPBI">
+                    <catDesc>Ny Carlsberg Glyptotek</catDesc>
+                  </category>
+                  <category xml:id="tlaOC4FXKDV6BAQ5D2FXSTT7RRKVY">
+                    <catDesc>Nationalmuseet</catDesc>
+                  </category>
+                  <category xml:id="tlaZXOO62EMLZFBNLSWR5RREZS4UQ">
+                    <catDesc>C. Niebuhr Instituttet</catDesc>
+                  </category>
+                </category>
+              </category>
+            </category>
+            <category xml:id="tlaHRTGFPJGPVAYTNSJFKRJQTBNPQ">
+              <catDesc>Mittelamerika</catDesc>
+              <category xml:id="tla33TBKRCHYJCMDKL5QLQS52RPSU">
+                <catDesc>Kuba</catDesc>
+                <category xml:id="tla4TI2MW6UCVDJHA3BBXIWZQOAKE">
+                  <catDesc>Havana</catDesc>
+                  <category xml:id="tlaGJTJOWF4TBHDHGY2NKE2SRHQYI">
+                    <catDesc>Museo Nacional, Palacio de Bellas Artes, Inst. Nacional de Cultura</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaILXEZHTDKRH2HMZG3I4JVYZXJM">
+                  <catDesc>Santiago de Cuba</catDesc>
+                  <category xml:id="tlaDUJ47VYQUBBUVDWHUW22HVX3HA">
+                    <catDesc>Museo Emilio Bacardi Moreau</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaBUA3DJAWIFAHDDUCJFLAEVSWJY">
+                <catDesc>Mexiko</catDesc>
+                <category xml:id="tlaHIRAQGSLSFGKLFMBP5RVCAGNR4">
+                  <catDesc>Mexico Stadt</catDesc>
+                  <category xml:id="tla2NFAFRGYSJFIPAAFGTUMOBLMAE">
+                    <catDesc>Museo Nacional de Antropologia</catDesc>
+                  </category>
+                </category>
+              </category>
+            </category>
+            <category xml:id="tlaNKKY5E7SXVBNLNYKVOZVHAT3VM">
+              <catDesc>Asien</catDesc>
+              <category xml:id="tla3TSH7T3TFRCEJAWITWOPKVVK7U">
+                <catDesc>Indien</catDesc>
+                <category xml:id="tla6LGFFUH3AJBOLGXKVCAISJHB2U">
+                  <catDesc>Kalkutta</catDesc>
+                  <category xml:id="tla5FHRRLNRX5GIPG6PXKHWGODEYU">
+                    <catDesc>Indian Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaKBMI3GLUMNFPDEY2XR7MXSVPQQ">
+                  <catDesc>Baroda</catDesc>
+                  <category xml:id="tlaJSP4GEMEFJFVVANOPV4ABTBD2A">
+                    <catDesc>Museum and Picture Gallery</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaPB5GX7LNW5EEPL3AEIHGYXPSSQ">
+                  <catDesc>Bombay</catDesc>
+                  <category xml:id="tlaLOCR2PIMHNCBVG7OLDCMCTVMUE">
+                    <catDesc>Prince of Wales Museum of Western India</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaQ4HWL7H4HBBWND4FXBLDU67ZWQ">
+                  <catDesc>Lucknow</catDesc>
+                  <category xml:id="tlaSDKPKHELJJBSNESEYAHJLBXAHA">
+                    <catDesc>State Museum</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tla4IF3RAYNBND5LCI4RZQUAVOPEM">
+                <catDesc>Georgien</catDesc>
+                <category xml:id="tlaFDLF3P5HTNDU3PBSSL25532YMQ">
+                  <catDesc>Sotschni</catDesc>
+                  <category xml:id="tlaPHI7TVXYPZH75MZRGSWNYV2ZUE">
+                    <catDesc>Museum of History of Socni</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaITFVBGDHWZHFBAP2KT5G3IZO7Y">
+                  <catDesc>Tiflis</catDesc>
+                  <category xml:id="tla6YZFYKSTTFFCHO5SLYC3SBNG7Q">
+                    <catDesc>Art Museum of Georgia</catDesc>
+                  </category>
+                  <category xml:id="tlaZFU5OB2MYNHOVATOWE3AMHMZ6I">
+                    <catDesc>State Museum of History of Georgia</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaJVJ6R5EZ2ZGITEKUZJ3FD3ELLY">
+                  <catDesc>Suchumi</catDesc>
+                  <category xml:id="tlaTP2XXEU2MVGSXAIFWGVNSZFUY4">
+                    <catDesc>State Museum of Abkhazia</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tla62CXDP4W6JAMHPWUW2FZSBITEA">
+                <catDesc>Japan</catDesc>
+                <category xml:id="tla4ZEQB5RG7JAV3BS33W5JI3JZIQ">
+                  <catDesc>Kioto</catDesc>
+                  <category xml:id="tlaDKPLZXWNYNBXNESZZ5XWQSX24Q">
+                    <catDesc>The Museum of the Faculty of Letters, Kyoto University</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaECKSZ5IW7FGF3OPXELEDI2S7KU">
+                  <catDesc>Nariwa</catDesc>
+                  <category xml:id="tlaHT2BPZH3NJGB3P7CD76RLLR54Q">
+                    <catDesc>The Nariwa Culture Centre Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaSTSLE4JD4ZF6JOVGBOAMQITKQQ">
+                  <catDesc>Tokio</catDesc>
+                  <category xml:id="tla3ZQZ7GJG3JAGRL42KOQQA6JOFU">
+                    <catDesc>Matsuoka Museum of Art</catDesc>
+                  </category>
+                  <category xml:id="tla7CPTMPC4IBEE3PQAXMCZMYJXSY">
+                    <catDesc>Idemitsu Art Gallery</catDesc>
+                  </category>
+                  <category xml:id="tlaCTYQ7PYSANFPVCZKHD7LWUDM2I">
+                    <catDesc>University Museum, Waseda University, School of Literature</catDesc>
+                  </category>
+                  <category xml:id="tlaLN2UOWDQT5EO3KWN2V66DVPFQU">
+                    <catDesc>Bridgestone Museum of Art, Ishibashi Foundation</catDesc>
+                  </category>
+                  <category xml:id="tlaSARNLQNSBVCFRBP5XEOJ3ZSI7Y">
+                    <catDesc>Geijutsu Daigaku Shiryokon</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaW2RCCBNU7NHH5NIQSLXVTWJSZM">
+                  <catDesc>Tenri</catDesc>
+                  <category xml:id="tlaGP5SNWXMANFNPL7JQERQTB7EMQ">
+                    <catDesc>Tenri Sankokan Museum</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaARZVMG6BFFEPDKPK32JZPRRXAA">
+                <catDesc>Jemen</catDesc>
+                <category xml:id="tla4FOLMU4W6JDGLFKA6RVZMBFLZM">
+                  <catDesc>Aden</catDesc>
+                  <category xml:id="tlaLNF4KOUOWRERZPUYVTRB3SDCDU">
+                    <catDesc>Ägyptische Sammlung</catDesc>
+                  </category>
+                  <category xml:id="tlaPSP2RUOWEZH6ZME3YLMWHH6YAY">
+                    <catDesc>National Museum, Department of Antiquities and Museums</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaB4BGAYEEQJFIDDDEEQJYFRCNII">
+                <catDesc>Turkmenistan</catDesc>
+                <category xml:id="tlaQ6FKCYFC6RBCTKBJWUOHPQEOXA">
+                  <catDesc>Aschchabad</catDesc>
+                  <category xml:id="tlaMWOWVZ5NB5GTFC6SO6LYSTEYDU">
+                    <catDesc>Institute of History of the Academy of Sciences</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaDPVV7MMSGRD5LGNLGPVCOXO6W4">
+                <catDesc>Irak</catDesc>
+                <category xml:id="tlaBYDLODHJWRGEFORPRA267VW3C4">
+                  <catDesc>Mossul</catDesc>
+                  <category xml:id="tla3K6MEABQIZFQ5B752J6HQRQU2Y">
+                    <catDesc>Ägyptische Sammlung</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaP2K7VYKEPBA3LHBKKERKO62EDQ">
+                  <catDesc>Bagdad</catDesc>
+                  <category xml:id="tla72ZTEBR4SFD2TDYAZZIRUUZ464">
+                    <catDesc>State Organisation of Antiquities and Heritage, Iraq Museum</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaGNXVXK244RAI5OWHNY5PZ6V6Y4">
+                <catDesc>Libanon</catDesc>
+                <category xml:id="tlaABNMPZELBVELNMWBVJRBIP26WE">
+                  <catDesc>Beirut</catDesc>
+                  <category xml:id="tlaIJWDGL2N5VFXFJD6UEKDT6JBMU">
+                    <catDesc>National Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaK42GQGD2A5BEBPT6MLWIBNC7TA">
+                    <catDesc>Archaeology Museum, American University of Beirut</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaH4QDFSZ7KRDZPJYTBDJF2WCX7A">
+                <catDesc>Aserbaidschan</catDesc>
+                <category xml:id="tlaSVDB4LC3YVDA5IBIPU2QS2JWXM">
+                  <catDesc>Baku</catDesc>
+                  <category xml:id="tla5DNTPKNEDVGH5JLA4MXKU2OEZA">
+                    <catDesc>Museum of History of Azerbaijan</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaJ2FDR35S6VE3FFDBORGPY5ISLI">
+                <catDesc>Türkei</catDesc>
+                <category xml:id="tla6SAVLXUSSBCSRAZ6UGDSUEEIJM">
+                  <catDesc>Selçuk</catDesc>
+                  <category xml:id="tlaBDZCBMMDP5BUVPAATNZ3G2N22U">
+                    <catDesc>Efes Müzesi</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaA3SKL4PQVRFIFM3PJOAEFHKE6A">
+                  <catDesc>Ankara</catDesc>
+                  <category xml:id="tlaFRHN5MPCVNGQLJKKLQI766XIII">
+                    <catDesc>Museum of Anatolian Civilisations</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaZND4XMSSC5B7HEZM7OS2S2NGKY">
+                  <catDesc>Istanbul</catDesc>
+                  <category xml:id="tla2OUMXLBPRZB25MIEIPKMFKZ6F4">
+                    <catDesc>Ancient Oriental Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaYCATUS2HYFGJPOSLHXC4M6N6TU">
+                    <catDesc>Arkeoloji Müzesi</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaJLARKESMRZC2TOKWBKY5ORH3AI">
+                <catDesc>Iran</catDesc>
+                <category xml:id="tlaMML2HZZPLNF6XJQB4LK3S3TNH4">
+                  <catDesc>Teheran</catDesc>
+                  <category xml:id="tlaB2JDA7GRKZG4BNU4TGEHZZLL4Q">
+                    <catDesc>Museum Iran Bastan</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaJLJDEBUSVRHWBHD7H7XK2UCWUM">
+                <catDesc>Sri Lanka</catDesc>
+                <category xml:id="tla5OBTHX3GCZDA5EYM7HE4UA5FFM">
+                  <catDesc>Colombo</catDesc>
+                  <category xml:id="tlaCTCFFYJ4BRDP5A7DWKMTODA4CU">
+                    <catDesc>National Museum</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaODTUL6WZRRFYXIL5Q4B6IHP364">
+                <catDesc>Israel</catDesc>
+                <category xml:id="tla2O64C2SVEFDAPPOMXLWU6LAR3Y">
+                  <catDesc>Tel Aviv</catDesc>
+                  <category xml:id="tlaD4PCJLJWABFIBHGGPEFZNV3RRY">
+                    <catDesc>Museum of Antiquities of Tel Aviv-Yafo (Haaretz Museum)</catDesc>
+                  </category>
+                  <category xml:id="tlaHQ47VQOFQBFC5I75SCNLITRIPE">
+                    <catDesc>Nehusthan Pavilion</catDesc>
+                  </category>
+                  <category xml:id="tlaTUX6AHOCYNGZLCVC4AMAYCHVCY">
+                    <catDesc>Institute of Archaeology</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla46YBKCNWEVBY3BMKQGXFMGFNV4">
+                  <catDesc>Beit Shean</catDesc>
+                  <category xml:id="tla6MVBKPZRUNH2ZPMHPSILWFR2UI">
+                    <catDesc>Municipal Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaHZR2J5B3C5AQHEMCK5EHOOKHKE">
+                  <catDesc>Eyn Hashophet</catDesc>
+                  <category xml:id="tlaCMIWPIY25FHZJHWRSBZEPRJHKQ">
+                    <catDesc>Ägyptische Sammlung</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaL7KZALOCUZDZHFKJT3367CBFYY">
+                  <catDesc>Deganya Aleph</catDesc>
+                  <category xml:id="tlaHS4DTWVDUFCIRJ24ADHOPD7V4U">
+                    <catDesc>Bet Gordon</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaO4TRKZB54BDKXJURYNPZONVMCI">
+                  <catDesc>Kibbutz Kfar Menahem</catDesc>
+                  <category xml:id="tlaKG26QLIWGVCUPFHKY52FJ5UUN4">
+                    <catDesc>Shephela Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaOFFTXEE44ZCT3LHNKHAW4FR4NU">
+                  <catDesc>Jerusalem</catDesc>
+                  <category xml:id="tlaAZSS3AA2Y5FPHGH6EBST4B55ME">
+                    <catDesc>Museum of Assumptionist Fathers</catDesc>
+                  </category>
+                  <category xml:id="tlaELDUISRRQZFJZGDUA4W7MT7K5M">
+                    <catDesc>Flagellation Museum, Museum of the Studium Biblicum Franciscanum</catDesc>
+                  </category>
+                  <category xml:id="tlaFYM4NCYWAREFTIPEVC4RCUI44Y">
+                    <catDesc>The Bible Lands Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaGACMONL5SVF3XKJSBIW3NG6XEM">
+                    <catDesc>L. A. Mayer Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaKSF6PLNZZFCPFNHANYIZZMSCQI">
+                    <catDesc>Pontifical Biblical Institute Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaR3HJSETHDZEOJOVE6GHVUYUYWU">
+                    <catDesc>Bezalel National Art Museum (The Israel Museum)</catDesc>
+                  </category>
+                  <category xml:id="tlaRAHSJKEBFFDSTLMYHYVURRAFUM">
+                    <catDesc>H. E. Clark Collection</catDesc>
+                  </category>
+                  <category xml:id="tlaRK4ZTTSJTFFRTC32LYTRIXGVRQ">
+                    <catDesc>Russian Monastery on the Mount of Olives</catDesc>
+                  </category>
+                  <category xml:id="tlaW77NR7CEE5GFPEV6P4EMT6PH2Q">
+                    <catDesc>Rockefeller Archaeological Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaXB7X32CZTBE37I5FBM4ZOV56UI">
+                    <catDesc>Israel Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaQLNXWR37KRDVLNK5MNWQRUBQ4E">
+                  <catDesc>Ramat Hashofet</catDesc>
+                  <category xml:id="tlaY7XYUHRTH5ELFDFQLABGZCNENQ">
+                    <catDesc>Archaeological Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaR5O3CDKD6JC23OPC3UN6LGI5G4">
+                  <catDesc>Nir David</catDesc>
+                  <category xml:id="tlaYBCCYMKUAJBUPBXMBWGPF3TNUM">
+                    <catDesc>Museum of Mediterr. Archaeology</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaS3EDH3V5AFHHBHC6TTUMNVWQDU">
+                  <catDesc>Haifa</catDesc>
+                  <category xml:id="tlaJUDVCPUBBZGR5HYDKXTRZYJK2Q">
+                    <catDesc>Dagon Collection</catDesc>
+                  </category>
+                  <category xml:id="tlaMDXWKUWFLNB67LRW6SMQNAQN2M">
+                    <catDesc>National Maritime Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaNJMGSP5URNH3TKZ2NXXAWKHKHE">
+                    <catDesc>Museum of Ancient Art</catDesc>
+                  </category>
+                  <category xml:id="tlaV6ZTNTCZAVBWNKJ57WOS6QROXM">
+                    <catDesc>Music Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaVUFOGFREH5GPRKGHSOMLA7I6CQ">
+                    <catDesc>R. and E. Hecht Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaV27WPJWHPRH57GT7WIHO6XENLA">
+                  <catDesc>Kibbutz Hazorea</catDesc>
+                  <category xml:id="tlaS5Y34A3UD5EHDIAAUE43NPMY24">
+                    <catDesc>Wilfred Israel House for Art and Oriental Studies</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaXDPO5W62GZDA7AULLU2JAS4G2E">
+                  <catDesc>Akkon</catDesc>
+                  <category xml:id="tlaYBQC6TEVPZEJHCSSTPW72FJNWI">
+                    <catDesc>Municipal Museum</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaTSD2YCQLQFE7VBL6NTTU6VQYZY">
+                <catDesc>Armenien</catDesc>
+                <category xml:id="tlaMVSM3M2UQZGUJOUSRNKR2VILHY">
+                  <catDesc>Eriwan</catDesc>
+                  <category xml:id="tlaDK55FGARIZDUNKVZBRWQMFIKC4">
+                    <catDesc>State Museum of History of Armenia</catDesc>
+                  </category>
+                  <category xml:id="tlaJXQP2WJTHNFC5KLIZYZLC2CAIM">
+                    <catDesc>State Picture Gallery of Armenia</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaW2R272TFG5GBNGGAR2BNNAJJUE">
+                <catDesc>Zypern</catDesc>
+                <category xml:id="tla734GWEXPKZBYHKRETJMZQP65IY">
+                  <catDesc>Nikosia</catDesc>
+                  <category xml:id="tlaAUP7RP3OAVGPNPLKBYZ22WNHVA">
+                    <catDesc>The Cyprus Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaXYCOEXETMJAKLEG7JJZBZN556M">
+                  <catDesc>Limassol</catDesc>
+                  <category xml:id="tlaY67S6XNFUJF4TMECUUKL5GKZWU">
+                    <catDesc>Limassol District Museum</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaZ46G5LOM55D4NPMFM4RJ6PAZ7M">
+                <catDesc>Jordanien</catDesc>
+                <category xml:id="tlaT5MA2ABDWVAN7A5J7NJ44CMTQE">
+                  <catDesc>Amman</catDesc>
+                  <category xml:id="tlaJZFD5WRWUNGNHNAYALHRSTR2LM">
+                    <catDesc>Jordan Archaeological Museum, Department of Antiquities</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaZBP5TCODHBHPJDKSA7ATWUIMDQ">
+                <catDesc>Syrien</catDesc>
+                <category xml:id="tlaCQP72RV7SNGWTCJNCL5GD4YSSY">
+                  <catDesc>Lattakia</catDesc>
+                  <category xml:id="tla64KYRG4UYJCYZO26OCN3D2KARA">
+                    <catDesc>Ras Shamra Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaD3IDW5CAPVBKTIYSD52VNEWNPY">
+                  <catDesc>Damaskus</catDesc>
+                  <category xml:id="tlaDBQ4IG2ZAZHWFHOX6T4S5CEPOA">
+                    <catDesc>National Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaLAPH6WYSQJA3RBDMEYANWWXK4A">
+                  <catDesc>Aleppo</catDesc>
+                  <category xml:id="tlaN6WSO2PU7ZBOZBCCEKJBGFVQ54">
+                    <catDesc>Aleppo National Museum</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaZZDWN4HT2BAVTBUP5ZHKX6J7CY">
+                <catDesc>Tadschikistan</catDesc>
+                <category xml:id="tlaTLHJBTCCQFEIHFHV7CFC7QEUVM">
+                  <catDesc>Duschanbe</catDesc>
+                  <category xml:id="tlaQY3RXJKZPZAZTAO3FRVV5TGWNI">
+                    <catDesc>Institute of History, Archaeology and Ethnography of the Academy of Sciences of Tadschikistan</catDesc>
+                  </category>
+                </category>
+              </category>
+            </category>
+            <category xml:id="tlaPRXVLUJ7ENA4PH6XIPENAXFNZI">
+              <catDesc>Australien und Neuseeland</catDesc>
+              <category xml:id="tlaDUWGYNLAMRCYZD47WDAUQNIFPU">
+                <catDesc>Neuseeland</catDesc>
+                <category xml:id="tlaHXKXKSWVKJCL7O7B2JJ5UXLGII">
+                  <catDesc>Wellington</catDesc>
+                  <category xml:id="tlaZDEXVOY7P5E4NJEA2Z5OFGN7YU">
+                    <catDesc>Dominion Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaI2GRNFP75RAUZAFXA5XIHFDXGU">
+                  <catDesc>Palmerston North</catDesc>
+                  <category xml:id="tlaMV5FYY7K2BF7ZCX6RFYKYEK4EM">
+                    <catDesc>Public Library</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaPF3EHNY22RBVLHZMO37ZIH2DHQ">
+                  <catDesc>Auckland</catDesc>
+                  <category xml:id="tlaBJXIVRMG7JEH5MIVCL5XBDOGRU">
+                    <catDesc>Museum, Ägyptische Sammlung</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaPHN3MY63FNGMVCAHTD3BGWNKVI">
+                  <catDesc>Dunedin</catDesc>
+                  <category xml:id="tlaLJ73RLGAQFH45K5RS3R6SBZXIM">
+                    <catDesc>Otago Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaXVFT3MFVENDQDKHDL656YLLL6M">
+                  <catDesc>Christchurch</catDesc>
+                  <category xml:id="tlaJSIHVVBRCJHTRKOFD6VBIOAZT4">
+                    <catDesc>Ägyptische Sammlung</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaOS5UQ6XEGNFKDGN5DCZHZULJ2I">
+                <catDesc>Australien</catDesc>
+                <category xml:id="tlaA5VEBLTROJBBLN2O2THGVUGU6E">
+                  <catDesc>Adelaide</catDesc>
+                  <category xml:id="tla26Z23C5OB5CKPM2IFVQ77RIFX4">
+                    <catDesc>University Museum of Classical Archaeology</catDesc>
+                  </category>
+                  <category xml:id="tlaXAYZQGKLQRA3LMQDH4CPQZ6IXQ">
+                    <catDesc>South Australian Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaN2ZFMA2LU5C4ZIGTHPZQUJILXY">
+                  <catDesc>St. Lucia (Queensland)</catDesc>
+                  <category xml:id="tlaAWGNDDRHYZBKPGWWTM75IG2PKM">
+                    <catDesc>University of Queensland Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaPYQBOAZZT5BXPOVPLD3DOY6QBA">
+                  <catDesc>Hobart</catDesc>
+                  <category xml:id="tlaJ62ZBSON25EQBK7TE55SZWSSOQ">
+                    <catDesc>Tasmanian Museum and Art Gallery</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaWZAS3PCOCVATTGSOSMORROVVOE">
+                  <catDesc>Melbourne</catDesc>
+                  <category xml:id="tla6POILMR5PBGM5KZZHF22NNEFGU">
+                    <catDesc>Victoria Arts Center</catDesc>
+                  </category>
+                  <category xml:id="tlaPFH2J4FLJBH5XLTDTZE54Y6KLQ">
+                    <catDesc>National Museum of Victoria</catDesc>
+                  </category>
+                  <category xml:id="tlaULBOLLKJB5F3XA2NP7BEHGAK7M">
+                    <catDesc>Australian Institute of Archaeology</catDesc>
+                  </category>
+                  <category xml:id="tlaZSAHGINTIVCJBBIMFWSAB6K6YQ">
+                    <catDesc>National Gallery of Victoria</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaZPAJPPRVMRD77PT4BJNHHVNGPI">
+                  <catDesc>Sydney</catDesc>
+                  <category xml:id="tlaHQ7LEIHVXRCQDKKIXJDJF7JUAY">
+                    <catDesc>Australian Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaPBYPXOGCXJAIVG755F625PDPHA">
+                    <catDesc>Macquarie University, School of History, Philosophy and Politics</catDesc>
+                  </category>
+                  <category xml:id="tlaVBO4IXJ2NRHSLBYIGW2I35LBYE">
+                    <catDesc>Nicholson Museum of Antiquities</catDesc>
+                  </category>
+                </category>
+              </category>
+            </category>
+            <category xml:id="tlaVEI3KVRNMJEOLF4EWOBXCV4XWM">
+              <catDesc>Südamerika</catDesc>
+              <category xml:id="tla6AU4NQFB7RCYHEYMZFZ4PNBGG4">
+                <catDesc>Venezuela</catDesc>
+                <category xml:id="tlaU6T6MBT5ONG6LKG5SJJPOJY2NM">
+                  <catDesc>Caracas</catDesc>
+                  <category xml:id="tlaITLHGDCOIZGFPF46BRLTY3ZOSI">
+                    <catDesc>Museo de Bellas Artes</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaASGQILDAMBBWDIJQDBIDRLGUCU">
+                <catDesc>Kolumbien</catDesc>
+                <category xml:id="tlaIHC3BF6M5BFLZHF6R4RWLP7DMA">
+                  <catDesc>Bogota</catDesc>
+                  <category xml:id="tlaDCATFYQY2ZDGZEGFVCRAGZ5U2M">
+                    <catDesc>Inst. de Ciencias Naturales, Museo de Historia Natural, Univ. Nac.</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaBK3Z2HN47JCWHCA3ITSLAN7MKI">
+                <catDesc>Argentinien</catDesc>
+                <category xml:id="tla2R2XC7WQJVBNRNPAMWMXCPBN4U">
+                  <catDesc>Buenos Aires</catDesc>
+                  <category xml:id="tla3I2C7E4KY5DQZFPNHITYTTIMBM">
+                    <catDesc>Museo Nacional de Arte Oriental</catDesc>
+                  </category>
+                  <category xml:id="tla6BHDJGQG6FCWJAM73VVYG66RTE">
+                    <catDesc>Museo Etnográfico de la Facultad de Filosofia y Letras</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaIKO5UG7Y4FG65LQBZEMRLVHLMI">
+                  <catDesc>La Plata</catDesc>
+                  <category xml:id="tla44SOM5H5CBCKLFLUM44M5PQ3K4">
+                    <catDesc>Museo de Ciencias Naturales de la Plata</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaHBALTY4BFVEX7JF3BR7MTYP3FU">
+                <catDesc>Uruguay</catDesc>
+                <category xml:id="tlaD7YO2DMCJRER7EANIW4JCRFFTA">
+                  <catDesc>Montevideo</catDesc>
+                  <category xml:id="tlaGXQXT3BDT5HYDGEJUEC5W4HO5Q">
+                    <catDesc>Sociedad Urug. de Egiptologia</catDesc>
+                  </category>
+                  <category xml:id="tlaHN3BJZU3MZHPVEMLA7ADLAHQEA">
+                    <catDesc>Museo Nacional de Historia Natural</catDesc>
+                  </category>
+                  <category xml:id="tlaN2PE6WQQHRA3XH5JF5AUVUAYEA">
+                    <catDesc>Museo de Historia del Arte</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaX4P253DSYJE3PIS2MGBIVDAWM4">
+                <catDesc>Brasilien</catDesc>
+                <category xml:id="tla6DSFU6TGVNGGVPVKBK34MGDXNU">
+                  <catDesc>Sao Paulo</catDesc>
+                  <category xml:id="tlaHTVKMMVCZ5BHPCBVM3TZ7CUFAQ">
+                    <catDesc>Museu de Arqueologia e Etnologia da Universidade de Sao Paulo</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaC3GW6CTRE5BN3GTLA2FHEPBYJU">
+                  <catDesc>Rio de Janeiro</catDesc>
+                  <category xml:id="tlaEW6GB7VDQ5ERVKGRPFEEOCUXWI">
+                    <catDesc>Museu Nacional</catDesc>
+                  </category>
+                  <category xml:id="tlaYKBM2I5PZ5BYPI5WAVSNHRVNWY">
+                    <catDesc>Museu Nacional de Belas Artes</catDesc>
+                  </category>
+                </category>
+              </category>
+            </category>
+            <category xml:id="tlaW2NJGUEPWZGO7MMOJ6EANCRT7Y">
+              <catDesc>(in situ)</catDesc>
+            </category>
+            <category xml:id="tlaWYXAL6F6XRH4VOZFX4MY7E63UM">
+              <catDesc>(Grabungsmagazin)</catDesc>
+              <category xml:id="tla4PXSC254BNHSDKRNHUFTNZZNXE">
+                <catDesc>IFAO / Balat</catDesc>
+              </category>
+              <category xml:id="tlaPXOB5NUUGFFXDFRWVQCURFBNLQ">
+                <catDesc>IFAO / Deir el-Medine</catDesc>
+              </category>
+              <category xml:id="tlaT4MI6A2RKBAF7LTB7XMV37IIUQ">
+                <catDesc>SCA / Edfu</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaZBOIYJ5VIJC6RIX6XKP2JVYCQQ">
+              <catDesc>Afrika</catDesc>
+              <category xml:id="tlaKKWN4OPL3JHQ7JROLGJN2SF2DU">
+                <catDesc>Libyen</catDesc>
+                <category xml:id="tlaPPK2CCGIBNDWVO4N7D2GFBD3KY">
+                  <catDesc>Kyrene</catDesc>
+                  <category xml:id="tlaC422FCIA2BGRXH4RY4GLSFZW7A">
+                    <catDesc>Museum of Sculpture</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaZMOBLLCNNJENXJVI5HARRKZRVA">
+                  <catDesc>Marsa Susa</catDesc>
+                  <category xml:id="tlaH7MHTR5QC5EBNG4JV4U34FHVJA">
+                    <catDesc>Apollonia Museum</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaKKZRW2AAZVDVZPMGEB7MYOLE7U">
+                <catDesc>Ägypten</catDesc>
+                <category xml:id="tla2N5F6U34VRH77MOCMXIMWFH5RI">
+                  <catDesc>Mit Rahina</catDesc>
+                  <category xml:id="tla73V43UBBHBHRDITBHEWBNEJM7M">
+                    <catDesc>Mit Rahina Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla4ZSAUJUBXNBJZFGBEAOVAZBJR4">
+                  <catDesc>Miniya</catDesc>
+                  <category xml:id="tlaSFHATSIQ7JF7PE2SDIAP7PYH2I">
+                    <catDesc>Minia Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaBDNNGM4DQJG3RBIFDPV2SIBWSQ">
+                  <catDesc>Gisa</catDesc>
+                  <category xml:id="tlaJMDQOBFRHBAY7OEQDETSCVL7NA">
+                    <catDesc>Solar Boat Museum (Cheops Boat Museum)</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaBYYUJ7HO3ZHRZBXCQGSBDUAYAU">
+                  <catDesc>Aschmunein</catDesc>
+                  <category xml:id="tlaNGADXQ3ESJDVDBPVJAONUF22II">
+                    <catDesc>Aschmunein Open Air Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaCRVKATGHKRFVPDBMEAS3JOGC4A">
+                  <catDesc>Suez</catDesc>
+                  <category xml:id="tla6NMGPCALOFB7HOADWCPCQEH7MU">
+                    <catDesc>Suez Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaDBHDNJ6RCFDPNA55JWWL2FNQBQ">
+                  <catDesc>Assuan</catDesc>
+                  <category xml:id="tlaHDFJH4PFKZGOHP56GY33AKWUNA">
+                    <catDesc>Nubia Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaT745TE3455CMRNS4P6CWP7SJNI">
+                    <catDesc>Aswan Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaEU6PE7DH6ND3HB47RZKZJLPT5M">
+                  <catDesc>Ismailia</catDesc>
+                  <category xml:id="tlaILFJIZTXUVFNLPB5X6QNLBGNIE">
+                    <catDesc>Ismailia Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaFX2GFRKAINAEZATKEN73AHNWXU">
+                  <catDesc>Tanta</catDesc>
+                  <category xml:id="tlaX3ECQYUH3ZEXLIWDCSFXGNHDKQ">
+                    <catDesc>Tanta Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaGBA6NM4VHJBPNPYA4NJRWL5GLA">
+                  <catDesc>Kom Ushim</catDesc>
+                  <category xml:id="tlaNETL5EWR2VEGVLQ5T4XC75FV24">
+                    <catDesc>Kom Ushim Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaKQHATHCJQRHNNKEYUY3X2BDHXE">
+                  <catDesc>Zaqaziq</catDesc>
+                  <category xml:id="tla55TJTPTPYRDRFDDOWF77YYUB7M">
+                    <catDesc>Tell Basta Site Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaKVXK7WJ5HVBT3ETQWF37QP7M3I">
+                    <catDesc>University of Zagazig Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaLLYTPT7Q5RFGDKGRJ3VBMACFCM">
+                    <catDesc>Heriyet Rezan Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaLEDUZK7TSBBLXODTUQHW32CDZ4">
+                  <catDesc>Kafr el Sheikh</catDesc>
+                  <category xml:id="tlaPPKLJBCLRFBA5GDOOLQMH6EVEA">
+                    <catDesc>Kafr el Sheikh Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaMYHP23AZPNEDTJJ2NYEUXCFYYU">
+                  <catDesc>Kharga</catDesc>
+                  <category xml:id="tlaLQYVEUWWKVABVBDMK2MEJVLVXA">
+                    <catDesc>Wadi el-Gedid Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaNGDSOENKOZEJVENPFKPHYAE7PE">
+                  <catDesc>Mallawi</catDesc>
+                  <category xml:id="tlaXVHJ64ITNZCIBOW5W7TAS5ZCQQ">
+                    <catDesc>Antiquities Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaSPF5BCZGVRHXVKOXSY766QA5Q4">
+                  <catDesc>Alexandrien</catDesc>
+                  <category xml:id="tlaAH2QWPACOVAFVLPNIS7RFSHRHI">
+                    <catDesc>Museum of the Faculty of Arts, University of Alexandria</catDesc>
+                  </category>
+                  <category xml:id="tlaTP365PO46JHC7P53USYDPVXD2A">
+                    <catDesc>Graeco-Roman Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaV2JRHODWCVALDF2CNVYBOHNI6A">
+                    <catDesc>Jewellery Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaUSF6WYKVRRFHTLDM2OFI4XOD5A">
+                  <catDesc>Port Said</catDesc>
+                  <category xml:id="tlaVYEMC5AU2FC4TLDGHZQRSNQIOI">
+                    <catDesc>Port Said National Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaWLRFN3FJ4RBC5NQMV2YL546FLA">
+                  <catDesc>Assiut</catDesc>
+                  <category xml:id="tlaTHQ2QZHLBVD65A6JWVHMJKX27I">
+                    <catDesc>Beni Suef Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaX4BF5GAM7RCRJPXDA4PBUJGRWA">
+                  <catDesc>Sohag</catDesc>
+                  <category xml:id="tlaJH3DVVIUI5BMPLADOSYP3IYWLQ">
+                    <catDesc>Sohag Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaXDYKAWWYWBHFPP7MVKZA2MRZYA">
+                  <catDesc>Karnak</catDesc>
+                  <category xml:id="tlaB4XRRILT75HU5ET2FGGCPETHNE">
+                    <catDesc>Open-Air Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaYAK5GHWPNNHBPLSBJRU6I6FMR4">
+                  <catDesc>Kairo</catDesc>
+                  <category xml:id="tla2E4T57M7NZCC7EYM5U3IDHE5XE">
+                    <catDesc>Mohammed-Mahmoud-Khalil Museum</catDesc>
+                  </category>
+                  <category xml:id="tla2I2LDPDNQFFGNNMNDWAADCPQGE">
+                    <catDesc>Gezira Public Gardens</catDesc>
+                  </category>
+                  <category xml:id="tla2SMNTZV4W5GBFKJHK3T7EIL2PA">
+                    <catDesc>Cairo University - Faculty of Archaeology Museum</catDesc>
+                  </category>
+                  <category xml:id="tla3KQI62T3HJBFRPEQU6BD4CGSUU">
+                    <catDesc>Madbotat el-Athar Museum (confiscated Antiquities Museum) (Citadel of Salah el-Din)</catDesc>
+                  </category>
+                  <category xml:id="tla3QYRRW4V2FCATFOEGXFFU2EZ4M">
+                    <catDesc>Lycée Liberté (Lycée Français)</catDesc>
+                  </category>
+                  <category xml:id="tla5V4LG32PKVAPVEMXZSWTV2ZXEY">
+                    <catDesc>Coptic Museum</catDesc>
+                  </category>
+                  <category xml:id="tla7GIJHHMIE5C3VNVOTQFKMOUXEE">
+                    <catDesc>Military Museum (Citadel of Salah el-Din)</catDesc>
+                  </category>
+                  <category xml:id="tlaAY7SHCZNRNCDRMXCQKNBIRLXTY">
+                    <catDesc>College of the Holy Family</catDesc>
+                  </category>
+                  <category xml:id="tlaDZQ3HGHMKFGM3GZRVAZNQLX76E">
+                    <catDesc>St. George's Monastery</catDesc>
+                  </category>
+                  <category xml:id="tlaIUDG3ARYZFFNTDWLVUWQ5FAJPE">
+                    <catDesc>Police Museum (Citadel of Salah el-Din)</catDesc>
+                  </category>
+                  <category xml:id="tlaJ473G3GFQVGFVHFF3B3AB5SKNM">
+                    <catDesc>Heliopolis Open Air Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaLFXQK5IVQBGZPICA3WNBIEATZI">
+                    <catDesc>Institut Français d'Archéologie Orientale</catDesc>
+                  </category>
+                  <category xml:id="tlaQNUUX2SQTRCN7OZE22UOADOM6Q">
+                    <catDesc>Cairo University - Faculty of Medicin</catDesc>
+                  </category>
+                  <category xml:id="tlaQVHPZOLDRJCAPDFIMOGCLRC73Q">
+                    <catDesc>Bibliothèque Bonaparte</catDesc>
+                  </category>
+                  <category xml:id="tlaRJR6FHP26FBPVMGXDXHLLZIG2Y">
+                    <catDesc>Egyptian Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaSHEYFEYFERBDRM6UX3MCGXMEFY">
+                    <catDesc>Collège St. Joseph des Frères des Écoles Chrétiennes</catDesc>
+                  </category>
+                  <category xml:id="tlaTXBFVDBDQZCE3NBAM6UYSMCSMA">
+                    <catDesc>El-Matar Museum (Cairo Airport)</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaYUWN7GZG5VBTPHKGFONPBFB4DE">
+                  <catDesc>San el-Hagar</catDesc>
+                  <category xml:id="tlaZUJ7OMV66FAABCP3CDW2XQNRSU">
+                    <catDesc>San el-Hagar Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaZDOAPZWZHRC2VA2WOQAQVXOSNE">
+                  <catDesc>Luxor</catDesc>
+                  <category xml:id="tlaAOFQLOVTBBBFZCSAKOF5D5HCTE">
+                    <catDesc>Magazin des Antiquities Department</catDesc>
+                  </category>
+                  <category xml:id="tlaJDTW3SSLXVHWHPQXQKQNHLIATA">
+                    <catDesc>Mummification Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaKWOO3IEZNJDG5BJNVWKW4ZQJJQ">
+                    <catDesc>Luxor Museum of Egyptian Art</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaO7RD3MGUNVEMVNC6QWNR67476E">
+                <catDesc>Ghana</catDesc>
+                <category xml:id="tlaT4UYNMHBZ5GUZHU53A7OZGUHTI">
+                  <catDesc>Accra</catDesc>
+                  <category xml:id="tlaWFAO76QHQJHGBPNYBAMAF6O7KA">
+                    <catDesc>National Museum</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaRAKJHF37SZHT5AYGVGEL5OPNXQ">
+                <catDesc>Südafrika</catDesc>
+                <category xml:id="tlaAJ2N3VXYKVDNVEM5FGVZHZHNN4">
+                  <catDesc>Kapstadt</catDesc>
+                  <category xml:id="tlaRXYDSJKS6ZGZTOEBANKC2X4JAE">
+                    <catDesc>South African Cultural History Museum</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaS5CPQOIHNBG7LAJ5XZL53O4BJ4">
+                <catDesc>Äthiopien</catDesc>
+                <category xml:id="tlaJH2O2R2MDZCRPN2526I5ELALLM">
+                  <catDesc>Addis Abeba</catDesc>
+                  <category xml:id="tlaSMA4AW3V5RED5AZFFQAM2R4JMM">
+                    <catDesc>Archaeological Museum</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaWUS7ZZ6SV5CLND4COTL3GJHF3U">
+                <catDesc>Sudan</catDesc>
+                <category xml:id="tla3U42AI6ZXRAFDB5LCAIOVGIZ2Y">
+                  <catDesc>Wadi Halfa</catDesc>
+                  <category xml:id="tlaUZZL4BIZABF73GECYEL6WKJZFM">
+                    <catDesc>Halfa Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaKUQJPMOY2NFX3NVHVL5SKACWSY">
+                  <catDesc>Merowe</catDesc>
+                  <category xml:id="tlaDNYCKCFHNBGIZA7TOKXWVF4SC4">
+                    <catDesc>Merowe Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaMFH6J5IO2ZG45BRUXOH6JVMWZY">
+                  <catDesc>Khartum</catDesc>
+                  <category xml:id="tlaFQN7XMJQABG43LWRHYNXRJW7OQ">
+                    <catDesc>Sudan National Museum</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaXULZVECEUNDAHKYWHJONSMR7WE">
+                <catDesc>Tunesien</catDesc>
+                <category xml:id="tla32Q36BQHKRGYZEIJ7D2KJWVYRA">
+                  <catDesc>Karthago</catDesc>
+                  <category xml:id="tlaWM7ULSQ4SBE7LIX653QIGMO5LY">
+                    <catDesc>Musée la Vigerie de St. Louis</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaLAYL7F3Y35FRBKI2TS77GXFWXE">
+                  <catDesc>Tunis</catDesc>
+                  <category xml:id="tlaRXV7FZ3RCZBKXNWO6K6CEHIEG4">
+                    <catDesc>Musée National du Bardo</catDesc>
+                  </category>
+                </category>
+              </category>
+            </category>
+            <category xml:id="tlaZBSNWPNKRZH2FLOH76RV5BFZ6I">
+              <catDesc>(unbekannt)</catDesc>
+            </category>
+            <category xml:id="tlaZQHEZY7AUZF6BM54XPO3Z3LOJU">
+              <catDesc>Nordamerika</catDesc>
+              <category xml:id="tlaL7ODVKNVFBCB3CU332IKL2SHDU">
+                <catDesc>Kanada</catDesc>
+                <category xml:id="tla4SV2RJH7ZNERZFDKTYY5Z643UQ">
+                  <catDesc>Regina (Saskatchewan)</catDesc>
+                  <category xml:id="tlaFRUFGWNGJBE2XBO3BIGL6JS3EA">
+                    <catDesc>Norman Mackenzie Art Gallery</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla5I5KYSEDVNGJDMKXCJGKWLLDCY">
+                  <catDesc>Montréal</catDesc>
+                  <category xml:id="tla4YKLCAWUMNDG3JRCHWL7AG2BM4">
+                    <catDesc>McGill University Ethnological Museum</catDesc>
+                  </category>
+                  <category xml:id="tla54ELZYSVPFGYVKXYATU5OYIISM">
+                    <catDesc>Redpath Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaXYTIDZJQHBC5JOVYFW77OXOF3Y">
+                    <catDesc>Musée des Beaux-Arts de Montréal</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaHQRGBBEL7BAVHJY2CKJQ6WK5TM">
+                  <catDesc>Québec</catDesc>
+                  <category xml:id="tlaZDBK422JOZCD3OAVJP2QGEE2QY">
+                    <catDesc>Laval University Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaMP6VK5IW6FC55IRLVFCF3F3IHY">
+                  <catDesc>Niagara Falls</catDesc>
+                  <category xml:id="tlaWD5MKSBLXFC2TP522W2O44FOBQ">
+                    <catDesc>Niagara Falls Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaUAFFUFPXKFGFREB2U5ZDOKKNYA">
+                  <catDesc>Vancouver</catDesc>
+                  <category xml:id="tlaIDWTL7YCYVE5TOYKYJEBBYLHNA">
+                    <catDesc>Museum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaWKBSYZB3A5CDXFO4TPKPVS6ESI">
+                  <catDesc>Toronto</catDesc>
+                  <category xml:id="tla7ZQHHK4EHFBCFORGV3GR4IPYQE">
+                    <catDesc>Royal Ontario Museum</catDesc>
+                  </category>
+                  <category xml:id="tlaSTNXUHWLJRCEHKXI3DOXYOYVO4">
+                    <catDesc>The Lands of the Bible Archaeology Foundation</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaM4BPIWR72JDLPKZN5QWVSTOUQ4">
+                <catDesc>U.S.A.</catDesc>
+                <category xml:id="tla4NDQCI4YLZCTNJK7677STRJCHA">
+                  <catDesc>(Städte A-Ch)</catDesc>
+                  <category xml:id="tla2THRI7PEDVAXXJB6AASISJHM6A">
+                    <catDesc>Chicago (IL)</catDesc>
+                    <category xml:id="tlaAVAF4KFOSBG33LWXVBB7EDGFPM">
+                      <catDesc>Art Institute</catDesc>
+                    </category>
+                    <category xml:id="tlaI6LLY3EJVRAWDAR4GCRBLA425Y">
+                      <catDesc>Oriental Institute Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaXTEPN27SWNFXDJY6EVCDGGLL4M">
+                      <catDesc>George F. Harding Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaXVNNL7M5VZCP5JAGY4V5FWZCCM">
+                      <catDesc>Field Museum of Natural History</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla3NG3AQ5NTNCUHDRD3MAEWIJZOI">
+                    <catDesc>Berkeley (CA)</catDesc>
+                    <category xml:id="tlaBZDESZAD7RELZJMBJ76ZMLSSUU">
+                      <catDesc>Phoebe Apperson Hearst Museum of Anthropology</catDesc>
+                    </category>
+                    <category xml:id="tlaG2YJGIBHIJH45I5N4BKHEE5TBM">
+                      <catDesc>University Art Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaGQMG3N4LJZHWVJSEGGAB3ILKWE">
+                      <catDesc>Bade Institute</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla4CGUOSXVTBBBFLEPJJGSOXIVEM">
+                    <catDesc>Boston (MA)</catDesc>
+                    <category xml:id="tlaW5RFGYEN5JDHJHT4BQF3E7K2YI">
+                      <catDesc>Museum of Fine Arts</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla6RPXUC5CYVF3HP6MK57QCHQCK4">
+                    <catDesc>Bryn Athyn (PA)</catDesc>
+                    <category xml:id="tlaMLNXGDF4GBCEDEXOGBZZXG3B5Y">
+                      <catDesc>Museum of the Academy of the New Church</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla6WQ6Y6VKM5BALJZ6WEWI6KCJCU">
+                    <catDesc>Aurora (NY)</catDesc>
+                    <category xml:id="tlaB3BIZOJD25CEZILCLZ3K6B6ATI">
+                      <catDesc>Wells College Art Collection</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaBLJZOGYKDVAGHACHVMIJ4QAQ4Y">
+                    <catDesc>Ann Arbor (MI)</catDesc>
+                    <category xml:id="tlaEEQD4QSF2BDKVOEKMWINAZNPQM">
+                      <catDesc>University of Michigan, Kelsey Museum of Ancient and Mediaeval Archaeology</catDesc>
+                    </category>
+                    <category xml:id="tlaR36M3CRJVREKRBML2U56BGWUYE">
+                      <catDesc>University of Michigan, Museum of Art</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaDMPJEDYKYJAOTO5QU3ODGP3LZY">
+                    <catDesc>Brunswick (ME)</catDesc>
+                    <category xml:id="tlaCXA5F22EURCL7NV2ANKLWTBHWM">
+                      <catDesc>Bowdoin College Museum of Art</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaEGNJQ6TK5VGHPNLTCWZ2DNDTH4">
+                    <catDesc>Amherst (MA)</catDesc>
+                    <category xml:id="tlaB72OLQBHB5DR7HBNNPE6SC2JJY">
+                      <catDesc>Mead Art Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaF757L764TBCFDK74DEJFKI7TOQ">
+                    <catDesc>Cambridge (MA)</catDesc>
+                    <category xml:id="tla654VFI6HJNDLTFMBUBGF26TVGY">
+                      <catDesc>Fogg Art Museum, Harvard University</catDesc>
+                    </category>
+                    <category xml:id="tlaVQ34KHQM3FGMNPHUWQUP66H5CM">
+                      <catDesc>Semitic Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaYTXHPMTNXBD27JNJNMJ7N3EG7M">
+                      <catDesc>Peabody Museum of Archaeology and Ethnology</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaFHW2TEX42VAHVPSX6PP5O6XJW4">
+                    <catDesc>Atlanta (GA)</catDesc>
+                    <category xml:id="tlaHLNE6EAFNVDF5P33XWAPSFD6SY">
+                      <catDesc>M.C. Carlos Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaHNMIPUNAYRBNLCCLF6EDN733VM">
+                    <catDesc>Charleston (SC)</catDesc>
+                    <category xml:id="tlaAGTRNBKWMNEXTG76LBQHB6RE54">
+                      <catDesc>The Charleston Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaMER3NPX6YBE5PNAKPEAVGGJCR4">
+                    <catDesc>Birmingham (AL)</catDesc>
+                    <category xml:id="tlaDYBDMT5PGREK7EDCRVG5GODUSY">
+                      <catDesc>Museum of Art</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaOYI53U532ZC6ZHLQ2SKR4HDPJI">
+                    <catDesc>Champaign-Urbana (IL)</catDesc>
+                    <category xml:id="tla6DMO7AMVTNGWRKJTDI67TXASM4">
+                      <catDesc>Krannert Art Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaPH2GPB47DVFF7JC46GZSC7V4LU">
+                    <catDesc>Baltimore (MD)</catDesc>
+                    <category xml:id="tla2MKZIGHBVJFLVFBCP7X5EOF3FE">
+                      <catDesc>Museum of Art</catDesc>
+                    </category>
+                    <category xml:id="tlaN3DGPVGG45GCTBP4RNVWEABZNQ">
+                      <catDesc>Johns Hopkins University Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaSEIZV3OYQVDRVPMUU3N4WEQHJU">
+                      <catDesc>Goucher College</catDesc>
+                    </category>
+                    <category xml:id="tlaW22REGKPU5GFDGJEAATSJKMNZU">
+                      <catDesc>Walters Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaRVIRCXMS4BA5JNF2IMGAX5H7NE">
+                    <catDesc>Buffalo (NY)</catDesc>
+                    <category xml:id="tlaCLCXBQKIEJCNHJ47N4QDRWKQLA">
+                      <catDesc>Albright-Knox Art Gallery, The Buffalo Fine Arts Academy</catDesc>
+                    </category>
+                    <category xml:id="tlaHCXM4GPCURBUTBZC44CC2XKPJQ">
+                      <catDesc>Buffalo and Erie County Historical Society Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaUM5YDBWGLZBDDJA4HYCIOLIS2Q">
+                      <catDesc>Museum of Science</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaS3BKM2MHUNEIXE2ZMJKA6ABDZM">
+                    <catDesc>Bloomfield Hills (MI)</catDesc>
+                    <category xml:id="tlaYM65UNMBMNCPDPZUAMCNWZEK4M">
+                      <catDesc>Cranbrook Institute of Science</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaWGJZSKRLHFDVDHY7TGKABWEBZY">
+                    <catDesc>Bloomington (IN)</catDesc>
+                    <category xml:id="tlaMI3BQKW5KZEYHALYCMYTJZITGY">
+                      <catDesc>Indiana University Art Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaXVMYXHROWFATZLXQ5AWFSWS3SA">
+                    <catDesc>Chapel Hill (NC)</catDesc>
+                    <category xml:id="tlaISME5675TRBJZFULK7JSGGIB4Q">
+                      <catDesc>Ackland Art Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaY35IFY5B7NBNFF4GGIT6RHMQOE">
+                    <catDesc>Berrien Springs (MI)</catDesc>
+                    <category xml:id="tlaIA57WHFUQJFBBKXO3NHXJ5EIIU">
+                      <catDesc>Andrews University</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tla5RLAQ4BRQZFVNO3AHFYUXXXD44">
+                  <catDesc>(Städte L-P)</catDesc>
+                  <category xml:id="tla3MHGFID5KRCNHEPVNU7V3TO3L4">
+                    <catDesc>Providence (RI)</catDesc>
+                    <category xml:id="tlaS72FJQL4URFDPKDTLZUAO2RQR4">
+                      <catDesc>Museum of Art, Rhode Island School of Design</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla474LZS2SPJHCJO6LU75MVNWEWE">
+                    <catDesc>Newark (DE)</catDesc>
+                    <category xml:id="tlaPU4ZP6RIDFEZXKXON6DJA67Y5I">
+                      <catDesc>University of Delaware</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla4LUSOAXTANEH7LJB67JNXWGWEQ">
+                    <catDesc>New Brunswick (NJ)</catDesc>
+                    <category xml:id="tlaNYMEEHWB4JHEBKZUFTOT3CH27Q">
+                      <catDesc>Rutgers University Library</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla6KSXIEUKNNDPTIKACUYBFO4QJA">
+                    <catDesc>Los Angeles (CA)</catDesc>
+                    <category xml:id="tlaOIDKYEVKZNBIZB3STFTNRPOQSY">
+                      <catDesc>County Museum of Art</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla6RCR5GUOURAIDKHIPVIKNDJYIQ">
+                    <catDesc>Portland (ME)</catDesc>
+                    <category xml:id="tla5D4QJTJDQRACVBIVGTJZD5ULX4">
+                      <catDesc>Museum of Art</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla74TOAD2KVRH53LBDYY6M2EVF34">
+                    <catDesc>Philadelphia (PA)</catDesc>
+                    <category xml:id="tlaDOJS33X3DVEKNOCWZYYKTC2TCU">
+                      <catDesc>Commercial Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaF6FYQMG2H5CDBHARW3CUB3IWSU">
+                      <catDesc>The Rosenbach Museum and Library</catDesc>
+                    </category>
+                    <category xml:id="tlaH4426FAAMJC6TDL76MHZKBMKIQ">
+                      <catDesc>The University Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaNYX5NTLQRNHLRMWEQNADWDH2NA">
+                      <catDesc>Philadelphia Museum of Art</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaAWEIXZCUAFB55DJ6OHMOKTRPZ4">
+                    <catDesc>Memphis (TN)</catDesc>
+                    <category xml:id="tla4ABJPIO43VHUBCSQ2C6R7QCJ3Y">
+                      <catDesc>Memphis State University</catDesc>
+                    </category>
+                    <category xml:id="tlaJDPJTV2NYJBYFMO35YMGARQFMQ">
+                      <catDesc>Institute of Egyptian Art</catDesc>
+                    </category>
+                    <category xml:id="tlaMOCORKV2MFALPGJC7NFZT7CMXY">
+                      <catDesc>Zoological Garden</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaCCQ2R5HCSNHFNFQGJ3MVOHVHXM">
+                    <catDesc>Omaha (NE)</catDesc>
+                    <category xml:id="tlaCKH7ZOERCNHL3ML2IU6P7A7IFQ">
+                      <catDesc>Joslyn Art Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaJ5VRTTCJUZEH5FPYN7P7DUIU6Q">
+                    <catDesc>Little Rock (AR)</catDesc>
+                    <category xml:id="tlaS4UHUREKAZHCFIDHXZPXEQ5LMU">
+                      <catDesc>Science and History</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaK4XHMT7ZAFG5JAY6Y2WJVA62OY">
+                    <catDesc>New York City (NY)</catDesc>
+                    <category xml:id="tlaCXBVV3IB2JDNTJRJTWJL2V7XCM">
+                      <catDesc>Brooklyn (NY)</catDesc>
+                      <category xml:id="tlaZGC73O5WYBC4ZDS3NGTA34NZ3A">
+                        <catDesc>The Brooklyn Museum</catDesc>
+                      </category>
+                    </category>
+                    <category xml:id="tlaCXUA5GP3EFEVFJJB5B2UVHVJDI">
+                      <catDesc>Cooper-Hewitt Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaH6JSFIW5CBGO7KIFGHIADHOWEI">
+                      <catDesc>Academy of Medicine</catDesc>
+                    </category>
+                    <category xml:id="tlaIL4SGUWMRFHHXFTXNS6CFPBBKY">
+                      <catDesc>Metropolitan Museum of Art</catDesc>
+                    </category>
+                    <category xml:id="tlaNJEHI6AWZRD3NCN4Z7S7RSWBFQ">
+                      <catDesc>Alfred University, Allen Steinheim Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaQBJ6ZBUYCFA2VMW3GKKHRTUC74">
+                      <catDesc>American Museum of Natural History</catDesc>
+                    </category>
+                    <category xml:id="tlaRCEYW5JSXRFX5JBGOMGGGNFV6E">
+                      <catDesc>Pierpont Morgan Library</catDesc>
+                    </category>
+                    <category xml:id="tlaS2N5YQLFF5BB3O3NPK7SD6K65A">
+                      <catDesc>Columbia University Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaTD5TBOLYRNBPLM7ICPFETRISSQ">
+                      <catDesc>Institute of Art and Archaeology</catDesc>
+                    </category>
+                    <category xml:id="tlaTK5SQOMPGRFTXBU2KM4BGCERQA">
+                      <catDesc>Hispanic Society</catDesc>
+                    </category>
+                    <category xml:id="tlaYLRJCC4SWFHOBMOQTRKORMC7GU">
+                      <catDesc>Queens College Art Collection</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaKAB7I7O5MBD6TCUAAUT76672NU">
+                    <catDesc>Princeton (NJ)</catDesc>
+                    <category xml:id="tla6KXQVIB52RHQ7D42H5SLUPFC6Y">
+                      <catDesc>Art Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaLBKP5EPQOJHVJO3YYJEMUOFUHM">
+                    <catDesc>Nevada City (CA)</catDesc>
+                    <category xml:id="tlaKFRZZMDM3FFEVBWLRN2H26UAVM">
+                      <catDesc>Lands of the Bible Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaLOBQZUUUH5CIPPQVKBURU67NEA">
+                    <catDesc>Oberlin (OH)</catDesc>
+                    <category xml:id="tlaR4SLWLNJXZG6RLO6RYM4VVDFAQ">
+                      <catDesc>Allen Memorial Art Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaMKVJ7XTYFND6FEHF5T5M5UGILE">
+                    <catDesc>Northampton (MA)</catDesc>
+                    <category xml:id="tlaFUGYVNFNCFENNKIBW3W3EUYMQI">
+                      <catDesc>Smith College Museum of Art</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaMNRTV5T6RBHV3K3Z4FBZOFL7XM">
+                    <catDesc>Milwaukee (WI)</catDesc>
+                    <category xml:id="tlaPJBOSVWL6FEBBG3PQELQQI5OMY">
+                      <catDesc>Milwaukee Public Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaRVRCNRQVYRCIPIZCRUEIQCSQPY">
+                      <catDesc>Art Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaO76WDV3D65FNVLYNBAPZ2B3GLU">
+                    <catDesc>Newark (NJ)</catDesc>
+                    <category xml:id="tlaVBRAWBDZX5BU5G7Z2CB3YWXTFE">
+                      <catDesc>Newark Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaPCZJPBIUXFDZXBJVEN5ENTI3UA">
+                    <catDesc>New Haven (CY)</catDesc>
+                    <category xml:id="tla4QU72FX2AJFKVPNZ5GG5HW7L5Y">
+                      <catDesc>Yale University Art Gallery</catDesc>
+                    </category>
+                    <category xml:id="tlaJWDZ7UA7L5A5LNY37XPSPAJYCY">
+                      <catDesc>Peabody Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaPH2MGSG2CBGEPDX3BXJZNUAHFU">
+                    <catDesc>Minneapolis (MI)</catDesc>
+                    <category xml:id="tlaEGLD7EX63NH6VEUMTG47JKEVXI">
+                      <catDesc>Public Library</catDesc>
+                    </category>
+                    <category xml:id="tlaEWGL55C5EZEGXOPF7UQKB2BUK4">
+                      <catDesc>The Minneapolis Institute of Arts</catDesc>
+                    </category>
+                    <category xml:id="tlaFGRJBOJXFRE5BDVAOVFIS6APKM">
+                      <catDesc>Walker Art Center</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaSYKOPSYJMVCFLBFGFHQWAY3ZII">
+                    <catDesc>Miami (FL)</catDesc>
+                    <category xml:id="tlaUXJB27JGC5CI3D6DCXBP7KS5HU">
+                      <catDesc>Lowe Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaTQTOTKGQHFFB7IIFH2ARGEHA2I">
+                    <catDesc>Pittsburgh (PA)</catDesc>
+                    <category xml:id="tlaNAH2TU5TOFHUNPIYLR3WZG2EL4">
+                      <catDesc>The Carnegie Museum of Natural History</catDesc>
+                    </category>
+                    <category xml:id="tlaTOFNHESUU5AAPLY4JKRGAZGU2M">
+                      <catDesc>Carnegie Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaUEBOFGLADJGITKNMOOQ34DMR3U">
+                    <catDesc>Phoenix (AZ)</catDesc>
+                    <category xml:id="tlaGQGAUMI3XZHGFGRUNMG5RNHEPI">
+                      <catDesc>Art Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaZTKIABHZPNHCFM6GVIR23DSBLQ">
+                    <catDesc>Manheim (PE)</catDesc>
+                    <category xml:id="tla4GMLAJXUGZAQ3PPFU4OEYAJHPI">
+                      <catDesc>Catholic University</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaZX5CUSABARF4NHGOEXP3O7MCHA">
+                    <catDesc>Louisville (KY)</catDesc>
+                    <category xml:id="tla4O36Y346KJBE5CBSCWVRHACOYU">
+                      <catDesc>The J.B. Speed Art Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaNW6WUIHIJZD5LNDDNVUL5LXJFU">
+                      <catDesc>The Southern Baptist Theological Seminary, Eisenberg Museum</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tla6HFVTW7K3NCQFFRH4QCMJPIZ6U">
+                  <catDesc>(Städte R-Z)</catDesc>
+                  <category xml:id="tla3UD2KDJRTRHBFD7IKOKUTNWXFY">
+                    <catDesc>Salem (MA)</catDesc>
+                    <category xml:id="tla2M6HT7PVLBEZNLGIB2DOCEOSII">
+                      <catDesc>Peabody Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla422HRCSJ35FKDI6URKODYWX3YU">
+                    <catDesc>San Jose (CA)</catDesc>
+                    <category xml:id="tlaKJSOFMVGTNFCLOEIR3F7GL4MSA">
+                      <catDesc>Rosicrucian Egyptian Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla5UL5UB4QWZFDPJDCYBUN4QQFJI">
+                    <catDesc>Urbana Champaign (IL)</catDesc>
+                    <category xml:id="tla77XJ7AZEUNBIJCY3FA4PX72KQA">
+                      <catDesc>Krannert Art Museum (University of Illinois)</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaBIAK4R2YXRCNJHJWWNVV76NYJA">
+                    <catDesc>Wellesley (MA)</catDesc>
+                    <category xml:id="tlaM6Z5BE3G35E67CE53BWROR2HDI">
+                      <catDesc>Jewett Arts Center</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaDFZ7DIKP6FAIJCR7HTL33VHWQY">
+                    <catDesc>San Francisco (CA)</catDesc>
+                    <category xml:id="tla64VOVWUBZRFBVDWIPDUHYPX2V4">
+                      <catDesc>M.H. de Young Memorial Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaOLZXRRX7IVGHPDCGZQGQIYICQ4">
+                      <catDesc>Fine Arts / Legion of Honor</catDesc>
+                    </category>
+                    <category xml:id="tlaQHPM3I7SFNCVLCSSK4WCYORMW4">
+                      <catDesc>State University</catDesc>
+                    </category>
+                    <category xml:id="tlaU2NOID4QIZC53ESFHSDE4KO3HI">
+                      <catDesc>Fine Arts / Young Mem. Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaDYUR2F7K2BF35OZAMLK4BUEVEQ">
+                    <catDesc>San Diego (CA)</catDesc>
+                    <category xml:id="tlaIZUEFGS2Q5EL5GNKHVMIQ4C4NY">
+                      <catDesc>San Diego Museum of Art</catDesc>
+                    </category>
+                    <category xml:id="tlaSWPKOE5BKFGZXIEKO7ALRVXU7Y">
+                      <catDesc>Museum of Man</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaECTWMZOLABBNJPLTD5FHBB5CJI">
+                    <catDesc>Shawnee (OK)</catDesc>
+                    <category xml:id="tlaKSCDC6P3SVDHPIAFVZLA7XOZG4">
+                      <catDesc>Mabee-Gerrer Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaETV5AKZ77FAZJM6DZMDEHGSMN4">
+                    <catDesc>Springfield (MA)</catDesc>
+                    <category xml:id="tlaQS52MQZ2QRFMTGHBBDJYQN6NRA">
+                      <catDesc>Smith Art Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaEVDQY3MFRBECVJ5RMZMUFSGV4Q">
+                    <catDesc>Toledo (OH)</catDesc>
+                    <category xml:id="tlaO6SYX2HGTJCETIOECKYO6OZEA4">
+                      <catDesc>Museum of Art</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaI7TFOJZQANETHI35GBCLHUQLAI">
+                    <catDesc>Santa Barbara (CA)</catDesc>
+                    <category xml:id="tlaJ7MGC7WQUJFYBNL6ZL4S5LC53E">
+                      <catDesc>Museum of Art</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaJYQZ3CFE25HQ7NQGBUCUO4W5ZI">
+                    <catDesc>Stanford (CA)</catDesc>
+                    <category xml:id="tlaKZXFA7VOQJEO5F5BUV2SQC7YLU">
+                      <catDesc>University Museum and Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaLJSYXJJCUJDY3IXWFSNB2SNDFM">
+                    <catDesc>Worcester (MA)</catDesc>
+                    <category xml:id="tla5JDHXRXQKFC6NBMC3Q4EWPWEQY">
+                      <catDesc>Art Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaLZJ5QCDYJVHFRFDZU5BI6J6B44">
+                    <catDesc>Rochester (NY)</catDesc>
+                    <category xml:id="tlaA4K62MH4EFHLDGWDZHSWOKOHWI">
+                      <catDesc>Rochester University</catDesc>
+                    </category>
+                    <category xml:id="tlaNJNDGWXBHVBX5DRR3V5MHXK7VI">
+                      <catDesc>Memorial Art Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaMLJ4LO4BWZGHTPURTVPDHSN5T4">
+                    <catDesc>St. Louis (MO)</catDesc>
+                    <category xml:id="tla7YYPKUMTLVFJHO3VUVE2CDNJCQ">
+                      <catDesc>Washington University Gallery of Art, Steinberg Hall</catDesc>
+                    </category>
+                    <category xml:id="tlaDHHM65LILFDEXE2K37SYOWTPEU">
+                      <catDesc>Art Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaNU6MOQQGOVHSHAPH7VGEVPKCEE">
+                    <catDesc>St. Paul (MN)</catDesc>
+                    <category xml:id="tlaJ5BKMGRMKFA25LMHOWTQGFW2VY">
+                      <catDesc>The Science Museum of Minnesota</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaOTPY6NHC3VAI5OGBGRKFFZ53T4">
+                    <catDesc>Salt Lake City (UT)</catDesc>
+                    <category xml:id="tlaJJKIDINW5BC4RIOGZ5TVQIEIUU">
+                      <catDesc>Museum of Fine Arts</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaR5VRT5VYRRCNXA6UP6CKPCH6CQ">
+                    <catDesc>Washington (DC)</catDesc>
+                    <category xml:id="tla3MUSWV7QURA2NOM575K52MIUBQ">
+                      <catDesc>Catholic University, Georgetown University Art Collection</catDesc>
+                    </category>
+                    <category xml:id="tlaEE6LIRT2K5GNDNQABNTD6JKO7I">
+                      <catDesc>Washington University</catDesc>
+                    </category>
+                    <category xml:id="tlaF6Q3CFZFYVHOFLRVLWLXGTEAWE">
+                      <catDesc>Smithsonian Institute</catDesc>
+                    </category>
+                    <category xml:id="tlaIKPE6UUMB5GE5NAIEWUQST5RTM">
+                      <catDesc>United States National Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaNHFDJDTRTBFENG2NOMOYRFWAHQ">
+                      <catDesc>Hirshhorn Museum and Sculpture Gallery</catDesc>
+                    </category>
+                    <category xml:id="tlaR3A23P44TJAVHKUFDAP3HXGUOU">
+                      <catDesc>Textile Museum</catDesc>
+                    </category>
+                    <category xml:id="tlaXAES67H6RJDORKDZ7W7BILM3BE">
+                      <catDesc>Dumbarton Oaks Research Library and Collection</catDesc>
+                    </category>
+                    <category xml:id="tlaZG455I7CQZA7LN6CRCVENPJ5H4">
+                      <catDesc>Freer Gallery of Art</catDesc>
+                    </category>
+                    <category xml:id="tlaZWJG6EN2RJHN7F4J22FRJW4SN4">
+                      <catDesc>The Phillips Collection</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaRPOXUEJUVFEY7DM6M3Q7DZQMMQ">
+                    <catDesc>Richmond (VA)</catDesc>
+                    <category xml:id="tlaEAEC7JZVAJBNBGQS4L3ZA6PRCI">
+                      <catDesc>Virginia Museum of Fine Arts</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaRR7VJDX5F5APJMXND4OB3G27OQ">
+                    <catDesc>South Hadley (MA)</catDesc>
+                    <category xml:id="tlaIBTKN65LWNBW7GQGCICR2ZHGKI">
+                      <catDesc>Mount Holyoke College</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaUYRKORRG6VBVXL24JOD5W6JWSI">
+                    <catDesc>Wilmington (NC)</catDesc>
+                    <category xml:id="tlaAWECVN4CFFADLGVKMRMZF34ZVY">
+                      <catDesc>New-Hannover Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaVHVIOV2IHVDMZMRY7AO5UL6LG4">
+                    <catDesc>San Antonio (TX)</catDesc>
+                    <category xml:id="tla42BOS4YUGZH3ZEIFQDALEX2GPA">
+                      <catDesc>San Antonio Museum Association</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaZLJI7EBECJH3JEW5BQTGND5LH4">
+                    <catDesc>Seattle (WA)</catDesc>
+                    <category xml:id="tla5LSGAOOJKJFB7OEEOMDJ2KV3XQ">
+                      <catDesc>Art Museum</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tlaF4L3TGIVYZH6FCQT25LUX37BKY">
+                  <catDesc>(Städte Ci-K)</catDesc>
+                  <category xml:id="tla3MZKR3KW7VFIBCV4KOY2Y7ZJHQ">
+                    <catDesc>Kansas City (MO)</catDesc>
+                    <category xml:id="tlaKRP5QRWPORHAFFKCG6WSE4Y3KM">
+                      <catDesc>University of Kansas, The Spencer Museum of Art</catDesc>
+                    </category>
+                    <category xml:id="tlaOHILO7DXONGM5NC6JCOOWYQO3U">
+                      <catDesc>Nelson-Atkins Museum of Art</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla4F7CXWXNN5ED5JJTY6F6M2BXWI">
+                    <catDesc>Kearney (NE)</catDesc>
+                    <category xml:id="tlaX6XRYJAZ3ZHMNMNL3FKUKLIJ34">
+                      <catDesc>Fort Kearny Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla4QWOERCQTJHR5B2TYJ53JDWGV4">
+                    <catDesc>Honolulu (HI)</catDesc>
+                    <category xml:id="tlaFUKB7UV47ZGDLO7D6QDV3KS3P4">
+                      <catDesc>Honolulu Academy of Arts</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla565XPF4ORJFIBEKH6FETG3A5NU">
+                    <catDesc>Columbia (MO)</catDesc>
+                    <category xml:id="tlaDNHY5JDHGNDFDHRXO5HU4XN4DU">
+                      <catDesc>Museum of Art and Archaeology</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla5YADI45R4VHBFIQJEJMXWH3V6Q">
+                    <catDesc>Hartford (CT)</catDesc>
+                    <category xml:id="tlaVD7SJ7PT3BB4PP73VRTFZIGUG4">
+                      <catDesc>Wadsworth Atheneum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla6XHJKGKLEFANNC4EBMX6ACTTOY">
+                    <catDesc>Corning (NY)</catDesc>
+                    <category xml:id="tlaSEKALXYYMJE3PAZP4LQXRVEOKI">
+                      <catDesc>Glas Center</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla7I7FFMSKQRDP5KESGYXOUFDGAY">
+                    <catDesc>Ithaca (NY)</catDesc>
+                    <category xml:id="tlaNXBK62CNGVCTPHPJSMLG32FZUY">
+                      <catDesc>Cornell University, Museum of Archaeology</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaB3W5UV57LVGUJNCFW6KMGMGU74">
+                    <catDesc>Houston (TX)</catDesc>
+                    <category xml:id="tla45TS7XDBDFEB3JISFWBSQITMPI">
+                      <catDesc>University of St. Thomas</catDesc>
+                    </category>
+                    <category xml:id="tla4HK56XCQBNEVBKREUDIPQKJ6JQ">
+                      <catDesc>Museum of Fine Arts</catDesc>
+                    </category>
+                    <category xml:id="tlaQNHH3776LZDRPKUSZNJXGZGJTQ">
+                      <catDesc>Museum of Natural Science</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaBIMYZZU4DZEFJE67XLILJORD4Y">
+                    <catDesc>Hanover (NH)</catDesc>
+                    <category xml:id="tla2J4REMUR5RCITE6NMMK5AYY7BU">
+                      <catDesc>Dartmouth College Museum and Galleries</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaFNPZJVE6RJCLLCFBEUO2FDMOC4">
+                    <catDesc>Dayton (OH)</catDesc>
+                    <category xml:id="tlaIC6OSIFACJF4XHZAK5FFBTRVUY">
+                      <catDesc>Art Institute</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaITVBJFU6WJB6TG7CCG7OJPCMNQ">
+                    <catDesc>Clinton (NY)</catDesc>
+                    <category xml:id="tlaFGKY4YEYNRHWXK2473ER7BYZMY">
+                      <catDesc>Hamilton College</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaLIE7MSEDIVEF3NUDCU2DOAMP6M">
+                    <catDesc>Cincinnati (OH)</catDesc>
+                    <category xml:id="tlaZGELJ4TBLBBT5FEFBYD5CKQEEY">
+                      <catDesc>Cincinnati Art Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaMGSALFW2IJEWBE4TCNZN2IPMNY">
+                    <catDesc>East Lansing (MI)</catDesc>
+                    <category xml:id="tlaYC3OMJ5E7BEKLOKZHU47EUKBSA">
+                      <catDesc>Michigan State University, Kresge Art Center Gallery</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaO33RER7CZZCD7HCE622DHEBL34">
+                    <catDesc>Columbus (MS)</catDesc>
+                    <category xml:id="tlaKIYWK4SPJJEUZMKHS33T7RFQ7M">
+                      <catDesc>Gallery of Fine Arts</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaPABEOPBE2VEGDMSLIUO5XHAY6M">
+                    <catDesc>Denver (CO)</catDesc>
+                    <category xml:id="tlaMZBCGVPMNFDOPO54Q6WHOFYSWE">
+                      <catDesc>Denver Art Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaRJM2MARG7RCLRPTHNFGK5IO4MA">
+                    <catDesc>Jacksonville (FL)</catDesc>
+                    <category xml:id="tlaHZM3HDWIVFGCXCVTO44QVNNA44">
+                      <catDesc>Cummer Gallery of Art</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaSBCXF53GC5GL5FBBV4CNILGXLU">
+                    <catDesc>Grand Forks (ND)</catDesc>
+                    <category xml:id="tlaJA3WVVPSYVB2ZJISDF63EJAFQI">
+                      <catDesc>University Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaSLN3DCNJU5HJ5B6N5CND5VTJKE">
+                    <catDesc>Columbus (OH)</catDesc>
+                    <category xml:id="tlaIHGEKI6QKJDYBHTIKQPVPBTCVQ">
+                      <catDesc>Museum of the Ohio State Archaeological and Historical Society</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaSQQP77TCR5BYREPRCEBYGCYTVM">
+                    <catDesc>Durham (NC)</catDesc>
+                    <category xml:id="tla7RUXEZBMWRFZ5IEHRWTE52QWZU">
+                      <catDesc>Duke University</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaVS72EU4CQFEVRFM5UQD5XGKOUM">
+                    <catDesc>Cleveland (OH)</catDesc>
+                    <category xml:id="tlaEZENPHRF4FBDXNIZVNBYZSTTGU">
+                      <catDesc>Museum of the Western Reserve Historical Society</catDesc>
+                    </category>
+                    <category xml:id="tlaNE42GOEKQ5E37LMHTOGMNHP7HY">
+                      <catDesc>Museum of Art</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaWNGE524MQZFJJPBCKV36SGBFUY">
+                    <catDesc>Dallas (TX)</catDesc>
+                    <category xml:id="tlaH5GLN2ELFJASDJHHL2NTJVTJSA">
+                      <catDesc>Museum of Fine Arts</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaWYCDWDHVC5HCNNHF5XFZ3LON4E">
+                    <catDesc>Indianapolis (IN)</catDesc>
+                    <category xml:id="tlaF56RPIGMDJD27KDEDOXK2OFIQE">
+                      <catDesc>John Herron Art Institute</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaWYK46CYEBBGSLI2YNZKY47ULEE">
+                    <catDesc>Huntington (NY)</catDesc>
+                    <category xml:id="tlaBSFLQHVFDRFUJGZKQAOYIVKIPI">
+                      <catDesc>Heckscher Museum</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaYBAVLG657JCQVIH5Y6HUPEN6AU">
+                    <catDesc>Detroit (MI)</catDesc>
+                    <category xml:id="tlaDHTBI44MMZHEPMUU6HVCXNH2JQ">
+                      <catDesc>Institute of Arts</catDesc>
+                    </category>
+                    <category xml:id="tlaMTYJFNORFVDLJAQ4NV72TNLZR4">
+                      <catDesc>Clark Museum</catDesc>
+                    </category>
+                  </category>
+                </category>
+              </category>
+            </category>
+          </category>
+          <category xml:id="tla2WTMWILFXFCFHIIN6JATL47IG4">
+            <catDesc>23 = Akteur</catDesc>
+            <category xml:id="tlaGT4HRUBG55AE5IB7RM2ZMJOQ6M">
+              <catDesc>Privatmann</catDesc>
+            </category>
+            <category xml:id="tlaKHC5ZCKCHJDG7J3PGYCUHGLR5E">
+              <catDesc>König</catDesc>
+            </category>
+            <category xml:id="tlaVBXHCUXMVFA5VBBSUX53ZW6Y5U">
+              <catDesc>Gott</catDesc>
+            </category>
+          </category>
+          <category xml:id="tlaP33RJ7RXYRHW7FU4BA2BULCCCI">
+            <catDesc>21 = Objekttyp</catDesc>
+            <category xml:id="tlaB22H5ZYF6NBTJEEIIQ3DWYXXEI">
+              <catDesc>Überreste</catDesc>
+              <category xml:id="tlaPTD6RR5YEZFRNCSMZAKPUJTV4M">
+                <catDesc>Knochen</catDesc>
+              </category>
+              <category xml:id="tlaZJGHMMLU6JGC7BH4S545JYIGPI">
+                <catDesc>Mumie</catDesc>
+              </category>
+              <category xml:id="tlaZLB5GOHSGNGWZAP2RJ5EVQYUEI">
+                <catDesc>Muschel</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaKIVHUYHHIBDNJDYK4HEVFBS2EI">
+              <catDesc>unbekannt</catDesc>
+            </category>
+            <category xml:id="tlaLY2FDYZWRVGKHK4FYAL3EVZW6U">
+              <catDesc>Architektur</catDesc>
+              <category xml:id="tlaVDJICLKKQJCY5DEUPRRGVDT3JA">
+                <catDesc>Gebäude &amp; Konstruktionen</catDesc>
+                <category xml:id="tla2KUBMS2CEJEI7DTTKCIK4JWQ7A">
+                  <catDesc>Talbezirk</catDesc>
+                </category>
+                <category xml:id="tla3OMHAO4VSFFGPCJ3YCYVOAPY4I">
+                  <catDesc>Brücke</catDesc>
+                </category>
+                <category xml:id="tla6GCJHSUTOFHEDPYNYSB6ODCLSQ">
+                  <catDesc>Turm</catDesc>
+                </category>
+                <category xml:id="tla7WQOKULE5JFPPAZ4DPJJBDANX4">
+                  <catDesc>Wirtschaftsgebäde</catDesc>
+                  <category xml:id="tla2F76RMDCIFGM5FMZASB5WZLA3Y">
+                    <catDesc>Werkstatt</catDesc>
+                  </category>
+                  <category xml:id="tlaI5UCR2NQDBE6BHB6CSZQRBFSJE">
+                    <catDesc>Kornspeicher</catDesc>
+                  </category>
+                  <category xml:id="tlaIYQ7LVNJGBEU3HD5ZZXRGPVOU4">
+                    <catDesc>Tierzuchtgebäude</catDesc>
+                  </category>
+                  <category xml:id="tlaXHRNFM3DERDHZIEM262OEZA3GI">
+                    <catDesc>Schatzhaus</catDesc>
+                  </category>
+                  <category xml:id="tlaYKSSZQO7YREZTPNIVYNBQ4HA5M">
+                    <catDesc>Verwaltungsgebäude</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaG2IECCH4XFGNNMPYXHKEONAS54">
+                  <catDesc>Kloster</catDesc>
+                </category>
+                <category xml:id="tlaGMZLAOCDP5B7NOVKBD543U4K7I">
+                  <catDesc>Fortifikation</catDesc>
+                  <category xml:id="tla6R2QNT4FJJEIXKWYN2WWJKYXCU">
+                    <catDesc>Grenzmauer</catDesc>
+                  </category>
+                  <category xml:id="tlaY4NUGV7AQ5D33KJRRZ4BWJKEL4">
+                    <catDesc>Festung</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaHV3JFDDE4NDJ5HTBR7F2QWPHFE">
+                  <catDesc>Grab</catDesc>
+                  <category xml:id="tla3CR6KBQ3UBDZLFDWKNTT4R3ARY">
+                    <catDesc>Galleriegrab</catDesc>
+                  </category>
+                  <category xml:id="tla3IZSQL4XPVEJBIJWYMAWG3XS6M">
+                    <catDesc>Cachette</catDesc>
+                  </category>
+                  <category xml:id="tlaCCBP62XK5ZFTDNWQK5MORJ4HNQ">
+                    <catDesc>Kenotaph / Scheingrab</catDesc>
+                  </category>
+                  <category xml:id="tlaDME3FXTGUBB2BNWGFCOV55XSUA">
+                    <catDesc>Pyramidengrab</catDesc>
+                  </category>
+                  <category xml:id="tlaFEO6RBKYTBCYNHD4IWIVAZI7V4">
+                    <catDesc>Felsgrab</catDesc>
+                  </category>
+                  <category xml:id="tlaGENSOWZN5FEGBJJ4IDSRSXJWPA">
+                    <catDesc>Südgrab</catDesc>
+                  </category>
+                  <category xml:id="tlaOUWV7WEJZNEIXCNNRH4SVXDN5A">
+                    <catDesc>Mastabagrab</catDesc>
+                  </category>
+                  <category xml:id="tlaRSPTCY2K3REO7BLYIU2MQSZYGU">
+                    <catDesc>Schachtgrab</catDesc>
+                  </category>
+                  <category xml:id="tlaSAIVAGWRSVCXNDUJCCFWD7EH4Y">
+                    <catDesc>Grubengrab</catDesc>
+                  </category>
+                  <category xml:id="tlaSESOISO52FBE5ESNI2EHQZLQVM">
+                    <catDesc>Schiffsgrab</catDesc>
+                  </category>
+                  <category xml:id="tlaUPPKQEOZHNCUHJDABY5KXO3BJY">
+                    <catDesc>Tumulusgrab</catDesc>
+                  </category>
+                  <category xml:id="tlaVJWAWBRE6NFJXIAQ5XKXHA3XO4">
+                    <catDesc>Tempelgrab</catDesc>
+                  </category>
+                  <category xml:id="tlaYOWN36PA7VGW3BABXERPB2XXBQ">
+                    <catDesc>Hypogaeum</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaJLN43XXHXRDAZHUOYB3BM3WWF4">
+                  <catDesc>Straße / Weg</catDesc>
+                  <category xml:id="tlaC72T2BEZSBBVLEM65DJRKKCOFQ">
+                    <catDesc>Militärstraße</catDesc>
+                  </category>
+                  <category xml:id="tlaGHNMLDH6TBATJEEH35OXQUNUDI">
+                    <catDesc>Prozessionsstraße</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaKDCR3NQLWFEDNL5BZVX2QCDMKQ">
+                  <catDesc>Stadt</catDesc>
+                  <category xml:id="tla6CVIMG3OTZGFTDJD2AZIJMEVKU">
+                    <catDesc>Arbeiterstadt</catDesc>
+                  </category>
+                  <category xml:id="tlaWTY5GLZGMNDTTPIHXTYQJUVIJM">
+                    <catDesc>Pyramidenstadt</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaM6LHBERYQZBZVEGKKTLCZ7FMXY">
+                  <catDesc>Wasserbauwerk</catDesc>
+                  <category xml:id="tla4DD7XP7NQFD2NMWQ5K2TXXJT54">
+                    <catDesc>Heiliger See</catDesc>
+                  </category>
+                  <category xml:id="tlaM62477XJ5ZECDDDAAWKPUEPBJA">
+                    <catDesc>Kaitribüne / Schiffsanlage</catDesc>
+                  </category>
+                  <category xml:id="tlaS75RBGP6RBDYFOVLSAN4VGEKYY">
+                    <catDesc>Brunnen / Nilometer</catDesc>
+                  </category>
+                  <category xml:id="tlaU4W5YGKPI5FL5G57TJW2NTPAYI">
+                    <catDesc>Hafen</catDesc>
+                  </category>
+                  <category xml:id="tlaWW35L6N7H5GDZP4KLF3MK444RI">
+                    <catDesc>Kanal</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaPX3PGTPSQVAIHHSIUSSEYVBUEI">
+                  <catDesc>Kirche</catDesc>
+                </category>
+                <category xml:id="tlaRRMC7LFARVDDPCSQOK4ROBRPWU">
+                  <catDesc>Moschee</catDesc>
+                </category>
+                <category xml:id="tlaUAH3A6TU3FB6HF7NNFYRHXNNKU">
+                  <catDesc>Kapellen</catDesc>
+                  <category xml:id="tla2Y73DZC2P5CLZOJAJQKDSKL3YA">
+                    <catDesc>Kiosk</catDesc>
+                  </category>
+                  <category xml:id="tlaCMGTMCFON5CIRM5AVVGBBDCFAE">
+                    <catDesc>Dachkapelle</catDesc>
+                  </category>
+                  <category xml:id="tlaJOURNPAMUBEMNNXRI4AMNLCUF4">
+                    <catDesc>Ka-Haus</catDesc>
+                  </category>
+                  <category xml:id="tlaO7JMJQFTO5CRPM5QK3I4PEFLNM">
+                    <catDesc>Gedächtniskapelle</catDesc>
+                  </category>
+                  <category xml:id="tlaPQSWNT7SINDD5CLLWIBEJQZ7TI">
+                    <catDesc>Wabet</catDesc>
+                  </category>
+                  <category xml:id="tlaY3ICYUIXTFDGRHZAQ53Z65K24E">
+                    <catDesc>Barkenstationskapelle</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaURCTTU5GIZC2TJNA6YQJE4WIC4">
+                  <catDesc>Tempel</catDesc>
+                  <category xml:id="tlaA3CREZPMNNFKDPPNP6DPNPETKA">
+                    <catDesc>Taltempel</catDesc>
+                  </category>
+                  <category xml:id="tlaAQDS45BQ6BFRPCG7LQVKC54GJM">
+                    <catDesc>Meret-Heiligtum</catDesc>
+                  </category>
+                  <category xml:id="tlaC2FEUF7SXFGJ5F6CIDXBGCUWQU">
+                    <catDesc>Barkenstationstempel</catDesc>
+                  </category>
+                  <category xml:id="tlaIBXR5HJO55AJ3I2YIAOM7ATCII">
+                    <catDesc>Sonnenheiligtum</catDesc>
+                  </category>
+                  <category xml:id="tlaIMSQEDD4UBETXCTCQ3VGDST4AQ">
+                    <catDesc>Mammisi</catDesc>
+                  </category>
+                  <category xml:id="tlaKF3YBBDH2FDQ5LPMGIINDW6QDI">
+                    <catDesc>Pyramidentempel</catDesc>
+                  </category>
+                  <category xml:id="tlaMB2A2GCHTFC4VDDDMDBBNX3NIA">
+                    <catDesc>Höhlentempel / Speos</catDesc>
+                  </category>
+                  <category xml:id="tlaS2SMVDKDFBCSBPQ24Q67UNC45A">
+                    <catDesc>Gegentempel</catDesc>
+                  </category>
+                  <category xml:id="tlaUQFTBQLPUNFD7BYUJ3QBKKWYHY">
+                    <catDesc>Terrassentempel</catDesc>
+                  </category>
+                  <category xml:id="tlaZ6GZDXE5NRGTDE3IL5CKVU2Z3E">
+                    <catDesc>Totentempel</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaUUXHEUGSKFHOLKMRQQPCG3QHA4">
+                  <catDesc>Synagoge</catDesc>
+                </category>
+                <category xml:id="tlaXBLYB2AT4VHJDJRSOOGMAQVIME">
+                  <catDesc>Haus</catDesc>
+                  <category xml:id="tla6EMYESTXTVCVFCS25LO445AKSU">
+                    <catDesc>Wohnhaus</catDesc>
+                    <category xml:id="tlaB5N6INHOVVEGFP65LRQGWODH7Y">
+                      <catDesc>Turmhaus</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaXHSWXYHW2VGNPF5MI7RREKLG7I">
+                    <catDesc>Palast</catDesc>
+                  </category>
+                </category>
+              </category>
+            </category>
+            <category xml:id="tlaNWXI27WQTVAMLFBD5HNFNJLFPE">
+              <catDesc>Artefakt</catDesc>
+              <category xml:id="tla2JK45TRNWVF67CVWL76SID5S4Q">
+                <catDesc>Behälter</catDesc>
+                <category xml:id="tlaBZQQMFDB4VBZJH3R66Y3XK64XI">
+                  <catDesc>Gefäß</catDesc>
+                  <category xml:id="tlaDRWEIUJUCJFEPEMM4L64NP3MWY">
+                    <catDesc>Vorrats- &amp; Transportgefäße</catDesc>
+                    <category xml:id="tlaUYFSMRJKXZAKJPE6V7NT2TBZBU">
+                      <catDesc>Amphore</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaEWHGDMVTHNDRJJBWGDSCORNF6A">
+                    <catDesc>Becher</catDesc>
+                    <category xml:id="tlaBRTSNASDPRHBDBHUPUYK3VJXVM">
+                      <catDesc>Kelche</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaI6L3KNNYJFGSNIG2BPXEYEYYYY">
+                    <catDesc>Schalen &amp; Teller</catDesc>
+                    <category xml:id="tla2PT5JHAN55BEJCRTB6N772WNW4">
+                      <catDesc>Waagschale</catDesc>
+                    </category>
+                    <category xml:id="tlaFOAP5JBU2FFBJO4D7KPYB3JDYI">
+                      <catDesc>Waschschüssel</catDesc>
+                    </category>
+                    <category xml:id="tlaKVSEXZBTO5HVPEKALT6UEI2K2E">
+                      <catDesc>Schminkschale</catDesc>
+                    </category>
+                    <category xml:id="tlaXZVB3LYEEZA2FPPKXLHFMQ6DJY">
+                      <catDesc>Nun-Schale</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaSY2OHZ3XGRBN5BSKAWAGGRDNNY">
+                    <catDesc>Krüge &amp; Flaschen</catDesc>
+                    <category xml:id="tla2E5WMIXOWNEGXJJJAUS7P54K2A">
+                      <catDesc>Situla</catDesc>
+                    </category>
+                    <category xml:id="tla3PGC2ASLQJH6NDQ3XI5ETTYOPU">
+                      <catDesc>Kanopenkrug</catDesc>
+                    </category>
+                    <category xml:id="tla3TMXZJJSYJEXBIHU4OQG5UQOOA">
+                      <catDesc>Alabastron</catDesc>
+                    </category>
+                    <category xml:id="tla5YGOPAVCNFGTZDVTEUXIXQVIV4">
+                      <catDesc>Waschkrug</catDesc>
+                    </category>
+                    <category xml:id="tlaGC2DVFWJS5B5LKYQPJ4PKKMVJM">
+                      <catDesc>Neujahrsflasche</catDesc>
+                    </category>
+                    <category xml:id="tlaL7AX7OFTKZFS5NACFLZBPJPVNM">
+                      <catDesc>Uschebtikrug</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaTMZFASVFGND77AYDORYJI3QLDU">
+                    <catDesc>Tiegel</catDesc>
+                    <category xml:id="tlaFP35KSSZTFCFHKPHSE3CNZANWI">
+                      <catDesc>Schmelztiegel</catDesc>
+                    </category>
+                    <category xml:id="tlaSQV35W4MSNAG7DK37GHWV53MLI">
+                      <catDesc>Kosmetiktiegel</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tlaEOH26S2KCJC5JHPL35OJ42T5N4">
+                  <catDesc>Sarg</catDesc>
+                  <category xml:id="tlaCKI3UAVKUBAE5JBVC2KXXZSXKE">
+                    <catDesc>Kastensarg</catDesc>
+                  </category>
+                  <category xml:id="tlaJYMQTYYXXBAHXG5GPYB2J6LME4">
+                    <catDesc>anthropoider Sarg</catDesc>
+                  </category>
+                  <category xml:id="tlaQTUQJB6RVZHQ5N6F6WVRMECFDE">
+                    <catDesc>Tiersarg</catDesc>
+                  </category>
+                  <category xml:id="tlaXJ4WDB7EV5CI5LCWN245DTAPZI">
+                    <catDesc>Uschebtisarg</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaF7E3PVPVEBHPNMADEIYW5RORPA">
+                  <catDesc>Körbe</catDesc>
+                  <category xml:id="tlaVWB3DFC6IZBRXNMA73RZBYQVTQ">
+                    <catDesc>Lebensmittelkörbe</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaHVHBYDV7EBB2TIF5VPLWL6INRI">
+                  <catDesc>Osirisziegel</catDesc>
+                </category>
+                <category xml:id="tlaPAZQJR6JKZEQDDKX4SCYZSIJNM">
+                  <catDesc>Leichenumhüllung</catDesc>
+                  <category xml:id="tla2P2OU5FWNZBP3HF5A46NDRXJVA">
+                    <catDesc>Penishülle</catDesc>
+                  </category>
+                  <category xml:id="tlaFUN2YX6Z5VDUXIPIFCSW7LP7X4">
+                    <catDesc>Ganzkörperkartonage</catDesc>
+                  </category>
+                  <category xml:id="tlaGAWMAZS6HZCFDF5KBZBCSRPPKQ">
+                    <catDesc>Fußhülle</catDesc>
+                  </category>
+                  <category xml:id="tlaH3CBZIIOSREGJP5SH4JRMWHRRM">
+                    <catDesc>Mumienmaske / Maske</catDesc>
+                    <category xml:id="tla5O2UEYQXSVFM7GJ2Z42JFFLDNA">
+                      <catDesc>Gesichtsmaske</catDesc>
+                    </category>
+                    <category xml:id="tlaKUVXG4QQ65AQPKJO5HCKH6CTCU">
+                      <catDesc>Stülpmaske</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaL6MBS55VRVAQ5JB72DFUPGPLR4">
+                    <catDesc>Leichentuch</catDesc>
+                  </category>
+                  <category xml:id="tlaMP737HZGCZEGZORTCE7JR6EWNE">
+                    <catDesc>Fingerhülle</catDesc>
+                  </category>
+                  <category xml:id="tlaPN5YIWK5AVGUDPUIIUO32C7DCQ">
+                    <catDesc>Fellumhüllung</catDesc>
+                  </category>
+                  <category xml:id="tlaXSPKIMG62NBEDNZFAK6ONEGVV4">
+                    <catDesc>Mattenumhüllung</catDesc>
+                  </category>
+                  <category xml:id="tlaYBCRSZ3FBRG7HN6QI4LRPZ25CY">
+                    <catDesc>Mumienbindenumwicklung</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaRJQSBIRGHJD6HFCQS55BQ3CRHA">
+                  <catDesc>Kasten</catDesc>
+                  <category xml:id="tla3QUUX5LA2ZBDHE75NTXIOPASRA">
+                    <catDesc>Kanopenkasten</catDesc>
+                  </category>
+                  <category xml:id="tlaCNIJ3DT72BFBTKASKSBCB45OKY">
+                    <catDesc>Toilettenkästchen</catDesc>
+                  </category>
+                  <category xml:id="tlaKOMNR2MCIJBZBOYUUALVMV2RHE">
+                    <catDesc>Naos</catDesc>
+                  </category>
+                  <category xml:id="tlaPOLRZULC45B65ODEC7YFAIC6CI">
+                    <catDesc>Perückenbehälter</catDesc>
+                  </category>
+                  <category xml:id="tlaSIESSHVLFRCBJF5XWN64G3ZYHA">
+                    <catDesc>Kleidertruhe</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaT3EF3WQ7GNAF3FRHP6QDKZVU4Q">
+                  <catDesc>Gehäuse / Hülle</catDesc>
+                  <category xml:id="tlaA73ZD5A2MNCKXH353YNRO5U2WE">
+                    <catDesc>Lebensmittelgehäuse</catDesc>
+                  </category>
+                  <category xml:id="tlaDLJFK7AEBFEP7CWAQKNSRQWAL4">
+                    <catDesc>Köcher</catDesc>
+                  </category>
+                  <category xml:id="tlaFHSO6EJNAJH4ZD6P4UEXEXEQRI">
+                    <catDesc>Amuletthülse</catDesc>
+                  </category>
+                  <category xml:id="tlaISHSECSFWVBJ7GGWHJKU3NWFPE">
+                    <catDesc>Handwaagengehäuse</catDesc>
+                  </category>
+                  <category xml:id="tlaO6TMJXNM6ZF5BBD4P7OLZCOGMI">
+                    <catDesc>Schriftrollengehäuse</catDesc>
+                    <category xml:id="tla7ABBTB23CBDVZMTMNQXLURQ44Y">
+                      <catDesc>Ptah-Sokar-Osiris-Figur</catDesc>
+                    </category>
+                    <category xml:id="tlaGSCEQRGOKND2VMPLCM74QQBT4A">
+                      <catDesc>Papyrusschatulle</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaPR2MB7627RH7BGTIQ2EEFB6JYU">
+                    <catDesc>Musikinstrumentengehäuse</catDesc>
+                  </category>
+                  <category xml:id="tlaU4SRRI5FIJE5XAI6PVUBY2F3CA">
+                    <catDesc>Schreibbinsengehäuse</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaULZGCBDMGBHLJHINAPD5D77OLM">
+                  <catDesc>Sarkophag</catDesc>
+                  <category xml:id="tlaDANO34XQS5APLJKVBO75DNYRRA">
+                    <catDesc>rock-cut pit sarcophagus</catDesc>
+                  </category>
+                  <category xml:id="tlaJFOEHWNDQJAFVA2TMGURELNXVM">
+                    <catDesc>Uschebtisarkophag</catDesc>
+                  </category>
+                  <category xml:id="tlaSUJOPO4IA5GY3H7S5A5PPMEJ44">
+                    <catDesc>Kastensarkophag</catDesc>
+                  </category>
+                  <category xml:id="tlaZEXUVHMWU5GUNGG6FGOF3TXFVU">
+                    <catDesc>anthropoider Sarkophag</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaYZROY7L4KNGQNHDBNQKNLK3XWE">
+                  <catDesc>Kornosiris</catDesc>
+                </category>
+              </category>
+              <category xml:id="tla46EEHPJHQJFQ7ICDCBFA4WNR7Q">
+                <catDesc>Skulptur</catDesc>
+                <category xml:id="tla6ZDTVZOWOFD3RAKWUZTPZZRFNY">
+                  <catDesc>Statue / Figur</catDesc>
+                  <category xml:id="tlaJOPRB4FLUVEO3LBMALUJKOZMXU">
+                    <catDesc>Dienerfigur</catDesc>
+                  </category>
+                  <category xml:id="tlaTEIKTAAVEFBNTLQFZ2OPWWRH5I">
+                    <catDesc>Ächtungsfigur</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tla64Y2SM2JZ5AIPMQGOLBC36323Q">
+                <catDesc>Schriftmedien</catDesc>
+                <category xml:id="tla5QIW3ZRHQFGINHBP4GI2GI4LFA">
+                  <catDesc>Schriftrolle</catDesc>
+                </category>
+                <category xml:id="tla5Z4BBZUQ3JBTVEJSKXNCA7LKUQ">
+                  <catDesc>Schreibtafel</catDesc>
+                </category>
+                <category xml:id="tlaEP7XNRXU4ZAU7BKOHF5H2PYC34">
+                  <catDesc>Stele</catDesc>
+                  <category xml:id="tla2QJQDZOOOBARDOTA6BLKAT5EPE">
+                    <catDesc>Slab stela</catDesc>
+                  </category>
+                  <category xml:id="tla7OQNLVAE2FB5HIHUYLRMMIWJYU">
+                    <catDesc>Stele mit Scheintürfassung</catDesc>
+                  </category>
+                  <category xml:id="tlaCUNICVTWNNF6VN2RUTXZNNN444">
+                    <catDesc>rechteckige Stele</catDesc>
+                  </category>
+                  <category xml:id="tlaG3RHFFZZ5VGMXPLIK23T5VPX2E">
+                    <catDesc>Grenzstele</catDesc>
+                    <category xml:id="tlaNCFHNFDVFRBTXEABFZKKEJON7I">
+                      <catDesc>Schenkungsstele</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaJ7IA6TR4HFDZVFJLMQ4ZKOXUMY">
+                    <catDesc>Altarstele (Amarna)</catDesc>
+                  </category>
+                  <category xml:id="tlaLCPWQCZ2HVFBVFJHVYSQ2UJHIY">
+                    <catDesc>rundbogige Stele</catDesc>
+                  </category>
+                  <category xml:id="tlaNLZJDZX7VVCCPHEYK5NKR75654">
+                    <catDesc>Horusstele / Horuscippus</catDesc>
+                  </category>
+                  <category xml:id="tlaNYY3IYP3XZDOBFNZUGI7RV52IY">
+                    <catDesc>Wandstele</catDesc>
+                  </category>
+                  <category xml:id="tlaXKMFQ6O4IVAQVEVHNLR3TMS6QA">
+                    <catDesc>Felsstele</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaLKQP7D6XGBGV5K52MIEFX2NWNI">
+                  <catDesc>Ostrakon</catDesc>
+                </category>
+                <category xml:id="tlaM2UOQEMSJRD3JEZW5ZJSY7P3TI">
+                  <catDesc>Schreibblatt</catDesc>
+                </category>
+                <category xml:id="tlaOPJINUAIVNEFLJTHV5WTMHHHII">
+                  <catDesc>Etikett</catDesc>
+                  <category xml:id="tlaALBHSJGZ5JA6VMMRPTA6KVMUDI">
+                    <catDesc>Mumienetikett</catDesc>
+                  </category>
+                  <category xml:id="tlaDQBSH25355EPTNBFSHUAOPFJDQ">
+                    <catDesc>Gefäßetikett</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaTR7VBJP3LBFKXHCPVKPX6G7QFE">
+                  <catDesc>Codex / Buch</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaB33RP4MSDZBQFDKY4EIN66J644">
+                <catDesc>Mobiliar</catDesc>
+                <category xml:id="tla4OUGU4JB5ZCFVNJZNXW66GTGTE">
+                  <catDesc>Kopfstütze</catDesc>
+                </category>
+                <category xml:id="tla4TZC3EJ6YNB67B3QLA7RRFKBFU">
+                  <catDesc>Sitzmöbel</catDesc>
+                  <category xml:id="tla6QNNOQJL5JBQNGFSVL5XQ7Q54E">
+                    <catDesc>Hocker</catDesc>
+                    <category xml:id="tlaEW5K62T3IZAFFNL7RUAL5BW2DM">
+                      <catDesc>Klapphocker</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tla7VPYHV5J3RADZPYZK7IT7MAUGY">
+                    <catDesc>Schemel</catDesc>
+                    <category xml:id="tlaXQIRGGIEQ5E2PFCOE5LFTYGXBE">
+                      <catDesc>Fußschemel</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaDLRVSAQHNJEENHRAUZ4DTTZ7HM">
+                    <catDesc>Stuhl</catDesc>
+                    <category xml:id="tlaA7RSUKHALJHBNBR2PMQTJL52F4">
+                      <catDesc>Stuhl mit Armlehne</catDesc>
+                    </category>
+                    <category xml:id="tlaJMPPH73FLFANPDXX7NOSO22NFA">
+                      <catDesc>Tragestuhl</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tlaIREAP7P2WZERBP7HKUC3YG53SU">
+                  <catDesc>Liegemöbel</catDesc>
+                  <category xml:id="tlaH2O5SPNJOJGGNIWHRFPJF4TRKI">
+                    <catDesc>Bett</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaRQIXQ4ON2NDETGLHUL7OX2HAFE">
+                  <catDesc>Geburtsziegel</catDesc>
+                </category>
+                <category xml:id="tlaVIPFZSQ4DBBWPOBZXODCMHLEWI">
+                  <catDesc>Baldachin</catDesc>
+                </category>
+                <category xml:id="tlaWDFPDGEHKFCBRA7MRLLCL3EDM4">
+                  <catDesc>Tischmöbel</catDesc>
+                  <category xml:id="tlaLNLWNNXOLBGO7PPALV6WU647II">
+                    <catDesc>Opfertafel</catDesc>
+                  </category>
+                  <category xml:id="tlaNQ2GHQK3OJCNRPIPKLK5M4R5OE">
+                    <catDesc>Opferplatte / Seelenhaus</catDesc>
+                  </category>
+                  <category xml:id="tlaRMZLPW7BXVETFD2DTU36FJCYFI">
+                    <catDesc>Opfertisch</catDesc>
+                  </category>
+                  <category xml:id="tlaYDHSECVKFVG3BHUXVG4EJEG4G4">
+                    <catDesc>Opferbecken</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaWS2SDAG4N5CDRNCBYS3CBU62II">
+                <catDesc>Geräte &amp; Instrumente</catDesc>
+                <category xml:id="tla4PYCPK4LNZHM3OGXSPPF6DFDOU">
+                  <catDesc>Spinnerei- &amp; Webereiutensilien</catDesc>
+                  <category xml:id="tlaBOOFV6D25JH3VERSDKGRQE3UZQ">
+                    <catDesc>Webstuhlgewicht</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla7TW6KQ5AFNCHHMFLNSC37ZDAZQ">
+                  <catDesc>Textilverarbeitungsutensilien</catDesc>
+                  <category xml:id="tla5U7ADNHPFJE6XEFMRSY4WQFMUI">
+                    <catDesc>Plissierholz</catDesc>
+                  </category>
+                  <category xml:id="tlaQ7CO6QJRLRCENH2KCRQ5YMEIUM">
+                    <catDesc>Nadel</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaFYFPWGV4BVHYLBDYPTVLIYHT64">
+                  <catDesc>Transportgeräte</catDesc>
+                  <category xml:id="tla2C6KX2JLTJHUVP4EU4WQVTB7UY">
+                    <catDesc>Schlitten</catDesc>
+                  </category>
+                  <category xml:id="tlaIHYRCL3YY5DQXB6V677QJL3TZY">
+                    <catDesc>Wagen</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaGOAIUPI6JNCCDCAVVM6C4HFBFE">
+                  <catDesc>Wagen- &amp; Jagdutensilien</catDesc>
+                  <category xml:id="tla33B3CQSP4ZGWNDQ65FZABY5EL4">
+                    <catDesc>Köcher</catDesc>
+                  </category>
+                  <category xml:id="tlaLUAZAW6FWFEANCHIHSPQXY25PE">
+                    <catDesc>Keule</catDesc>
+                  </category>
+                  <category xml:id="tlaSY3YLRSYOBGKBLN7XSBN4KJ2NE">
+                    <catDesc>Messer</catDesc>
+                    <category xml:id="tla6CVCFM2J2NDEFHQA6K4D45DAB4">
+                      <catDesc>Pescheskaf-Messer</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tlaKPHDZQ5JNJBG5ECJ7FSWHVKIRY">
+                  <catDesc>Musikinstrumente</catDesc>
+                  <category xml:id="tlaL6JZNJ5B4BCHRGGYJEJQPSOR5E">
+                    <catDesc>Menit</catDesc>
+                  </category>
+                  <category xml:id="tlaOFSBV6J67ZCP7DPIGZEX6CJKFI">
+                    <catDesc>Sistrum</catDesc>
+                  </category>
+                  <category xml:id="tlaR6XGJOAXWVD2VAWIS355I4ZX2A">
+                    <catDesc>Harfe</catDesc>
+                  </category>
+                  <category xml:id="tlaWRP7D2OX5ZHANFAZKBCFHRLCR4">
+                    <catDesc>Flöte</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaNPYF7NIJNFALPOP76NXZ7F22XE">
+                  <catDesc>Messgeräte</catDesc>
+                  <category xml:id="tlaK2DCOCYK2VBWHCDD7TAX5Y6E64">
+                    <catDesc>Ellenmaßstab</catDesc>
+                  </category>
+                  <category xml:id="tlaLISJ6Z4ODBFRNA74Z7SRYZQBCU">
+                    <catDesc>Gewichte</catDesc>
+                  </category>
+                  <category xml:id="tlaRFTKXT4X3RBL3K6ANRNUR2JBCI">
+                    <catDesc>Waage</catDesc>
+                  </category>
+                  <category xml:id="tlaZI3KYIWKYFHPLEIORHVYZPBXDQ">
+                    <catDesc>Wasseruhr</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaQ2LHAISZD5HELOC4QFRG4WDAHI">
+                  <catDesc>Toilettenutensilien</catDesc>
+                  <category xml:id="tlaCWU7KTQMI5B47PUTCUTE3HGUIA">
+                    <catDesc>Rasiermesser</catDesc>
+                  </category>
+                  <category xml:id="tlaDFVKM5QT5VEALMI3FULA5G4EEA">
+                    <catDesc>Schminkgefäß</catDesc>
+                  </category>
+                  <category xml:id="tlaFCCC2DIQCNHWJGCZAKR2JCKWUY">
+                    <catDesc>Schminkstäbchen</catDesc>
+                  </category>
+                  <category xml:id="tlaMU3ICRHCBRE2ZAJDJI3D4Z2DGA">
+                    <catDesc>Schminkpalette</catDesc>
+                  </category>
+                  <category xml:id="tlaTIYZLILISVB6BKPDHUTV56ZVAE">
+                    <catDesc>Spiegel</catDesc>
+                  </category>
+                  <category xml:id="tlaYQVBNGAHLZHLTDJXTTUPW2BK5U">
+                    <catDesc>Salbölpalette</catDesc>
+                  </category>
+                  <category xml:id="tlaZ7RJ364DONCWPNSGAGWNGBXBME">
+                    <catDesc>Salblöffel</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaSSJTUKEWTJCRHN5LWLMGB4OIVQ">
+                  <catDesc>Schreib- &amp; Malutensilien</catDesc>
+                  <category xml:id="tla32XNHAGVG5FN5JOAG6OLE5ZL2I">
+                    <catDesc>Schreibrohr</catDesc>
+                  </category>
+                  <category xml:id="tla7752ML47CZG6RM3K2VDGRC3OPY">
+                    <catDesc>Malerpalette</catDesc>
+                  </category>
+                  <category xml:id="tlaD6U4R3NIKFEXXKVUSK73F6PYGQ">
+                    <catDesc>Schreibbinse</catDesc>
+                  </category>
+                  <category xml:id="tlaHEIHGH5M4RBNDBKHO6IHXY4CFU">
+                    <catDesc>Papyrusglätter</catDesc>
+                  </category>
+                  <category xml:id="tlaLDUJHIGOAZGTBJVGQC6G7NECCI">
+                    <catDesc>Schreiberpalette</catDesc>
+                  </category>
+                  <category xml:id="tlaXP7ENURRIJCHVOQFE2JYHV7UEY">
+                    <catDesc>Schreibgriffel</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaUDJEAH7X6JAB7FLD7LOHSSDOUU">
+                  <catDesc>Siegelutensilien</catDesc>
+                  <category xml:id="tla2SFVG2GHTFEZZOEVM7BY5EUXUU">
+                    <catDesc>Siegelplatte</catDesc>
+                  </category>
+                  <category xml:id="tlaH3464MKLERBS5PJ4ZG4CQKWYOU">
+                    <catDesc>Plombierung</catDesc>
+                  </category>
+                  <category xml:id="tlaMKCB4MOILVFYNBS6PUGQ2KH5DU">
+                    <catDesc>Rollsiegel</catDesc>
+                  </category>
+                  <category xml:id="tlaNE4K5UKL5NG6LBSWQXNZ2RQZBM">
+                    <catDesc>Brenneisen</catDesc>
+                  </category>
+                  <category xml:id="tlaXJEW2NYCENB3JE57KU4O6ZNBTI">
+                    <catDesc>Siegelring</catDesc>
+                  </category>
+                  <category xml:id="tlaZSLLLBVUOVHR5HY27NPC4OY4RI">
+                    <catDesc>Stempelsiegel</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaVGWAPYSDOBAAROLY4VOHCU4H34">
+                  <catDesc>Räucherutensilien</catDesc>
+                  <category xml:id="tlaTZITRCBJ6FCAJKS5Y7A4PY3MWA">
+                    <catDesc>Räucherarm</catDesc>
+                  </category>
+                  <category xml:id="tlaYBZE7FEAERDSFDVXQCCQXR6NSA">
+                    <catDesc>Räuchergefäß / -pfanne</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaWVAHYFV24FCR3PZAIGIAM53PM4">
+                  <catDesc>Reibstein</catDesc>
+                </category>
+                <category xml:id="tlaXHO2MYFDFVFXFBTRYRGMTOLDRI">
+                  <catDesc>Spiel- &amp; Sportutensilien</catDesc>
+                  <category xml:id="tlaOZPXFN4JXNGEDHFRV4PMGNO4PY">
+                    <catDesc>Puppe</catDesc>
+                  </category>
+                  <category xml:id="tlaSTUIM6YKN5EVHM4IUIDQN56NAM">
+                    <catDesc>Brettspiel</catDesc>
+                  </category>
+                  <category xml:id="tlaZIPZMV2NFJHP5HB6F7XA5TDDAU">
+                    <catDesc>Ball</catDesc>
+                  </category>
+                  <category xml:id="tlaZV2B22FBCFHIFLBFYQRUBRD7PM">
+                    <catDesc>Brettspielfigur</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaXUOU3463ENG5HJEDXR74C5GSIQ">
+                  <catDesc>Model / Matrize</catDesc>
+                  <category xml:id="tlaBBZHVAX2MVAEVBEXSIMTEW3V3A">
+                    <catDesc>Guß- &amp; Pressform</catDesc>
+                    <category xml:id="tlaUFLXRM5GHBBSHLVIMXS7FCC45I">
+                      <catDesc>Ziegelstreichform</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tlaZ6BJ3YQXRBAEVPN5EYSZS6NSRM">
+                  <catDesc>Töpferutensilien</catDesc>
+                  <category xml:id="tlaVFG5HZJCCZBFVEYOKCUXDLXINY">
+                    <catDesc>Töpferscheibe</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaZMDKUD6ZNBFSBMHYESKFI3A7ZI">
+                <catDesc>Tracht</catDesc>
+                <category xml:id="tla3MSDW5IAFZCI3FT4R4GHAHOFRQ">
+                  <catDesc>Textilien</catDesc>
+                  <category xml:id="tla2XDOY5TPI5BXPOV25RZK57MUMM">
+                    <catDesc>Mumienriemen</catDesc>
+                  </category>
+                  <category xml:id="tlaFZKGHRO4GBDA3EUTOYEVG525GI">
+                    <catDesc>Laken</catDesc>
+                  </category>
+                  <category xml:id="tlaS63JJ4SLKRHWRANIQ4ORQK64TI">
+                    <catDesc>Mumienbinde</catDesc>
+                  </category>
+                  <category xml:id="tlaVQEDP5UFPVDYVJPON3YNYRHVYI">
+                    <catDesc>Taue</catDesc>
+                  </category>
+                  <category xml:id="tlaWJZO2KQXUNE6VNIN2QLO35DOHE">
+                    <catDesc>Hypocephalus</catDesc>
+                  </category>
+                  <category xml:id="tlaXL2YAN6JPZDWTHOV2OMJMASBTU">
+                    <catDesc>Stoff</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaHMDNBBVDMJG3RCNJ4ASN5XVDDI">
+                  <catDesc>Bekleidung</catDesc>
+                  <category xml:id="tla3FVH47ECNVB5RAFMRAS3JE4DFI">
+                    <catDesc>Kopfbekleidung</catDesc>
+                    <category xml:id="tlaQXQ5AKHAFRAFLH77GAAB6AWMCI">
+                      <catDesc>Perücke</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaA7PAFCMJ75A35GSI5UUG6PN6NQ">
+                    <catDesc>Fußbekleidung</catDesc>
+                    <category xml:id="tlaJG6AIA7FNVGFZDZJYORXDWSOWI">
+                      <catDesc>Sandale</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaVQ4RETLHJRGIBPMWKSNSBWIRCE">
+                    <catDesc>Lendentuch</catDesc>
+                  </category>
+                  <category xml:id="tlaZ3D5DJRL75FGPFIMYUDC5ZPTSQ">
+                    <catDesc>Tunika</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaQ3UY3JANGZD6NN2VSUXKC47CYI">
+                  <catDesc>Trachtassessoirs</catDesc>
+                  <category xml:id="tlaLQKHCWDTSVC4NBXFVCAML2EQBU">
+                    <catDesc>Perlennetz</catDesc>
+                  </category>
+                  <category xml:id="tlaSA2MB42LX5EFHFDDTH6DDOXZEQ">
+                    <catDesc>Schmuck</catDesc>
+                    <category xml:id="tla3MMFFLHZI5F4DHBJTX2Q7PI3JA">
+                      <catDesc>Haarkranz</catDesc>
+                    </category>
+                    <category xml:id="tla5YMCM3AQXZHTZC7QLGRI7FC7SM">
+                      <catDesc>Menit-Kette</catDesc>
+                    </category>
+                    <category xml:id="tlaEPUEHMPEENHALE77SHS4SPPNSI">
+                      <catDesc>Ohrschmuck</catDesc>
+                    </category>
+                    <category xml:id="tlaIFYMOSU3BND2ZHIRFDOHHVTYGE">
+                      <catDesc>Leichenband</catDesc>
+                    </category>
+                    <category xml:id="tlaQNM26WD2VJFNJIEQD65MPK66KM">
+                      <catDesc>Perle</catDesc>
+                    </category>
+                    <category xml:id="tlaZW5XPFGVJBGIVEERAKDE3F2HSA">
+                      <catDesc>Anhänger</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaUHWKE6FXGZF5NL2GH52ALWAQEA">
+                    <catDesc>Stöcke &amp; Stäbe</catDesc>
+                  </category>
+                  <category xml:id="tlaVLSX3M2HGJCH7NSEWS4BIGL2PY">
+                    <catDesc>Kronen &amp; Hüte</catDesc>
+                  </category>
+                </category>
+              </category>
+            </category>
+            <category xml:id="tlaO77RFF6A5BDNZALFYDSOSEMPH4">
+              <catDesc>Realia / Naturformen</catDesc>
+              <category xml:id="tlaEQZEGXGFTNHLLIGILFKVE2IXXA">
+                <catDesc>Fels</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaPN7PZTXCIFEZJOIEDWA7WW65EM">
+              <catDesc>unbestimmt</catDesc>
+            </category>
+          </category>
+          <category xml:id="tla7LANG42J4FH5XOJL7VIHZKH5FA">
+            <catDesc>24 = Material</catDesc>
+            <category xml:id="tla3NHNBPVU3VF2RERSPPZ46ELQHE">
+              <catDesc>Holz</catDesc>
+            </category>
+            <category xml:id="tla6HRN4262MRB7ZJCTZKSQ33LLE4">
+              <catDesc>Papyrus</catDesc>
+            </category>
+            <category xml:id="tla6SMVRSODQ5BXVIABWOLOT2GBB4">
+              <catDesc>Ton</catDesc>
+            </category>
+            <category xml:id="tlaH7S5EKRWZ5EVBI35BBLML3MRL4">
+              <catDesc>Kalkstein</catDesc>
+            </category>
+            <category xml:id="tlaPC6MNZWZLVC7REJRXEKIN7UMQM">
+              <catDesc>Fayence</catDesc>
+            </category>
+            <category xml:id="tlaRA4YWGA3EFBQNLB5JORH4HJLNM">
+              <catDesc>Leder</catDesc>
+            </category>
+            <category xml:id="tlaTCNODPO4NFBSRI7WQYIR23ALJI">
+              <catDesc>Stein</catDesc>
+            </category>
+            <category xml:id="tlaUOGHTTMOBFAL3JU5ZH62ICOCMA">
+              <catDesc>Keramik</catDesc>
+            </category>
+            <category xml:id="tlaY5Z4OMEPCVHCXNRDGD7MTL5H24">
+              <catDesc>Elfenbein</catDesc>
+            </category>
+          </category>
+          <category xml:id="tla2KR2OCPWNJHKRG3V5XS2C2O7UE">
+            <catDesc>33 = Gruppierung</catDesc>
+            <category xml:id="tlaUIOCASM5IBAV3IRO6UPRQSGNEE">
+              <catDesc>unbestimmt</catDesc>
+            </category>
+            <category xml:id="tlaXS262SLB2FDP7CBCEZNWNE7KMQ">
+              <catDesc>Archiv</catDesc>
+            </category>
+          </category>
+          <category xml:id="tlaNUR4SFIADFGU3BTNL2G7VT67VQ">
+            <catDesc>29 = Skeuomorph</catDesc>
+            <category xml:id="tlaKONZHVUFIZCANIKXE654IAXFXI">
+              <catDesc>Skeuomorph</catDesc>
+            </category>
+          </category>
+          <category xml:id="tla77YNOMBDLZAMDB7JQULDBCTEVM">
+            <catDesc>30 = Abschrift</catDesc>
+            <category xml:id="tla6QBFHMPUNVHNFECABLQYCU5NO4">
+              <catDesc>sekundäre Aufschrift</catDesc>
+            </category>
+          </category>
+          <category xml:id="tlaJZMJSNJQ35F4BO65Q5OVGJIJVY">
+            <catDesc>27 = Imitation</catDesc>
+            <category xml:id="tlaSSJSULI7RFGDRNWABAGGBBVC2Q">
+              <catDesc>Imitation</catDesc>
+            </category>
+          </category>
+          <category xml:id="tla2FCXD44JGZGYXNI4LAFEKOGDPM">
+            <catDesc>25 = Kontext</catDesc>
+            <category xml:id="tla5YYX5M3ZMNG5TN4FH4CXIJV42U">
+              <catDesc>Zauber</catDesc>
+            </category>
+            <category xml:id="tlaJTPKDP7HTRGIBKN34QHASPR4LE">
+              <catDesc>Grabausstattung</catDesc>
+            </category>
+            <category xml:id="tlaRRQV23QVBRFHVGR3CUSJTMAD4E">
+              <catDesc>Ritual</catDesc>
+            </category>
+            <category xml:id="tlaRWZ6E5P2ZJBEFPZMJTXLNGGB6Q">
+              <catDesc>Kult</catDesc>
+            </category>
+            <category xml:id="tlaZF4KPLYHPZCVBNS4BBE2DN333E">
+              <catDesc>Gebrauchsgegenstand</catDesc>
+            </category>
+          </category>
+          <category xml:id="tla3EPPDTJ5FVCA7LO6GBN25EGXBM">
+            <catDesc>28 = Miniatur</catDesc>
+            <category xml:id="tlaIREQIEIXKJEL3DOBWTJA4XFUSE">
+              <catDesc>Miniatur</catDesc>
+            </category>
+          </category>
+          <category xml:id="tlaIOOFFM7DCJGJFIP5MPUNO55RVE">
+            <catDesc>5 = Schriftformen</catDesc>
+            <category xml:id="tla7SDIQ6CH55FODFOUJ3NVYEZOYY">
+              <catDesc>Aramäisch</catDesc>
+            </category>
+            <category xml:id="tlaAX44V2CHHJEQ7I4UHZ2XB3WYMU">
+              <catDesc>Schriften moderner Schriftsprachen</catDesc>
+            </category>
+            <category xml:id="tlaJ5E7HWT7JZB2FMVPVI77H7VB3A">
+              <catDesc>Hieroglyphen</catDesc>
+              <category xml:id="tlaEZXNXXZNJRHZFIZEQDGAHVVH5U">
+                <catDesc>Kursivhieroglyphisch</catDesc>
+              </category>
+              <category xml:id="tlaLF5ZEAG65JG6BFTD3HTDQZPXIM">
+                <catDesc>Ptol.-röm. Schriftsystem</catDesc>
+              </category>
+              <category xml:id="tlaRH2J5C23AVEWTIXGCUVLGCC7TY">
+                <catDesc>Kryptographisch</catDesc>
+              </category>
+              <category xml:id="tlaTYXKD55ZDRB5NAWUTC7YWWJQRQ">
+                <catDesc>reguläre Hieroglyphenschrift</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaMRV4NILEZNFS7O5LIZAMJZKPLE">
+              <catDesc>Hieratisch</catDesc>
+              <category xml:id="tlaDS372PTLDNA6ZADSSC6LBEJD7M">
+                <catDesc>Archaisches Hieratisch</catDesc>
+              </category>
+              <category xml:id="tlaFFA2PGLQSNHMJFJP2RKAOMK43E">
+                <catDesc>Mittelhieratisch</catDesc>
+                <category xml:id="tlaE6EFYLK5PRF6VDRCSQ3NJB526M">
+                  <catDesc>Mittelhieratische Kanzleischrift</catDesc>
+                </category>
+                <category xml:id="tlaN2T36QN2JRDVHGNTDG6ZR3FF6Q">
+                  <catDesc>Mittelhieratische Buchschrift</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaLKARVWCGJFB5DL4L7OLRU66NJY">
+                <catDesc>Neuhieratisch</catDesc>
+                <category xml:id="tla2A65KN6SDNG5LDBR3BSWA6JSEM">
+                  <catDesc>Neuhieratische Kanzleischrift</catDesc>
+                </category>
+                <category xml:id="tlaABR7EWEFGBCJBOKIGKKDVUJS3Q">
+                  <catDesc>Neuhieratische Buchschrift</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaMGESF7LTKZCDTID4ECIMFU67UY">
+                <catDesc>Abnormhieratisch</catDesc>
+              </category>
+              <category xml:id="tlaSRFM7BGQJBFRJL5GJ2P7WGZWBA">
+                <catDesc>Althieratisch</catDesc>
+              </category>
+              <category xml:id="tlaXPUJ7HQYQBGMTHWPGBWUCR26LQ">
+                <catDesc>Späthieratisch</catDesc>
+                <category xml:id="tlaZ35DNIOFZ5G3VJN6XHP2CTCUBQ">
+                  <catDesc>Späthieratische Buchschrift</catDesc>
+                </category>
+              </category>
+            </category>
+            <category xml:id="tlaMWT355LFDNE3HCEWGJVKCA2ERE">
+              <catDesc>Meroitisch</catDesc>
+            </category>
+            <category xml:id="tlaOT3TJKRQMRHE3ERU34VMN4DF4U">
+              <catDesc>Koptisch</catDesc>
+              <category xml:id="tlaBCLYT4Q5YFASJMCYQJUQJRZ7AM">
+                <catDesc>Koptische Kursive</catDesc>
+              </category>
+              <category xml:id="tlaS3DGZAE2PZD73EGLXBIDWJSLHE">
+                <catDesc>Koptische Halbunziale</catDesc>
+              </category>
+              <category xml:id="tlaZ6Y3QAKWPNAFZEFASSITKKTYTY">
+                <catDesc>Koptische Unziale</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaUHT63RLVTNFE3BC4EM7H6L6RJY">
+              <catDesc>Demotisch</catDesc>
+              <category xml:id="tlaGDR4SNZFHJFFNDCHQKX7QZYPAY">
+                <catDesc>Spätdemotisch</catDesc>
+              </category>
+              <category xml:id="tlaKLYSEDKWFBEYPBSWTNU7AM36GU">
+                <catDesc>Mitteldemotisch</catDesc>
+              </category>
+              <category xml:id="tlaQDTWEYB6KRGZTDLEPLFFJXN7G4">
+                <catDesc>Frühdemotisch</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaYAF2UU4R25FIROCOE72WV3YVMI">
+              <catDesc>Lateinisch</catDesc>
+            </category>
+            <category xml:id="tlaYXPU67OHQVBHVJLP7YLICWKTYA">
+              <catDesc>Griechisch</catDesc>
+            </category>
+          </category>
+          <category xml:id="tlaGDFTM4DNPRFT7ARXZSSHZ7VZJI">
+            <catDesc>32 = Technik</catDesc>
+            <category xml:id="tlaTPJ2XG5NGZFIJGXAPYH7IGUFUM">
+              <catDesc>unbestimmt</catDesc>
+            </category>
+            <category xml:id="tlaXBDPINNBLZBQZDLDKZKKKAINBE">
+              <catDesc>geschnitzt</catDesc>
+            </category>
+          </category>
+          <category xml:id="tlaEM7EXOH7ONGGFBP3SB3YHS426M">
+            <catDesc>3 = Fundstellen</catDesc>
+            <category xml:id="tla3PEYR6TNZRCYBEGAYXCNBLUEBQ">
+              <catDesc>Niltal südlich des 3. Katarats bis zum 4. Katarakt</catDesc>
+              <category xml:id="tla4K63P4AVMBGGRNBYDUPI4EGBUI">
+                <catDesc>Pnubs</catDesc>
+              </category>
+              <category xml:id="tla5XKJZBNHQ5DH3OG6DT73N2X7N4">
+                <catDesc>Gebel Barkal</catDesc>
+              </category>
+              <category xml:id="tla5XWLGMNL4FDAPN24SBNQVGZOXY">
+                <catDesc>Kawa</catDesc>
+              </category>
+              <category xml:id="tlaHG4QZPHNWNE2XAG3IQQZFSOZZE">
+                <catDesc>Sanam Abu Dom</catDesc>
+              </category>
+              <category xml:id="tlaKBD54W3APBFZHAX4BQ3PFFANJM">
+                <catDesc>Napata</catDesc>
+              </category>
+              <category xml:id="tlaPIDYXAAJ45FCPATGJWHYZAS5PM">
+                <catDesc>Argo</catDesc>
+              </category>
+              <category xml:id="tlaPJYTUZYRY5CV7OPWID3W5LGL4Q">
+                <catDesc>Kerma</catDesc>
+              </category>
+              <category xml:id="tlaQRX5PIJT4ZCABLC6GTM3A66QCE">
+                <catDesc>Nuri</catDesc>
+              </category>
+              <category xml:id="tlaTQVHERHS5BFGLHSPNQGQJNXKPI">
+                <catDesc>Dongola</catDesc>
+              </category>
+              <category xml:id="tlaUCVOSZ2YUZFLLCOXEH5IQW24T4">
+                <catDesc>el-Kurru</catDesc>
+              </category>
+            </category>
+            <category xml:id="tla6NJP62ZOOVGENAF3BKE3OR7CG4">
+              <catDesc>(unbestimmt)</catDesc>
+            </category>
+            <category xml:id="tlaBALRMKSX4RCFJBB24NEIG4MIAE">
+              <catDesc>Nildelta</catDesc>
+              <category xml:id="tla22BFCHYQGFC7FHBU7DQYAUVDEI">
+                <catDesc>südliches Delta</catDesc>
+                <category xml:id="tlaBHD3CGTJGFBFHAB45BMC3YHHRQ">
+                  <catDesc>westlicher Teil</catDesc>
+                  <category xml:id="tlaCQEXXNY7UFFHDEWWAEM6MYJY4A">
+                    <catDesc>Letopolis</catDesc>
+                  </category>
+                  <category xml:id="tlaGNCHIULZSVB2XGP3WOJ6VBESK4">
+                    <catDesc>Merimde-Beni-Salame</catDesc>
+                  </category>
+                  <category xml:id="tlaL74GTSQTZNDOBHU7BUXKV5IOTQ">
+                    <catDesc>Terenuthis</catDesc>
+                  </category>
+                  <category xml:id="tlaRLO4NJHU3VFCDNPNRJ5OIQSF5U">
+                    <catDesc>el-Qatta</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaLUQMOESPBVHSDKIYCVU4QJZQUE">
+                  <catDesc>zentraler Teil</catDesc>
+                  <category xml:id="tla5DBEL23ENNCO3PCILVKAG4BYA4">
+                    <catDesc>Athribis</catDesc>
+                  </category>
+                  <category xml:id="tlaNBRK4362GBBS5LJJ7ZWKWQH3FI">
+                    <catDesc>Tuch el-Meleq</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaMQN3L5V4AVANBNS3ZNBRADMLAA">
+                  <catDesc>östlicher Teil</catDesc>
+                  <category xml:id="tla2X5LJC27KVCFDNRQXGSPZG7FDA">
+                    <catDesc>Gebel el-Ahmar</catDesc>
+                  </category>
+                  <category xml:id="tlaCGSB2R4IMJCTVJ6GEADDIEBNWA">
+                    <catDesc>Tell el-Jahudija</catDesc>
+                  </category>
+                  <category xml:id="tlaELVLGXV3QNDIXFG4WV4YGK7RIE">
+                    <catDesc>Ma'sara</catDesc>
+                  </category>
+                  <category xml:id="tlaHYKS2XE7WFEUJOVBAKVUOSUBXY">
+                    <catDesc>el-Mineiar</catDesc>
+                  </category>
+                  <category xml:id="tlaIBLDCA7DNJDAXFZSTWPZDLQ7SI">
+                    <catDesc>Bilbeis</catDesc>
+                  </category>
+                  <category xml:id="tlaR5IJ27RPYJEC7OMMHIS6WXXK7A">
+                    <catDesc>Heliopolis</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaIJYTSZ3DLZDGHMJR4C43JDUUE4">
+                <catDesc>vom Suezkanal zum Nil</catDesc>
+                <category xml:id="tlaEJ5NSLRQNVGUFDOJCRIK3CVIWY">
+                  <catDesc>Wadi Tumilat</catDesc>
+                  <category xml:id="tla4EENHGCLKBFELOYFSL7MNBGAYI">
+                    <catDesc>Tjeku</catDesc>
+                  </category>
+                  <category xml:id="tlaO3TB4IYE3BES7G47ELHNP6GSTE">
+                    <catDesc>Tell el-Maschuta</catDesc>
+                  </category>
+                  <category xml:id="tlaWYEVB2H26JAYVKD3JDUSB66LS4">
+                    <catDesc>Tell er-Retabe</catDesc>
+                  </category>
+                  <category xml:id="tlaXLIXCHIMXJAKHE37SNCXEFPJUM">
+                    <catDesc>Pithom</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaPU3TEBN7N5FDHKSQHHYGRHYHYE">
+                  <catDesc>Gebel Abu-Hassa</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaU4Z2DGVNWBBMLD5GD24DX3QKCQ">
+                <catDesc>nördliches Delta</catDesc>
+                <category xml:id="tlaIWBOJMGRKZAI3FDXPNMXSFPHQM">
+                  <catDesc>zentraler Teil</catDesc>
+                  <category xml:id="tla4ZW7V6Y5QJFYRJXHJ65XTMLQQA">
+                    <catDesc>Behbeit el-Hagar</catDesc>
+                  </category>
+                  <category xml:id="tla5HC6ICFQ5RGMRFBYYHOD6ZOKA4">
+                    <catDesc>Tell Mustai</catDesc>
+                  </category>
+                  <category xml:id="tla5NGQ5UGSBFGABLAQW3XWKN3YWM">
+                    <catDesc>Tell el-Belamun</catDesc>
+                  </category>
+                  <category xml:id="tlaJFONOHDXD5D3NF6ABSM7IY2QOE">
+                    <catDesc>Tell Tibilla</catDesc>
+                  </category>
+                  <category xml:id="tlaLG6U2DG5QBFTFJTINMG4IPL2R4">
+                    <catDesc>Busiris</catDesc>
+                  </category>
+                  <category xml:id="tlaOV655ZB3FFFUPDPLHFMMCORSWA">
+                    <catDesc>Sebennytos</catDesc>
+                  </category>
+                  <category xml:id="tlaOW6IU53NCFGY3ON4R76Q6WMTAE">
+                    <catDesc>Ma'sara</catDesc>
+                  </category>
+                  <category xml:id="tlaSOPJL3PRZ5B3JP6LBCALNKZKIA">
+                    <catDesc>Xois</catDesc>
+                  </category>
+                  <category xml:id="tlaV5GUCODM45AQLDEECYGSMPQQXI">
+                    <catDesc>Buto</catDesc>
+                  </category>
+                  <category xml:id="tlaZGMRXNW7WRFXTFSOJALIA2A7HQ">
+                    <catDesc>Tanta</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaOTKNRCAOWZATDB266AYBXUXJE4">
+                  <catDesc>östlicher Teil</catDesc>
+                  <category xml:id="tlaF45DPZ36QRD2JPS4SCOKTYDADQ">
+                    <catDesc>Bubastis</catDesc>
+                  </category>
+                  <category xml:id="tlaJCQVTFDTSRB35IUP5DVT7XOUKI">
+                    <catDesc>Imet</catDesc>
+                  </category>
+                  <category xml:id="tlaMI463ZT56RAHNJZMRJ2HQUJBFM">
+                    <catDesc>Horbeit</catDesc>
+                  </category>
+                  <category xml:id="tlaMPEQWUPDQBGV5DOG755QTFYFXI">
+                    <catDesc>Mit Jaisch</catDesc>
+                  </category>
+                  <category xml:id="tlaNVIS72L2OBHPJA4IOA27WG5AOE">
+                    <catDesc>Tuch el-Qaramus</catDesc>
+                  </category>
+                  <category xml:id="tlaOZ4QHHCIIZA73PXFWLWHGGR5MY">
+                    <catDesc>Daphne</catDesc>
+                  </category>
+                  <category xml:id="tlaPNUNV5Y35FFZBHFP7ZB66MJDWA">
+                    <catDesc>Baklija</catDesc>
+                  </category>
+                  <category xml:id="tlaR6LJPQH3ERDJPONBEHGEKI26DQ">
+                    <catDesc>el-Munagat</catDesc>
+                  </category>
+                  <category xml:id="tlaRSDXUFF745C37ARA72C6QMSVAY">
+                    <catDesc>el-Chata'na</catDesc>
+                  </category>
+                  <category xml:id="tlaSH6XJRRRJNCI5EAMNJSPU5QZ3A">
+                    <catDesc>Tanis</catDesc>
+                  </category>
+                  <category xml:id="tlaT43FHBSDM5ET5FP4CMOPRHQJHM">
+                    <catDesc>Tell el-Moqdam</catDesc>
+                  </category>
+                  <category xml:id="tlaUUFUTAO2CRGMBCCHZUSIX54NYY">
+                    <catDesc>Sile</catDesc>
+                  </category>
+                  <category xml:id="tlaUV7M4QWTNNHFNAOZNLDMEUQ2I4">
+                    <catDesc>Tell ed-Dab'a</catDesc>
+                  </category>
+                  <category xml:id="tlaUZYOPM5FU5CC5AETRZKG6ETNNQ">
+                    <catDesc>Mendes</catDesc>
+                  </category>
+                  <category xml:id="tlaXF74GZP3A5CTXHEMEW4BAGXGAU">
+                    <catDesc>Faqus</catDesc>
+                  </category>
+                  <category xml:id="tlaYNGNGUJD6RBAHPPMETU6TNQX5Q">
+                    <catDesc>Thmuis</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaP3CETTKCSVC2BGF6GYT2KSYYQ4">
+                  <catDesc>westlicher Teil</catDesc>
+                  <category xml:id="tla42UHTTPRIJD6BKVINF5RNCHYNQ">
+                    <catDesc>Kom el-Hisn</catDesc>
+                  </category>
+                  <category xml:id="tla4W3RKNA2SVA7TATDOP4WXMDPFE">
+                    <catDesc>Rosette</catDesc>
+                  </category>
+                  <category xml:id="tlaCJ3TD3P53VAURNH74TMRZF653A">
+                    <catDesc>Naukratis</catDesc>
+                  </category>
+                  <category xml:id="tlaJAPLD5QERREFTBGTVSA3Z3QYQE">
+                    <catDesc>Damanhur</catDesc>
+                  </category>
+                  <category xml:id="tlaV7ON34EUUBB3TJYKXB3ZNH67BQ">
+                    <catDesc>Sais</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaPFIFC6WAYFBBJFTEKB7M3STHZU">
+                  <catDesc>Nordküste</catDesc>
+                  <category xml:id="tlaDSW5GW5HENDW5OLNBZLN42EWFU">
+                    <catDesc>Kom esch-Schugafa (Alexandria)</catDesc>
+                  </category>
+                  <category xml:id="tlaGU23DGCAIZCGRNQCYEUZTFF6FI">
+                    <catDesc>Taposiris Magna</catDesc>
+                  </category>
+                  <category xml:id="tlaMYI47NGXPNBZ5HNMRWYZWJ24EA">
+                    <catDesc>Kom el-Idris</catDesc>
+                  </category>
+                  <category xml:id="tlaON7JIYBPHFAGJFUAIZCGYCSYNU">
+                    <catDesc>Kanopus</catDesc>
+                  </category>
+                  <category xml:id="tlaP5PHG7ZM3ZEBRKBABQ2SZYNW4Y">
+                    <catDesc>Pelusium</catDesc>
+                  </category>
+                </category>
+              </category>
+            </category>
+            <category xml:id="tlaBUWJS23DLVAVFH7H5SRJOOAPFM">
+              <catDesc>Niltal südlich des 1. Katarakts bis zum 2. Katarakt</catDesc>
+              <category xml:id="tla6VL7V2BNIFCNJAFW3CRMI64FKQ">
+                <catDesc>Abu Simbel</catDesc>
+                <category xml:id="tlaR6Y6XEI6QBDONIUN2YDEHJDWZQ">
+                  <catDesc>Abu Simbel</catDesc>
+                </category>
+              </category>
+              <category xml:id="tla7S7NTM7P2VBUVC77Z76EDJKIIE">
+                <catDesc>Dakke bis Abu Simbel</catDesc>
+                <category xml:id="tlaKHD2BMU6QZA37C2XZMYE7FPDYM">
+                  <catDesc>westliches Ufer</catDesc>
+                  <category xml:id="tla6UBXD73ACZAYPGKJ6XGVJNZ62Q">
+                    <catDesc>Sayala</catDesc>
+                  </category>
+                  <category xml:id="tlaGBRDGGW3XVARDDDY5CIGMJPSGQ">
+                    <catDesc>Ermenne</catDesc>
+                  </category>
+                  <category xml:id="tlaGX4XGIN7J5BDVHAOC5HEMK3SZU">
+                    <catDesc>Tomas</catDesc>
+                  </category>
+                  <category xml:id="tlaIHT6E676DJFO3OR5LYOGCCI6LA">
+                    <catDesc>Amada</catDesc>
+                  </category>
+                  <category xml:id="tlaSC352ETLQBBHFMHLESXVXAKYIQ">
+                    <catDesc>Aniba</catDesc>
+                  </category>
+                  <category xml:id="tlaTIDXLPPUL5HYXLFPAZ5BDEMTAE">
+                    <catDesc>Hierasykaminos</catDesc>
+                  </category>
+                  <category xml:id="tlaX4QQKDWFFFDB7JDHLHMLEOK624">
+                    <catDesc>Wadi es-Sebua</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaTYHMMHS7NFBQFASBACI7RUHQIY">
+                  <catDesc>östliches Ufer</catDesc>
+                  <category xml:id="tla4SHOZRWM4ZDMJEXXYCEKSAYF7Q">
+                    <catDesc>Quban</catDesc>
+                  </category>
+                  <category xml:id="tla7Y5DUFTXTNE5RBZNGQDZRSSNLY">
+                    <catDesc>Toschqa</catDesc>
+                  </category>
+                  <category xml:id="tlaBBVGTJLTRBD53OQZBOEFYS63UI">
+                    <catDesc>Qasr Ibrim</catDesc>
+                  </category>
+                  <category xml:id="tlaTZQFPMP5JFCUZGEUHJR26CLFXE">
+                    <catDesc>Derr</catDesc>
+                  </category>
+                  <category xml:id="tlaXWTXKPEPWRDDVD6QUHK3USP55M">
+                    <catDesc>Korosko</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaADPSIZ75TZDM7P62YEGXEKKTHU">
+                <catDesc>Dakke</catDesc>
+                <category xml:id="tlaYGNF37YOARHYPJDAKTXMWDPJRA">
+                  <catDesc>Dakke</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaKRV3GM777FBVVHBGPABDIRAPEI">
+                <catDesc>1. Katarakt bis Dakke</catDesc>
+                <category xml:id="tla77RGQQ53DBDFJBPNQ7RKYTYVHM">
+                  <catDesc>westliches Ufer</catDesc>
+                  <category xml:id="tlaGSDIFBXPDZHYVFT3RXA4FV2N5U">
+                    <catDesc>Gerf Hussein</catDesc>
+                  </category>
+                  <category xml:id="tlaKQ4VEK5G5FCP7OSBMDSVQ2QD2Q">
+                    <catDesc>Qertassi</catDesc>
+                  </category>
+                  <category xml:id="tlaO4UUADN375A3LDUHHX7BXIW2WM">
+                    <catDesc>Beit el-Wali</catDesc>
+                  </category>
+                  <category xml:id="tlaO7GX2JNVWRE3FESZO47YUCBD64">
+                    <catDesc>Dendur</catDesc>
+                  </category>
+                  <category xml:id="tlaQVJJXVRHRZGOPD2H7HT4ZV7CKI">
+                    <catDesc>Wadi Qitna</catDesc>
+                  </category>
+                  <category xml:id="tlaRJDKDN7RUZC6DLMB5SEJ2VYODI">
+                    <catDesc>Debod</catDesc>
+                  </category>
+                  <category xml:id="tlaSEY4ZK3JNZG3XCRD7K5QDPXFVQ">
+                    <catDesc>Kalabscha</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaGA4NCPVRMNFSVD7SSTWUXNWZLI">
+                  <catDesc>östliches Ufer</catDesc>
+                  <category xml:id="tlaBEEOZJ5YFVGIVAAL7PCBPWQC6E">
+                    <catDesc>Ajuala</catDesc>
+                  </category>
+                  <category xml:id="tlaX26AQYRTVJFINMA4INCEMGABAA">
+                    <catDesc>Khor Dehmit</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaS6VBVY25EZFVJMDQKQGVT2QE5I">
+                <catDesc>zwischen Abu Simbel und dem 2. Katarakt</catDesc>
+                <category xml:id="tla3HMAPZL64NFLFDBQECAJX6EOCI">
+                  <catDesc>Gebel esch-Schams</catDesc>
+                </category>
+                <category xml:id="tlaBYHX25PZNNAARPSR3E4U4TLQRQ">
+                  <catDesc>Akscha</catDesc>
+                </category>
+                <category xml:id="tlaFV5HKLWMB5HY3C5ZULRPG6OBBE">
+                  <catDesc>Abu Oda</catDesc>
+                </category>
+                <category xml:id="tlaFZVUWJ5LLNHILBPOFVO3HUKIKY">
+                  <catDesc>Gebel Adde</catDesc>
+                </category>
+                <category xml:id="tlaHCGUPUIH45FXJFFRVOX4T45C4Y">
+                  <catDesc>Wadi Halfa</catDesc>
+                </category>
+                <category xml:id="tlaMTEJA5EFERBGRL22QWBG4YVXRU">
+                  <catDesc>Serre</catDesc>
+                </category>
+                <category xml:id="tlaQRIO5KUTZFERZLVV4WBGZTDIUU">
+                  <catDesc>Faras</catDesc>
+                </category>
+                <category xml:id="tlaS6GDQ67UIBGSTOSQKBQ56SB2VY">
+                  <catDesc>Buhen</catDesc>
+                </category>
+              </category>
+            </category>
+            <category xml:id="tlaE2B3E3J45ZC6DCPA5RZIGZZ7EY">
+              <catDesc>Wüste östlich des Niltals und Küste des Roten Meeres (Staatsgebiet Ägypten und Sudan)</catDesc>
+              <category xml:id="tla3FRDJZKIZNE3NNWU33D3CKXNF4">
+                <catDesc>südliche Routen</catDesc>
+                <category xml:id="tla3YZGESWDVZFPZLITU7KTF57TCM">
+                  <catDesc>Wadi Allaqi</catDesc>
+                </category>
+                <category xml:id="tlaDABYGSE4XBANPHUQLPAO7MEP2A">
+                  <catDesc>Wadi el-Hudi</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaGFDPKSIYJVFMZD3DCA27FR4C24">
+                <catDesc>Routen zum Roten Meer</catDesc>
+                <category xml:id="tla3M3C6TGTKRA7NPZDPEUU72433I">
+                  <catDesc>Kanais</catDesc>
+                </category>
+                <category xml:id="tla3VL2L2L3KNGHBLYARDFPH6TPBU">
+                  <catDesc>Barramije</catDesc>
+                </category>
+                <category xml:id="tla54JWTN54WNBVNMPOSYF5JQJ3ZA">
+                  <catDesc>Wadi Gasus</catDesc>
+                </category>
+                <category xml:id="tla5PKEXGN6XNAGNPFXJ2JIYF726U">
+                  <catDesc>Berenike</catDesc>
+                </category>
+                <category xml:id="tlaFN72ZPMF2ZCV5GYEF7QJGAZXFY">
+                  <catDesc>Wadi Hamâma</catDesc>
+                </category>
+                <category xml:id="tlaHL6GBGX26BC2XCKMBEEFOKRC7Y">
+                  <catDesc>Wadi Hammamat</catDesc>
+                  <category xml:id="tlaIW4DXVW3KJEWFLKPHNWZSF4LSM">
+                    <catDesc>Qasr el-Banat</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaKJNTDBQKQZAHNMOJUM4VDHFQCA">
+                  <catDesc>Wadi Abbad</catDesc>
+                </category>
+                <category xml:id="tlaKKSCREF2MZDLBFN3CJ6L44X3GY">
+                  <catDesc>Wadi Atalla</catDesc>
+                </category>
+                <category xml:id="tlaLP3GXRJ72VH2DARNNKWEGSXIRE">
+                  <catDesc>Wadi Gawasis</catDesc>
+                </category>
+                <category xml:id="tlaPPFR6SGBD5F3VMDHLIGU7TUARA">
+                  <catDesc>Wadi el-Gidâmi</catDesc>
+                </category>
+                <category xml:id="tlaZBF5ZADTUFFGNIBNGWQIVJVMLI">
+                  <catDesc>Wadi el-Fawachir</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaYM7ABEEBHRCGZHXP7LGWFOEZMI">
+                <catDesc>Sinai</catDesc>
+                <category xml:id="tla4IUVOG75VNEYVJ4ZGXOSX2FT7Y">
+                  <catDesc>Serabit el-Chadim</catDesc>
+                </category>
+                <category xml:id="tla5PPRSZOGFJCMVMORMDRPS5X2QU">
+                  <catDesc>Wadi Nasb</catDesc>
+                </category>
+                <category xml:id="tlaQMBTD2UIXVHK5BKVR75VWYANNA">
+                  <catDesc>Rod el-Air</catDesc>
+                </category>
+                <category xml:id="tlaXPGRVXOALZF2FB4XVSF5USDARY">
+                  <catDesc>Wadi Maghara</catDesc>
+                </category>
+              </category>
+            </category>
+            <category xml:id="tlaHKPRMC5M5JHDHACZICND5E3NJE">
+              <catDesc>Niltal südlich von Assiut bis zum 1. Katarakt</catDesc>
+              <category xml:id="tla2LKORXWT6ZEVVOVZTU5WQBEKQM">
+                <catDesc>zwischen Assuan und Philae</catDesc>
+                <category xml:id="tla2UL2L2L5GFDBZOM42VB3F62KRY">
+                  <catDesc>Konosso</catDesc>
+                </category>
+                <category xml:id="tlaG5VRXHOVCNHXTKNM4QRNPOZFTM">
+                  <catDesc>Bigga</catDesc>
+                </category>
+                <category xml:id="tlaIIMLKYBGMRE3DGJLRUPXWORJFI">
+                  <catDesc>Sehel</catDesc>
+                </category>
+                <category xml:id="tlaPA2BRW3KTVDZNIGTZ37XKTC2YM">
+                  <catDesc>Philae</catDesc>
+                </category>
+              </category>
+              <category xml:id="tla3CYKLCG42FAB3JYXJFOYMTR34E">
+                <catDesc>Abydos</catDesc>
+                <category xml:id="tlaUGEDNM7L25CZ5EOPKOT4HIZAFY">
+                  <catDesc>Abydos</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaASKBCQLYJ5DDRCVIMWXF5ZQJZQ">
+                <catDesc>Elkab und Hierakonpolis (Kom el-Ahmar)</catDesc>
+                <category xml:id="tlaNWV3DQDYZ5BKFKUR6MRV76Y5XY">
+                  <catDesc>Hierakonpolis</catDesc>
+                </category>
+                <category xml:id="tlaZJ2DOAUGEBAHRDZRFNPFAWDT4A">
+                  <catDesc>Elkab</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaFJ5TFXCLKNEG5MX2WSVIHC2G2U">
+                <catDesc>zwischen Abydos und Theben</catDesc>
+                <category xml:id="tla6UFABA3HPFFVNKLYUBUZJ5CKYI">
+                  <catDesc>östliches Ufer</catDesc>
+                  <category xml:id="tla5THBM2KC6NDHDMTLDLFPL3AQKE">
+                    <catDesc>Qene</catDesc>
+                  </category>
+                  <category xml:id="tlaHYET77EWLFB4FIVBIWMT5TY5ZM">
+                    <catDesc>el-Qala</catDesc>
+                  </category>
+                  <category xml:id="tlaK5LEZLASHBGSJP2LNAJBY4AQZQ">
+                    <catDesc>Schanhur</catDesc>
+                  </category>
+                  <category xml:id="tlaNDJX4X5REZDNFOMORWMO6PYZII">
+                    <catDesc>Medamud</catDesc>
+                  </category>
+                  <category xml:id="tlaPGBUJXILWBDLJMW777DP4VRIJU">
+                    <catDesc>Qus</catDesc>
+                  </category>
+                  <category xml:id="tlaXRLOXFASKNHRBA7RJ35ADQQQFY">
+                    <catDesc>Koptos</catDesc>
+                  </category>
+                  <category xml:id="tlaZ3DOC2J76RETBJ7G2PIJGQE2BQ">
+                    <catDesc>Chenoboskion</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaM6RQB65O3JAGLAANCXH4PD2SQE">
+                  <catDesc>westliches Ufer</catDesc>
+                  <category xml:id="tla2AVZ43KNO5GVLHV6H33NG7M6CY">
+                    <catDesc>Abadijeh</catDesc>
+                  </category>
+                  <category xml:id="tla2UK57LIC4RDHPHBULX3YILG6KM">
+                    <catDesc>Ombos</catDesc>
+                  </category>
+                  <category xml:id="tla57QDPRBGGFERPJHONVR7NPAXDQ">
+                    <catDesc>Hu</catDesc>
+                  </category>
+                  <category xml:id="tla5GHAEE4RAFEZNOBSJCHKMB3VW4">
+                    <catDesc>Deir el-Ballas</catDesc>
+                  </category>
+                  <category xml:id="tla5XJ3I4MXXRC23EWQPNDWBHPDEA">
+                    <catDesc>Naqada</catDesc>
+                  </category>
+                  <category xml:id="tlaKVMVMBDEWBDCFBNY4E3BRCLNPQ">
+                    <catDesc>el-Amrah</catDesc>
+                  </category>
+                  <category xml:id="tlaN2QWVQP2NZFL7L5N4QRVMQ6EUI">
+                    <catDesc>Qamula</catDesc>
+                  </category>
+                  <category xml:id="tlaN4GNGV4FJZESZM67GMMZUGT2C4">
+                    <catDesc>Dendara</catDesc>
+                  </category>
+                  <category xml:id="tlaQUQOGN2W4VEWDEGD3MNLCE3CRY">
+                    <catDesc>Gebel el-Araq</catDesc>
+                  </category>
+                  <category xml:id="tlaR5NDZ43RBRESPCTXYIKOGEFMY4">
+                    <catDesc>Nag' Hammadi</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaN2RDQCOO6VDBJHW6EVBGKKV7VM">
+                <catDesc>zwischen Assiut und Abydos</catDesc>
+                <category xml:id="tlaN7PVNHK625DQDDAZSQJ6ETU36M">
+                  <catDesc>östliches Ufer</catDesc>
+                  <category xml:id="tla4LGAJNYWKVFRZHKOD4LZXXROA4">
+                    <catDesc>Gebel Scheich el-Haridi</catDesc>
+                  </category>
+                  <category xml:id="tla4T7AO4FU7BBR5BOZ4FVQIIYOG4">
+                    <catDesc>el-Salamuni</catDesc>
+                  </category>
+                  <category xml:id="tla6Z46BHW7WZGDFGU46OS4HDCHWU">
+                    <catDesc>Balabisch</catDesc>
+                  </category>
+                  <category xml:id="tla7JIPPT7HWNBSLLKJTP32DOVQVI">
+                    <catDesc>Qau el-Kebir</catDesc>
+                  </category>
+                  <category xml:id="tla7LPJ2TECP5BEHAHDNNVNKRJXR4">
+                    <catDesc>el-Badari</catDesc>
+                  </category>
+                  <category xml:id="tlaC2Z63NXQFBBFNLB3RZEJJQTBVQ">
+                    <catDesc>Achmim</catDesc>
+                  </category>
+                  <category xml:id="tlaEX5WE4HJLNBG5FQSYNHVAES3SQ">
+                    <catDesc>Megeb</catDesc>
+                  </category>
+                  <category xml:id="tlaIEPAOJWPNFH6LLPKM235N3ZSGA">
+                    <catDesc>el-Hemamija</catDesc>
+                  </category>
+                  <category xml:id="tlaLYC5TPBHKZD6HFL4WYAKJDBKD4">
+                    <catDesc>Naga (Nag') ed-Der</catDesc>
+                  </category>
+                  <category xml:id="tlaMUUL3RFV25A2VJVQCZLZTS4W3Y">
+                    <catDesc>Nag' Wisa</catDesc>
+                  </category>
+                  <category xml:id="tlaNGDAPYWJXVHWZOGMB4UUCAPDHE">
+                    <catDesc>el-Chawalid</catDesc>
+                  </category>
+                  <category xml:id="tlaOBLEFFISIVDODOY6V5WBES5ADM">
+                    <catDesc>Mescheich</catDesc>
+                  </category>
+                  <category xml:id="tlaOJ377AW4ZRGPFBRWDKAUB5IHMA">
+                    <catDesc>Tasa</catDesc>
+                  </category>
+                  <category xml:id="tlaUCJZQ2QW3FGXVBKCJX4K6JYOUI">
+                    <catDesc>el-Matmar</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaWXXNUSAWOVFUTK3T64L4F4DAZ4">
+                  <catDesc>westliches Ufer</catDesc>
+                  <category xml:id="tla4OYVP4O3GJH4BJPVB2WRCFTOKM">
+                    <catDesc>er-Raqaqna</catDesc>
+                  </category>
+                  <category xml:id="tlaAO5OW7XDXJHLBJVS4MIGBLFN3U">
+                    <catDesc>Sohag</catDesc>
+                  </category>
+                  <category xml:id="tlaAVGS35DRF5EZFG4XTODL5BX7MM">
+                    <catDesc>Thinis</catDesc>
+                  </category>
+                  <category xml:id="tlaBGCL2CHJEJDPZHT5Q6WHF2T6HE">
+                    <catDesc>el-Hagarsa</catDesc>
+                  </category>
+                  <category xml:id="tlaFVSSH5HS5RBLXLR6CFOPVC7JPQ">
+                    <catDesc>Kom Isfaht</catDesc>
+                  </category>
+                  <category xml:id="tlaQKICI6IT7ZCJDJFUICKUYO2XTQ">
+                    <catDesc>Mahasna</catDesc>
+                  </category>
+                  <category xml:id="tlaSS4B5IAYWRBRZBB6Q5CHG5LNUA">
+                    <catDesc>Deir Rifeh</catDesc>
+                  </category>
+                  <category xml:id="tlaU3ZQSALHEREJJCI6UZK3YH5S3Q">
+                    <catDesc>Kom Ischqau</catDesc>
+                  </category>
+                  <category xml:id="tlaWYZFBMTMAZA2FI3AVYEWUPVXHQ">
+                    <catDesc>Tahta</catDesc>
+                  </category>
+                  <category xml:id="tlaYZOQ5HECXNBYLDAZPRUIIRDA5E">
+                    <catDesc>el-Menschiyeh (Ptolemais Hermiu)</catDesc>
+                  </category>
+                  <category xml:id="tlaZR4U6SEVWZCSRDOC7LPPLE6RDI">
+                    <catDesc>Beit Challaf</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaNE2TEF2YWJBWBARUXJGUAOFZXU">
+                <catDesc>zwischen Theben und Elkab</catDesc>
+                <category xml:id="tlaE6EBGAEOMRGB7DP4LX4XFXKTAA">
+                  <catDesc>östliches Ufer</catDesc>
+                  <category xml:id="tlaAZ7FJSBH5BHKHGDLCDWUS2EZM4">
+                    <catDesc>Nag' el-Hammam (2 km NO von Elkab)</catDesc>
+                  </category>
+                  <category xml:id="tlaCMW4EPSVDJDQ7DD3FZ3LBOGXYA">
+                    <catDesc>Sarnik</catDesc>
+                  </category>
+                  <category xml:id="tlaDCSZZSLENZHY5EPFGHWYJPCZ4M">
+                    <catDesc>et-Tod</catDesc>
+                  </category>
+                  <category xml:id="tlaHKXOI5E7ZNF7TDLGBASBO4A46A">
+                    <catDesc>Mo'alla</catDesc>
+                  </category>
+                  <category xml:id="tlaHNHTKVPNO5AA5BBZD356F4S4BY">
+                    <catDesc>Mata'na</catDesc>
+                  </category>
+                  <category xml:id="tlaPXUMQCIEP5BPROZWAMTMCROGO4">
+                    <catDesc>Kontralatopolis</catDesc>
+                  </category>
+                  <category xml:id="tlaUN7N7J7ZDNEJ5DWDJRAUVUX7CE">
+                    <catDesc>Komir</catDesc>
+                    <category xml:id="tlaTAFEK7BMIFHMFMWSRN6JOZZFOM">
+                      <catDesc>Saft el-Henna</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaVLP4OWR7TJGAZLE3OJ5GHCVQTE">
+                    <catDesc>el-Dibbabija</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaEADC3TZLQRHQZDQZF3H6PD3CKE">
+                  <catDesc>westliches Ufer</catDesc>
+                  <category xml:id="tlaM4SOHCRELFHLNC27MWIGAD4VM4">
+                    <catDesc>Esna</catDesc>
+                  </category>
+                  <category xml:id="tlaMJFTXFNGEFBFPMQOVTCKIYMMVY">
+                    <catDesc>Armant</catDesc>
+                  </category>
+                  <category xml:id="tlaTJ3VC6VP2BBEDPTLQ32NGPMVV4">
+                    <catDesc>el-Kula</catDesc>
+                  </category>
+                  <category xml:id="tlaX4GCHEJEAFEYLCD5OMN3FWPS6M">
+                    <catDesc>Asfun el-Mata'na</catDesc>
+                  </category>
+                  <category xml:id="tlaZZVLCRSQFRFP3KLNZNCPSA6CDQ">
+                    <catDesc>Gebelein</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaRGS2OLARZRFTHEFGRYNKB6YJ5E">
+                <catDesc>Theben</catDesc>
+                <category xml:id="tlaCLFZC44SZ5C6FJHKC3YBOLHHXI">
+                  <catDesc>östliches Ufer</catDesc>
+                  <category xml:id="tlaLBISHPC2BNBWDLMXCBZJEM76TE">
+                    <catDesc>Luxor</catDesc>
+                  </category>
+                  <category xml:id="tlaQSVTRJ2TVBFTNKSOZMWO7Q76J4">
+                    <catDesc>Theben</catDesc>
+                    <category xml:id="tlaGYNQQNK4NFFJDPCKFM2C5MXBRA">
+                      <catDesc>Tal der Könige</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaSGFCZP5Y35GEBCOGT7RCMOXSNM">
+                    <catDesc>Karnak</catDesc>
+                    <category xml:id="tlaCQ2JRDM3PNA6TCRWMH57XBAPBU">
+                      <catDesc>Chonstempel, südöstlich des Karnaktempels</catDesc>
+                    </category>
+                    <category xml:id="tlaYAZ72BD3IZGOLLOCE4DPEPFT7M">
+                      <catDesc>Mut-Tempel</catDesc>
+                    </category>
+                  </category>
+                </category>
+                <category xml:id="tlaVHGZGISIMJG6NBSUYALIZI4TIQ">
+                  <catDesc>westliches Ufer</catDesc>
+                  <category xml:id="tla2AH3DNLH7FHXTNWZFNFEGD5ELQ">
+                    <catDesc>Ilwet el-Scheich Abd-el-Gurna</catDesc>
+                  </category>
+                  <category xml:id="tla36AKKTU5DBFZHPGZYBGBBIIB5Y">
+                    <catDesc>Gurnet Murrai</catDesc>
+                  </category>
+                  <category xml:id="tla4SHO2GKY4NEV5EYKIDN4GOHDQA">
+                    <catDesc>Tal der Könige (Biban el-Muluk)</catDesc>
+                  </category>
+                  <category xml:id="tla5EG2AE4HAFCBVLR3OIDWCU73HU">
+                    <catDesc>Djeme</catDesc>
+                  </category>
+                  <category xml:id="tlaCLERK45WSZGFJLFSFFMKFGSCF4">
+                    <catDesc>Malqata</catDesc>
+                  </category>
+                  <category xml:id="tlaD2JRDZPOPJFIRMIKW2HDCNLOYM">
+                    <catDesc>Deir el-Bachit</catDesc>
+                  </category>
+                  <category xml:id="tlaEDSWLVWAWJCZNEFLRENF4R2OCA">
+                    <catDesc>Deir esch-Schelwit</catDesc>
+                  </category>
+                  <category xml:id="tlaFYDEOYNWHJEBDHP62FVCZ5PQHY">
+                    <catDesc>Dra abu el-Naga</catDesc>
+                  </category>
+                  <category xml:id="tlaGYV7XU55WVAJZOQZGAWDIPKGZY">
+                    <catDesc>Khokha</catDesc>
+                  </category>
+                  <category xml:id="tlaINTSIBUJ75GFDHWIHTNKFN26IE">
+                    <catDesc>Asasif</catDesc>
+                  </category>
+                  <category xml:id="tlaJHMKUZN4YRGCXJEHXKRYGL5MLA">
+                    <catDesc>Deir el-Medineh</catDesc>
+                  </category>
+                  <category xml:id="tlaLDGG7LEGBRBCBAY37VOZ34UYWQ">
+                    <catDesc>Qasr el-Aguz</catDesc>
+                  </category>
+                  <category xml:id="tlaOXIU5QGX5VAABKEZT5RNVBIEBM">
+                    <catDesc>Deir el-Bahari</catDesc>
+                    <category xml:id="tla6D3V7C7DW5AZ3EIZGRNNOIQBAM">
+                      <catDesc>Hatschepsut-Tempel</catDesc>
+                    </category>
+                    <category xml:id="tlaLDP5XOVUXZDOLNBL7MDQELKP74">
+                      <catDesc>Mentuhotep-Tempel</catDesc>
+                    </category>
+                    <category xml:id="tlaQDJW2FJY5JA2DCA5SB6CYBNLCY">
+                      <catDesc>Birabi</catDesc>
+                    </category>
+                    <category xml:id="tlaVI2BCCQPTRB4BNYYZEGQQYCIN4">
+                      <catDesc>Tempel Thutmosis' III.</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaTBL6LVAUP5EBBCCHBKYW6JGJTE">
+                    <catDesc>Medinet Habu</catDesc>
+                  </category>
+                  <category xml:id="tlaTICHJFEOLVCP3JDWTSQD2FFBSE">
+                    <catDesc>Qurna</catDesc>
+                  </category>
+                  <category xml:id="tlaXNR5C5APPZASBI3EKZT6EQ5REY">
+                    <catDesc>Scheich Abd-el-Gurna</catDesc>
+                    <category xml:id="tla7VY7ICOAOJFBZEHMRFVSEZUTFU">
+                      <catDesc>Gurnet Murrai</catDesc>
+                    </category>
+                    <category xml:id="tlaGJYDLFCCSVFRZJ6UXBILKB5DYE">
+                      <catDesc>Khokha</catDesc>
+                    </category>
+                    <category xml:id="tlaNRNSZO2JSZCGFAOBTZ5GBFJNGU">
+                      <catDesc>Asasif</catDesc>
+                    </category>
+                    <category xml:id="tlaPW2ABM2P7FC47KPZPBCUYQJILQ">
+                      <catDesc>Ilwet el-Scheich Abd-el-Gurna</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaYF6WKS2KHNBMVF4XX3PLFKIBZU">
+                    <catDesc>Ramesseum</catDesc>
+                  </category>
+                  <category xml:id="tlaZNHKKJOPIRFNHCHBC2FZE3EGM4">
+                    <catDesc>Tal der Königinnen (Biban el-Harim)</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaTZ7SXDLZKFCAJDCIMCBHLZSQHI">
+                <catDesc>Assuan</catDesc>
+                <category xml:id="tlaFYST3LL3LZBX3K27RVU3HFWFDM">
+                  <catDesc>Elephantine</catDesc>
+                </category>
+                <category xml:id="tlaHQ6TAYOMBZEWVFTZV33MWLVE4I">
+                  <catDesc>Assuan</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaYR4D246MOZGR3H5THHUQ2ULS4Q">
+                <catDesc>zwischen Elkab und Assuan</catDesc>
+                <category xml:id="tlaUB536QMTFNHDXJ6PDL22M6KSNE">
+                  <catDesc>östliches Ufer</catDesc>
+                  <category xml:id="tla4O7Y64CXSRBKVO43ENCXOKOIOA">
+                    <catDesc>Nag' el-Kagug</catDesc>
+                  </category>
+                  <category xml:id="tla6ZMA7B4GDNF23F5BETZDVAM6AI">
+                    <catDesc>Kom Ombo</catDesc>
+                  </category>
+                  <category xml:id="tlaDBSOTKB6BNFSZLEA45IS7TNA4E">
+                    <catDesc>Gebel el-Hammam</catDesc>
+                  </category>
+                  <category xml:id="tlaUVWHR354GJC7FBW2DY2GMWVP7Q">
+                    <catDesc>Bueb</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaW5XH4PUGO5FQTBVIWYSPDJZ3WY">
+                  <catDesc>westliches Ufer</catDesc>
+                  <category xml:id="tlaF5ZUDOTN3VGTHJDCWGXRLSBMHQ">
+                    <catDesc>el-Qubanije</catDesc>
+                  </category>
+                  <category xml:id="tlaFND3IEZXXJFA7GYJMCSFR6OZEI">
+                    <catDesc>Esbet er-Reseiris</catDesc>
+                  </category>
+                  <category xml:id="tlaIBLZAC23NFFBXDTB2MXOFFDZBI">
+                    <catDesc>Nag' el-Hammam (ca. 3 km nördlich von Gebel es-Silsile)</catDesc>
+                  </category>
+                  <category xml:id="tlaIC3Y3AOARBGDHPUIZHNNILGF7U">
+                    <catDesc>Gebel es-Silsile</catDesc>
+                  </category>
+                  <category xml:id="tlaMHKQZNF5IRAMHETGHU32FI67NE">
+                    <catDesc>Wadi Schatt er-Rigale</catDesc>
+                  </category>
+                  <category xml:id="tlaONO4KXU4RNH3HCECVJO5JTV2MY">
+                    <catDesc>Qubbet el Hawa</catDesc>
+                  </category>
+                  <category xml:id="tlaRBYSK262OZCSNB2PX3ZMUXXSAY">
+                    <catDesc>Nag' el-Hisaja</catDesc>
+                  </category>
+                  <category xml:id="tlaSFEBWV2ASBBXZEO23U3QPV27GU">
+                    <catDesc>Tell Edfu</catDesc>
+                  </category>
+                </category>
+              </category>
+            </category>
+            <category xml:id="tlaKKNV5MDOBFFCRBQDXDLN4FUVOQ">
+              <catDesc>Niltal von Kairo bis Assiut</catDesc>
+              <category xml:id="tla5EFAK4CGMVDZPIDIST4QUAMDCA">
+                <catDesc>Fajjum</catDesc>
+                <category xml:id="tla4UOMQ5KBONF6VGYD5CJXVIFH64">
+                  <catDesc>Tebtynis</catDesc>
+                </category>
+                <category xml:id="tla7E6I7CAI3NBH3DME5D3SZUUSN4">
+                  <catDesc>Bakchias</catDesc>
+                </category>
+                <category xml:id="tla7VCUGQCIVVBOHFDW57YHBJBLNU">
+                  <catDesc>Medinet el-Fajjum</catDesc>
+                </category>
+                <category xml:id="tlaDADYX4WVYJHXXJ3IERRW4SMXXU">
+                  <catDesc>Dimeh</catDesc>
+                </category>
+                <category xml:id="tlaETNCVGLC6ZB5TK4XPKLCLUT6SE">
+                  <catDesc>Theadelphia</catDesc>
+                </category>
+                <category xml:id="tlaJ5FCHXYBRBCBZNFDBFWEI4CEN4">
+                  <catDesc>Seila</catDesc>
+                </category>
+                <category xml:id="tlaQRQWG2UN25DYJFOFKIXX3OO2ZU">
+                  <catDesc>Medinet Quta</catDesc>
+                </category>
+                <category xml:id="tlaR735ML6THRFIFE5BQLKRMB5QZU">
+                  <catDesc>Hawara</catDesc>
+                </category>
+                <category xml:id="tlaU5T6QBQIQBBDTBOEZX5DJ3H54Y">
+                  <catDesc>Karanis</catDesc>
+                </category>
+                <category xml:id="tlaV23GS5PBZRDJVHVDTA5Z6FFKPA">
+                  <catDesc>Qasr el-Banat (im SW des Moerissees)</catDesc>
+                </category>
+                <category xml:id="tlaXLA5GLIZZJGJXPZMKPH6W4OPAM">
+                  <catDesc>Magdola</catDesc>
+                </category>
+                <category xml:id="tlaXS3ZPIWINVCNFASQHDT3PFNVGQ">
+                  <catDesc>Medinet Madi</catDesc>
+                </category>
+                <category xml:id="tlaZQTYT2OUNBGO7F4WJ2K3T3NZ4Y">
+                  <catDesc>Biahmu</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaAHTCKEAK3ZDYFBAVDDBPC5HAHI">
+                <catDesc>zwischen Tell el-Amarna und Assiut</catDesc>
+                <category xml:id="tlaQY23YBPECVCLFBZGS2CSVREDDU">
+                  <catDesc>östliches Ufer</catDesc>
+                  <category xml:id="tlaFJMAFBHVPNFWNE6RCA23I5XWQ4">
+                    <catDesc>Deir el-Gebrawi</catDesc>
+                  </category>
+                  <category xml:id="tlaI5SMOHSU35F5LGC36MLVSY25P4">
+                    <catDesc>el-Ataula</catDesc>
+                  </category>
+                  <category xml:id="tlaNWMFEJJZDNAPXFKDDIWBOIM35Q">
+                    <catDesc>Quseir el-Amarna</catDesc>
+                  </category>
+                  <category xml:id="tlaOJCZRXYVDJD2TF3C3KRPYZP6II">
+                    <catDesc>Gebel Abu-Foda</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaU6XX66EL3JFIPP24E3Z5L7XBKM">
+                  <catDesc>westliches Ufer</catDesc>
+                  <category xml:id="tlaEZQGV6DAUVEU7PSIUP2B3LPHUM">
+                    <catDesc>Dara</catDesc>
+                  </category>
+                  <category xml:id="tlaHT5AFZMHQ5FSZH7FSWNRRVB7NY">
+                    <catDesc>Manqabad</catDesc>
+                  </category>
+                  <category xml:id="tlaNHQPDAFP25BL3MPRLPXU2TCSKQ">
+                    <catDesc>Qusae</catDesc>
+                  </category>
+                  <category xml:id="tlaQTOOQ4NKC5DRHENFEFV66RZUBY">
+                    <catDesc>Meir</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaAJDSKE22X5DO7FNKB5TZY3KXVY">
+                <catDesc>Beni Hassan und Speos Artemidos</catDesc>
+                <category xml:id="tlaRQUYIDMHKVHCPHBBYB6326VWHU">
+                  <catDesc>Speos Artemidos</catDesc>
+                </category>
+                <category xml:id="tlaWPH2JS6LO5AWDK75YPUXIXKA2Q">
+                  <catDesc>Beni Hassan</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaKBEB43OQ3ZF5JE7N5WRIQRFGYY">
+                <catDesc>zwischen Assiut und Deir Dronka</catDesc>
+                <category xml:id="tla6MAM7ELCSJHCNDCEDDS3OI253I">
+                  <catDesc>Medjedni</catDesc>
+                </category>
+                <category xml:id="tlaGA7YUW532BCUNC2I5RIXZY6NFQ">
+                  <catDesc>Deir Dronka</catDesc>
+                </category>
+                <category xml:id="tlaM7A7SPCUZFHW5CKA7IVEAQKAHA">
+                  <catDesc>Assiut</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaOMQT7YQ5JRCMPH232CO2P26VKQ">
+                <catDesc>zwischen Beni Hassan und Tell el-Amarna</catDesc>
+                <category xml:id="tlaJORE4GYJK5F7DFOZJ2CQ3VGP2Y">
+                  <catDesc>westliches Ufer</catDesc>
+                  <category xml:id="tla2NBYC433Q5ANTDAFFZCNFH2ZPQ">
+                    <catDesc>Tuna el-Gebel</catDesc>
+                  </category>
+                  <category xml:id="tlaN7YO57C7QBEM5OHX5MNIZMAJSQ">
+                    <catDesc>Roda</catDesc>
+                  </category>
+                  <category xml:id="tlaOGW32RJD2RDVBJ3VAYTLQGN4T4">
+                    <catDesc>Mallawi</catDesc>
+                  </category>
+                  <category xml:id="tlaSTJPU2W2XRARXPLSVM4L4OSMC4">
+                    <catDesc>Hermupolis magna</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaZRGESISAP5CQNKWHOJRI4H4XQA">
+                  <catDesc>östliches Ufer</catDesc>
+                  <category xml:id="tla4AYMD3DAKBG6DGK7LTQLW4CTLU">
+                    <catDesc>el-Maabde</catDesc>
+                  </category>
+                  <category xml:id="tlaGY5XTNHWU5CZVDPY7N4RD4OMVI">
+                    <catDesc>Antinooupolis</catDesc>
+                  </category>
+                  <category xml:id="tlaI4NHLIY73ZHFBIZWRW2AJ5F3ZM">
+                    <catDesc>el-Berscheh</catDesc>
+                  </category>
+                  <category xml:id="tlaVO43WZHRPZBLPDJ54VVWYHW3OY">
+                    <catDesc>Menat-Chufu</catDesc>
+                  </category>
+                  <category xml:id="tlaZLDIJHRPZJAN5GZ7NNZS77MRJU">
+                    <catDesc>Scheich Said</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaP6EP5SODRNDS7B5NWHUYMO2MXI">
+                <catDesc>zwischen Fajjum und Beni Hassan</catDesc>
+                <category xml:id="tlaMP4B4NCPUJAHLMZTDLRIBDBZCQ">
+                  <catDesc>östliches Ufer</catDesc>
+                  <category xml:id="tla6NUVJOZF3FFVJAIHWZAKGCHS2M">
+                    <catDesc>Scheich Mubarrak</catDesc>
+                  </category>
+                  <category xml:id="tlaAW6DFAYEUZFKRBHZYVKBFQ2BRA">
+                    <catDesc>Scheich el-Fadl</catDesc>
+                  </category>
+                  <category xml:id="tlaC6P66U3HP5F5TKUGO3V7VFRREE">
+                    <catDesc>Saujet el-Meitin</catDesc>
+                  </category>
+                  <category xml:id="tlaDCJ4PJ2LB5C37HF3HSBTILH6LM">
+                    <catDesc>el-Hibe</catDesc>
+                  </category>
+                  <category xml:id="tlaOPURGU2JLNCJ7EXKNOCLPTTGG4">
+                    <catDesc>es-Siririya</catDesc>
+                  </category>
+                  <category xml:id="tlaPSKJ6UPKQNAJXO7ZH77XF5P2CY">
+                    <catDesc>Tehne (Akoris)</catDesc>
+                  </category>
+                  <category xml:id="tlaSA7IYRTLGJDNPMZ5MNJFWSYHBU">
+                    <catDesc>Scharuna</catDesc>
+                  </category>
+                  <category xml:id="tlaTRNCUPI5L5GK7PBZ62WQC4PE7E">
+                    <catDesc>Hebenu</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaXIQBE6XISRGJTLNHKVE62Y23G4">
+                  <catDesc>westliches Ufer</catDesc>
+                  <category xml:id="tla3S2ZY76R7BF7NJCOFQZIGYGL24">
+                    <catDesc>Abusir el-Meleq</catDesc>
+                  </category>
+                  <category xml:id="tla5K5MFHJIAJDX3HZ5BSH2IICN2U">
+                    <catDesc>el-Lahun (Illahun)</catDesc>
+                    <category xml:id="tla6YDVZ6RHSBAIJEN5YNOJZPTECE">
+                      <catDesc>Nekropole</catDesc>
+                    </category>
+                    <category xml:id="tlaXAAEKHSKSJDQJAYLGFIGGZWUSM">
+                      <catDesc>Siedlung</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaAOF7W5GQXBDARKIID5DM2SPM2Q">
+                    <catDesc>Oxyrhynchos</catDesc>
+                  </category>
+                  <category xml:id="tlaBPUQJWLRIVCHJJ2NMCTASQQKSM">
+                    <catDesc>Harageh</catDesc>
+                  </category>
+                  <category xml:id="tlaDFSNUEXE6JA3XIJ4NZGURE3RZQ">
+                    <catDesc>Maiyana</catDesc>
+                  </category>
+                  <category xml:id="tlaGDJZ5TUTS5FGDI3XKLKEOWBKLQ">
+                    <catDesc>el-Minieh</catDesc>
+                  </category>
+                  <category xml:id="tlaKFA4OETSINAEZMWPIFZELLQBNA">
+                    <catDesc>Herakleopolis magna</catDesc>
+                  </category>
+                  <category xml:id="tlaSNYAXVBAMRFHVA6MDEWJJQ4XVE">
+                    <catDesc>Balansura</catDesc>
+                  </category>
+                  <category xml:id="tlaVMLZOM2MXZCYPNFHGX5I5S3VP4">
+                    <catDesc>Deschasche</catDesc>
+                  </category>
+                  <category xml:id="tlaZRXRXA7K5BACTHHDLTSLG2GTBA">
+                    <catDesc>Sedment</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaUK2KUTLMDJAKZPS7DCG2NU4ISM">
+                <catDesc>zwischen Kairo und Fajjum</catDesc>
+                <category xml:id="tla32B64TXG6NHEZNLL7NNPOBDSTU">
+                  <catDesc>östliches Ufer</catDesc>
+                  <category xml:id="tlaC2WYK4H6QVGURE6KW6ANFXU5KU">
+                    <catDesc>Wadi Garawi</catDesc>
+                  </category>
+                  <category xml:id="tlaGWZSUYUOXZAVLPVB2FRT5AJJKE">
+                    <catDesc>Kairo</catDesc>
+                  </category>
+                  <category xml:id="tlaHJMQUWO3ZRHPVNPR3IJPFAVN7M">
+                    <catDesc>Atfih</catDesc>
+                  </category>
+                  <category xml:id="tlaHXK3G4OJ4JFIPOXMPZE5LL5WCI">
+                    <catDesc>Heluan</catDesc>
+                  </category>
+                  <category xml:id="tlaMGEPQWTLB5EHXHSUEZF4WMLPHA">
+                    <catDesc>Tura</catDesc>
+                  </category>
+                  <category xml:id="tlaNQTB3CIFTZCJRCWJRLGNHAC3OU">
+                    <catDesc>Maadi</catDesc>
+                  </category>
+                  <category xml:id="tlaUTOE5VBTO5FKZMZX65IMFZF4PI">
+                    <catDesc>Lischt</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaPCZACZVC7JCHXNPXO2XJT4WWS4">
+                  <catDesc>westliches Ufer</catDesc>
+                  <category xml:id="tla22XDL7RDBFGW7CEJYPNQG3HYEU">
+                    <catDesc>Meidum</catDesc>
+                  </category>
+                  <category xml:id="tlaCFVNIMLRNZAKXJAN7SHA5XSZYM">
+                    <catDesc>Gebel er-Rus</catDesc>
+                  </category>
+                  <category xml:id="tlaEEWOTHSWCJB3HMJ4LQPYJT4IRQ">
+                    <catDesc>el-Gerzeh</catDesc>
+                  </category>
+                  <category xml:id="tlaEYL2L7M2SZCFXENP23R2P6HISI">
+                    <catDesc>Memphis</catDesc>
+                  </category>
+                  <category xml:id="tlaFHCXX5V3NNDE3L3BPCI6H4TLWY">
+                    <catDesc>Saujet el-Arjan</catDesc>
+                  </category>
+                  <category xml:id="tlaG3UOUVQETVA6DIBKA52PPC5V5Y">
+                    <catDesc>Tarchan</catDesc>
+                  </category>
+                  <category xml:id="tlaGGE4E7XI6NBFDK7KZQ53JDGAJE">
+                    <catDesc>Saujet Abu Mesallem</catDesc>
+                  </category>
+                  <category xml:id="tlaIB62VUULORB6THW24GAK2A5TOY">
+                    <catDesc>Dahschur</catDesc>
+                  </category>
+                  <category xml:id="tlaN7QFGPYE6ND55LIMSXLZ7HUAHY">
+                    <catDesc>Abu Gurab</catDesc>
+                  </category>
+                  <category xml:id="tlaO5AYJCUXENDODEGUIMCH2YWXWM">
+                    <catDesc>Abusir</catDesc>
+                  </category>
+                  <category xml:id="tlaOBWGLZS4ZRBM5BPAYARBF4AJBQ">
+                    <catDesc>Kafr Ammar</catDesc>
+                  </category>
+                  <category xml:id="tlaPWJMHAWWJBBKTNH5IMZYHOLBNY">
+                    <catDesc>Abu Roasch</catDesc>
+                  </category>
+                  <category xml:id="tlaRRQHQZRF6JAGXM36AK5VTUZKV4">
+                    <catDesc>Masghuna</catDesc>
+                  </category>
+                  <category xml:id="tlaTZ7HFSUO3ZCLLAAXX3AEWXALIE">
+                    <catDesc>Gisa</catDesc>
+                  </category>
+                  <category xml:id="tlaYE5ZC7D6LZDTZN2IQKMCRQHW44">
+                    <catDesc>Saqqara</catDesc>
+                    <category xml:id="tlaEWXT4Q4QYBAOHELCDQ5VPXNRXQ">
+                      <catDesc>Nekropolen</catDesc>
+                    </category>
+                    <category xml:id="tlaXVL3OFT6FRBKHI2ID3HMPWLVDY">
+                      <catDesc>Serapeum</catDesc>
+                    </category>
+                    <category xml:id="tlaYSHJQHOKUZHKJEJMNXA54O7WTE">
+                      <catDesc>Pyramiden</catDesc>
+                    </category>
+                  </category>
+                  <category xml:id="tlaZMZ63WJE2NE5ZGLQ6JMREE67B4">
+                    <catDesc>Riqqeh</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaY2H7KF7JC5HKHD4QXSXPZEH26Y">
+                <catDesc>Tell el-Amarna und Hatnub</catDesc>
+                <category xml:id="tlaE2J4NAPJFBHQTGSFIKRCFC6V4E">
+                  <catDesc>Tell el-Amarna</catDesc>
+                </category>
+                <category xml:id="tlaGGN7WFYXI5DTLG43NOFG7SVJ6A">
+                  <catDesc>Hatnub</catDesc>
+                </category>
+              </category>
+            </category>
+            <category xml:id="tlaKWWFQI5HHNE2BNRUV6EAFS7J5I">
+              <catDesc>Niltal südlich des 2. Katarakts bis zum 3. Katarakt</catDesc>
+              <category xml:id="tla3J57LVGE65EWPEJQM6NGWERKBA">
+                <catDesc>Sesibi</catDesc>
+              </category>
+              <category xml:id="tla4VV2ZQFQSNFUXL7GLJ2QP3BFAM">
+                <catDesc>Askut</catDesc>
+              </category>
+              <category xml:id="tla7P7Z2OTKOJDH7B3VOHVKSJ33RQ">
+                <catDesc>Semna</catDesc>
+              </category>
+              <category xml:id="tlaCHXFPBC7SBE2TB5O72GRHGNMZE">
+                <catDesc>Mirgissa</catDesc>
+              </category>
+              <category xml:id="tlaKGC2HFYONVDC7IRGXOYXCMHB4M">
+                <catDesc>Amara West</catDesc>
+              </category>
+              <category xml:id="tlaNGHY34ANYRC3TOUTJFTCNXQUYE">
+                <catDesc>Sai</catDesc>
+              </category>
+              <category xml:id="tlaPZZM3SUQPNDDVKNF3CIBOBXRXY">
+                <catDesc>Amara East</catDesc>
+              </category>
+              <category xml:id="tlaUCILL36KLZFH7DAMIITUCYCMWU">
+                <catDesc>Sedeinga</catDesc>
+              </category>
+              <category xml:id="tlaVC2HMWLXQNFI7OO5C5A2DQVX2M">
+                <catDesc>Kumme</catDesc>
+              </category>
+              <category xml:id="tlaWCMER7GMDVDGPE6SBI4A323HRI">
+                <catDesc>Uronarti</catDesc>
+              </category>
+              <category xml:id="tlaZO7AKABNLBDAVKSPREDRGBSARE">
+                <catDesc>Soleb</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaPMP7VF6LBNG3FKPINED7YOO3LM">
+              <catDesc>Wüste westlich des Niltals (Staatsgebiet Ägypten und Sudan)</catDesc>
+              <category xml:id="tlaAGPAHG75QRFV5OULSV2MQG3WO4">
+                <catDesc>Oase Kurkur</catDesc>
+              </category>
+              <category xml:id="tlaC4SPEOALFBAFBHXHFISVMPRQ4A">
+                <catDesc>Oase Dachla</catDesc>
+                <category xml:id="tlaLBFSRL3U65DEVGDTGRAPWRAU5Y">
+                  <catDesc>Balat</catDesc>
+                </category>
+                <category xml:id="tlaMRE4ONGFNJE6JBQ54NMN2YOPK4">
+                  <catDesc>Deir el-Hagar</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaCJT44PZWENHFPIZGQ72NN3H44A">
+                <catDesc>Oase Dungul</catDesc>
+              </category>
+              <category xml:id="tlaD3QHNMZXFVB2HF2YSAR57BDLSM">
+                <catDesc>Oase Selima</catDesc>
+              </category>
+              <category xml:id="tlaFKBDCIH3FNHYFN4L56HWVZTFIE">
+                <catDesc>Oase Charga</catDesc>
+                <category xml:id="tla5ISL7EXGYJHPRPFN24WHY5P6MU">
+                  <catDesc>Qasr Gueida</catDesc>
+                </category>
+                <category xml:id="tlaA6HKMDHMHFG5VHZZZ4O5LEUOWU">
+                  <catDesc>Gebel et-Teir</catDesc>
+                </category>
+                <category xml:id="tlaIVSRGWTX5BCPFDTPCUTBPPG2BE">
+                  <catDesc>Qasr Dusch</catDesc>
+                </category>
+                <category xml:id="tlaVUPHX5FDDJF6DK2YNH5YYGCOHI">
+                  <catDesc>Hibis</catDesc>
+                </category>
+                <category xml:id="tlaWBISS7Q7TBABBITCXNXFZL66N4">
+                  <catDesc>Qasr Sajjan</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaPYXD5MKDMRHM5D6OMV24BZLF5Q">
+                <catDesc>Wadi 'n-Natrun</catDesc>
+              </category>
+              <category xml:id="tlaSWRTITVT45BSBHQXPAYKBINNME">
+                <catDesc>Oase Farafra</catDesc>
+              </category>
+              <category xml:id="tlaU4DBTWP5RVHGHBAUNQWG5GL7ZY">
+                <catDesc>Oase Siwa</catDesc>
+              </category>
+              <category xml:id="tlaYQ6F5S3RIFFXDDDA4GFGGBU2GI">
+                <catDesc>Oase Bahrija</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaQOWZUQU5KVA5ZLY4L3SCWZAKTI">
+              <catDesc>Niltal südlich des 4. Katarakts bis Chartum</catDesc>
+              <category xml:id="tla33X5KPWRTNDKNAKNZCO7QAIAMQ">
+                <catDesc>Meroe</catDesc>
+              </category>
+              <category xml:id="tlaII2NXFEVRNFKBJZ2FOCXLGJXEU">
+                <catDesc>Naga</catDesc>
+              </category>
+              <category xml:id="tlaNLFGBK5HWBBO5JIOMD3M772V4I">
+                <catDesc>Musawwarat es-Sufra</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaTEG7WX4B3VCTHBUQLPCNM4RHFE">
+              <catDesc>Nordafrika</catDesc>
+              <category xml:id="tla6TU623R66JBBVJMJROR4ICRLKY">
+                <catDesc>Umm er-Raham</catDesc>
+              </category>
+              <category xml:id="tlaU3I33GWG4JEIXGC56EJDTDCSDI">
+                <catDesc>Berenike (kyrenäische Stadt an der Ostküste der Großen Syrte, heute Bengazi)</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaTIQ4FWZDNZGJHDOQ5IOQMEFM4E">
+              <catDesc>Vorderasien und Europa</catDesc>
+              <category xml:id="tla2GUN2SILEBGNHDMNDRBU37FXPM">
+                <catDesc>Timna'</catDesc>
+              </category>
+              <category xml:id="tla2HRFZYCFRBBVXHATBBN7UKOFQY">
+                <catDesc>Hamath. B. Tell el Hamme (13 km südlich von Besan)</catDesc>
+              </category>
+              <category xml:id="tla5N7EFKJ3HBEKFEQWSBFKSSSXEA">
+                <catDesc>Ostia antica</catDesc>
+              </category>
+              <category xml:id="tla5TLIW3RY5NAKNF4CS7NJ2O5WMM">
+                <catDesc>Benevent</catDesc>
+              </category>
+              <category xml:id="tlaA77DPUMJ6ZD4VE53RZGCJOVRGE">
+                <catDesc>Assur</catDesc>
+              </category>
+              <category xml:id="tlaASNDBNLBEZFQDFWMQ7P5Y76DHE">
+                <catDesc>Hamath. C. Hamat Tiberias (südlich von Tiberias)</catDesc>
+              </category>
+              <category xml:id="tlaBFVOAF5NLBGBTOBBROOXLXARWI">
+                <catDesc>Hamath. A. Hamah (am Orontes, Mittelsyrien)</catDesc>
+              </category>
+              <category xml:id="tlaBLCB4C7LAVAHRGQSMHY5HJUTRI">
+                <catDesc>Pompeji</catDesc>
+              </category>
+              <category xml:id="tlaEUATHPGDEFCFLKWUX3J3YALGGE">
+                <catDesc>Raphia</catDesc>
+              </category>
+              <category xml:id="tlaGHKHPFSFDRC6RH65KFMQEOOVWM">
+                <catDesc>Gezer</catDesc>
+              </category>
+              <category xml:id="tlaHWHDNIG4SJAKBJPDZDFGQD66UM">
+                <catDesc>Beirut</catDesc>
+              </category>
+              <category xml:id="tlaKEWO73CGSJCFDBJXHLHQ4TALQI">
+                <catDesc>Gasa</catDesc>
+              </category>
+              <category xml:id="tlaLXWZAW4Z6JGSZDYBUZKCKB2DXM">
+                <catDesc>Rom</catDesc>
+              </category>
+              <category xml:id="tlaPAZVKLJLXBE5TKLFRBKD5R4LTI">
+                <catDesc>Tayma</catDesc>
+              </category>
+              <category xml:id="tlaQF6KKTLEMVCALOZRON4JAI5IGM">
+                <catDesc>Hazor</catDesc>
+              </category>
+              <category xml:id="tlaXYAORBBGBVGMJICREDG7A5ETUA">
+                <catDesc>Qatna</catDesc>
+              </category>
+              <category xml:id="tlaZLJ4J2EB3RGJ3F6MTS7PQCUBSQ">
+                <catDesc>Byblos</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaVKVTR4BA7NAX7PXTNFZ45JEKK4">
+              <catDesc>(unbekannt)</catDesc>
+            </category>
+          </category>
+          <category xml:id="tlaMXWX4WG43ZHI7D4RLTGK3IBGXY">
+            <catDesc>9 = Datierungen</catDesc>
+            <category xml:id="tlaD3R5CH5NZBDA7IZMCKKJPWYZKU">
+              <catDesc>(Jahrhunderte v.Chr.)</catDesc>
+              <category xml:id="tla2ZIZTYBKYNFNVFTFBA32CAAY7A">
+                <catDesc>1. Jhdt. v.Chr.</catDesc>
+                <category xml:id="tla3V5NOJIC3VBIZBA7QCD6OFSAQY">
+                  <catDesc>4. Viertel 1. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tla7LG7A3WDXNFCVDQICH6CXVIJXM">
+                  <catDesc>1. Hälfte 1. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaEIO2LWBQURGJVC7LQZE5UHGMPU">
+                  <catDesc>2. Viertel 1. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaOSHKAITIJJAOVE4XNMQOVUA6JA">
+                  <catDesc>2. Hälfte 1. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaUQRNNAQXKBBLFEREMXSODORMFY">
+                  <catDesc>1. Viertel 1. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaZLKNXXGL7VA7VEECINB7NS65WI">
+                  <catDesc>3. Viertel 1. Jhdt. v.Chr.</catDesc>
+                </category>
+              </category>
+              <category xml:id="tla5I4CKE7K4FE67NZU4FYVG66GG4">
+                <catDesc>9. Jhdt. v.Chr.</catDesc>
+                <category xml:id="tlaEHYAY2QQMFBLXE4DYP6AR3ZN3I">
+                  <catDesc>4. Viertel 9. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaFMKPIG5ISZH6JOPISBT7M5INSU">
+                  <catDesc>2. Hälfte 9. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaKNIVMJRE45AXBDQFA37HTNZZF4">
+                  <catDesc>1. Hälfte 9. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaTA5P36EB5NABBB6Q4J22ZQNF3I">
+                  <catDesc>1. Viertel 9. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaVZHQZE6KPJFARE6JBNNOWVD7JI">
+                  <catDesc>3. Viertel 9. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaZBQWVJND7ZCKNG4LSV64RXUJJU">
+                  <catDesc>2. Viertel 9. Jhdt. v.Chr.</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaJ5JVKLZBXJH5VGTKXCTPBJ2KZE">
+                <catDesc>4. Jhdt. v.Chr.</catDesc>
+                <category xml:id="tla2VUPFL5N5FCC7FF4ECKTUY35Q4">
+                  <catDesc>2. Hälfte 4. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tla33LKEBW63FFSNCVMGOSMDBGFNQ">
+                  <catDesc>1. Hälfte 4. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaCSL4LTLEQBBSXGZ353PCVGCFZQ">
+                  <catDesc>1. Viertel 4. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaIPYKL4XDHJBFJE7D7AZ47HXVIM">
+                  <catDesc>3. Viertel 4. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaPYJNB3V355DMZERYYWMFHZ5NNI">
+                  <catDesc>4. Viertel 4. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaSX4FBQBUQFCSHBJFDSCPRLRRY4">
+                  <catDesc>2. Viertel 4. Jhdt. v.Chr.</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaL34UY7MQCRB2JCBPNZKLGP2ZL4">
+                <catDesc>2. Jhdt. v.Chr.</catDesc>
+                <category xml:id="tlaBZNFBS76HVCPTJSYIUV22TSXBQ">
+                  <catDesc>2. Hälfte 2. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaDZUK4KHXJZBK5DIDGR6JDOMV4A">
+                  <catDesc>2. Viertel 2. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaHXGOS6R4BFGJRAFU6ZWTFAIYOA">
+                  <catDesc>1. Hälfte 2. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaPTSGMJ72MVDM3LGZS63DM4ENQI">
+                  <catDesc>1. Viertel 2. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaWFXACEBXJZA77IUNL2T2G4WJWA">
+                  <catDesc>4. Viertel 2. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaXQOCZAYRS5B4FA7XUIXRLZXOCA">
+                  <catDesc>3. Viertel 2. Jhdt. v.Chr.</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaNVFQR5PSCZEFPELBXY57W2VQPM">
+                <catDesc>3. Jhdt. v.Chr.</catDesc>
+                <category xml:id="tla2EPYVX63FFBRJBCOEKC2E42K6Y">
+                  <catDesc>2. Viertel 3. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tla2RNQRYRR75HBHJQXKCIINNWCIE">
+                  <catDesc>2. Hälfte 3. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tla7FG3AE5TKBHCBCQIUHZIQS5SPE">
+                  <catDesc>3. Viertel 3. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaCXCXYSLLUFHMPGQ7ROYMAHLCAA">
+                  <catDesc>1. Hälfte 3. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaRDSBFVI3QJG7XNZOXVDLV3LU6I">
+                  <catDesc>1. Viertel 3. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaRUEGPD2BQBAIRAF35NA3L4VJHY">
+                  <catDesc>4. Viertel 3. Jhdt. v.Chr.</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaPBLVUQXCI5HETLV6ICT7YYYOZI">
+                <catDesc>7. Jhdt. v.Chr.</catDesc>
+                <category xml:id="tlaQIVC46ND4BDUXAWR4EYMD4AUME">
+                  <catDesc>4. Viertel 7. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaR7RP4HBK7FCSTB74WGGFMBAXJE">
+                  <catDesc>1. Hälfte 7. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaVPDCMRCERVH3JBGCJQFWOEV4PE">
+                  <catDesc>2. Viertel 7. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaVRYK3DNABFC37OCSLTNEE6SX2M">
+                  <catDesc>2. Hälfte 7. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaYJ43LQBBSNEVHJTOY2KXTZ4KSQ">
+                  <catDesc>1. Viertel 7. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaZ7SE63TCNBHDNCAJXDFKZVI43M">
+                  <catDesc>3. Viertel 7. Jhdt. v.Chr.</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaSUWAELMXDVA5VF7G6BGY5FP24Q">
+                <catDesc>5. Jhdt. v.Chr.</catDesc>
+                <category xml:id="tla2SVJUWTG65CGBPSRR2JVGCFZQI">
+                  <catDesc>3. Viertel 5. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tla37AKJCT3O5EXHKZVR4OERWJUMM">
+                  <catDesc>2. Viertel 5. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tla3RSAUA2SMZGCDEMLGVH47P6IOM">
+                  <catDesc>1. Hälfte 5. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaGGPOQYXYZBDUZNTFBXUVFYGDEM">
+                  <catDesc>2. Hälfte 5. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaM5RNBQZBHJDSJLRFTESD5PXUUM">
+                  <catDesc>4. Viertel 5. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaSWTOWPX765HQBK4FBHAFFBF4XE">
+                  <catDesc>1. Viertel 5. Jhdt. v.Chr.</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaSYVSDPY4UFC7VFGH34ZDTEPMMM">
+                <catDesc>6. Jhdt. v.Chr.</catDesc>
+                <category xml:id="tla5RWQE6I76ZDJ7C6RZZHDZ5NZOA">
+                  <catDesc>2. Hälfte 6. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tla742V5NN54JCLRMXZSWDVTG4YK4">
+                  <catDesc>4. Viertel 6. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tla7WVJGW33WFHVZI2UBOIDWIKIPI">
+                  <catDesc>1. Hälfte 6. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaONBKOHQ33BA2ZC2SC2HQHOG3UY">
+                  <catDesc>2. Viertel 6. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaRDVGZ5PV4BAGRG2ZBOUB4SBJHI">
+                  <catDesc>3. Viertel 6. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaWHI6OSNIHJEDFI4VOSPL3NGNQM">
+                  <catDesc>1. Viertel 6. Jhdt. v.Chr.</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaTIKGPKBTXVA6PHCKCHQJ6VIM2M">
+                <catDesc>8. Jhdt. v.Chr.</catDesc>
+                <category xml:id="tla3T5D7CE7MZFTXM5NHH6TB354A4">
+                  <catDesc>1. Hälfte 8. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tla6SL7CB3TV5GCDOFNO6SEKXCPDU">
+                  <catDesc>1. Viertel 8. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaAY7RFFECHJFYXJVVW7UO73DNDM">
+                  <catDesc>3. Viertel 8. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaG4YYFKH7ARFA5JOTIHYTNEI4LY">
+                  <catDesc>2. Viertel 8. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaUH3G5FM2SREITBEJ5RTX7TZYZ4">
+                  <catDesc>2. Hälfte 8. Jhdt. v.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaVIZ3CULWTNB6FPFNJ3OBEDTL5I">
+                  <catDesc>4. Viertel 8. Jhdt. v.Chr.</catDesc>
+                </category>
+              </category>
+            </category>
+            <category xml:id="tlaDUVGWT7GSRCKDM5LFTGU6MZ3GY">
+              <catDesc>(Epochen und Dynastien)</catDesc>
+              <category xml:id="tla3GGZCLNRQVF6PAEQA6LCFBNE6M">
+                <catDesc>Zweite Zwischenzeit</catDesc>
+                <category xml:id="tlaE4VXX5LISZC2XIR6AYPM3Y3TQI">
+                  <catDesc>15. / 16. / 17. Dynastie</catDesc>
+                </category>
+                <category xml:id="tlaGKB34UGJLZA6ZPUYTDRQ7UNPH4">
+                  <catDesc>13. / 14. Dynastie</catDesc>
+                  <category xml:id="tlaQXLWLXSIOBEBRBINKZ7WPX6C3U">
+                    <catDesc>Sebekhotep IV.</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tla7FUWX6PWFJDAXEWQDOAA4FYXFU">
+                <catDesc>prädynastische Zeit</catDesc>
+                <category xml:id="tla6YAAR2WRI5F6BLP6YMW3G67P6Q">
+                  <catDesc>Neolithikum vor der Badari-Kultur</catDesc>
+                </category>
+                <category xml:id="tlaFMNBFXWGA5C2TEXFRDXOGXBEPE">
+                  <catDesc>Badari-Kultur</catDesc>
+                </category>
+                <category xml:id="tlaIPXSCTKV4REDHIXWTZWDXVXJWY">
+                  <catDesc>Naqada III</catDesc>
+                </category>
+                <category xml:id="tlaP5F2WOP6YZGBHK5KCSCP2UXJHM">
+                  <catDesc>Naqada I</catDesc>
+                </category>
+                <category xml:id="tlaWLIRCHQ3DRF4ZOTIREDVCPKC5A">
+                  <catDesc>Naqada II</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaBILVGTX4DVEERA2TQ2DFPYYTK4">
+                <catDesc>Thinitenzeit</catDesc>
+                <category xml:id="tlaRHWO4WZITFG7LC64PRWKXGSBLE">
+                  <catDesc>1. Dyn.</catDesc>
+                  <category xml:id="tla6OQR45RINVBEXKRXU67UUYG5WI">
+                    <catDesc>Semerchet / Semempses</catDesc>
+                  </category>
+                  <category xml:id="tla7W7ATEIEBBB7JBXHCOIEEDK3X4">
+                    <catDesc>( ) / Itj</catDesc>
+                  </category>
+                  <category xml:id="tlaC36PPQYVH5G4LLVMYYF4KAQ7V4">
+                    <catDesc>Den / Usaphais</catDesc>
+                  </category>
+                  <category xml:id="tlaDXQSYPUVZ5ENLH22UECZNJZFSY">
+                    <catDesc>Aha / Menes</catDesc>
+                  </category>
+                  <category xml:id="tlaIT24BFWQQ5FL7NSNEPBYN3JUQA">
+                    <catDesc>Wadj / Ita</catDesc>
+                  </category>
+                  <category xml:id="tlaO23PARFR5BEZDPKFYTPTWNISIM">
+                    <catDesc>Adj-ib / Miebis</catDesc>
+                  </category>
+                  <category xml:id="tlaWJGLV3QK3BEPZGHRP6D5EYZMOQ">
+                    <catDesc>Qa-a / Bieneches</catDesc>
+                  </category>
+                  <category xml:id="tlaWOKINRAGTVBY5ER4WSNTGPTAIU">
+                    <catDesc>Djer / Athotis</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaRRYWO76XVZHRHDJI4376RX5OXM">
+                  <catDesc>2. Dyn.</catDesc>
+                  <category xml:id="tla727RS3OFRFACXG74OQBUG4CYYA">
+                    <catDesc>unteräg. Könige parallel zu Peribsen</catDesc>
+                  </category>
+                  <category xml:id="tlaGFTQ3LZ2NFFXFN5WCQWTHB25UA">
+                    <catDesc>Nebre / Kiechos</catDesc>
+                  </category>
+                  <category xml:id="tlaJSG47O3RY5DP3JBUHLKVBBPI4U">
+                    <catDesc>Nineter / Binothis</catDesc>
+                  </category>
+                  <category xml:id="tlaKJ7NJARIAFDH3DQBXQXJPIHK44">
+                    <catDesc>Hetepsechemui / Boethos</catDesc>
+                  </category>
+                  <category xml:id="tlaNLBRXU2SHBA53A3CBNJNFJUNEU">
+                    <catDesc>Sechem-ib / Sethenes</catDesc>
+                  </category>
+                  <category xml:id="tlaOUIVW3MIHNHIPC7R333PQRIGYM">
+                    <catDesc>Chasechemui / Chasechem</catDesc>
+                  </category>
+                  <category xml:id="tlaVHOWISQK4FB6LJYLLQUBLBINUU">
+                    <catDesc>Peribsen</catDesc>
+                  </category>
+                  <category xml:id="tlaY7ZEMNUP3VGFNMNVJTHPC5A7VY">
+                    <catDesc>Weneg-Nebti / Tlas</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaZ4YNGVLCKBBYTETIZHVGTUQAOM">
+                  <catDesc>0. Dyn.</catDesc>
+                  <category xml:id="tla2SRQ3JK6ZJDMNGUGSSLVAS2EUY">
+                    <catDesc>"Mund"</catDesc>
+                  </category>
+                  <category xml:id="tla3HF272323RDJXBXFYT7IVUSFSU">
+                    <catDesc>Skorpion</catDesc>
+                  </category>
+                  <category xml:id="tla7E6ZCCAAKJAUHM2T67D4D5G5CI">
+                    <catDesc>Narmer</catDesc>
+                  </category>
+                  <category xml:id="tlaFQEHFFBL6ZEA7LVBPHY4A6JP7A">
+                    <catDesc>"Arme" / Ka / Sechen</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaDBDBZEFDGZGGBMERHVKJ6PMPHQ">
+                <catDesc>Altes Reich</catDesc>
+                <category xml:id="tla7QKSXYEUCFHNBCFOS7XUZFGCJU">
+                  <catDesc>3. Dyn.</catDesc>
+                  <category xml:id="tla35QR2MPL3NF4HIHPDLJJF7NC6U">
+                    <catDesc>Huni / Qahedjet</catDesc>
+                  </category>
+                  <category xml:id="tlaATAYWXKNBVHT3FWOC65D5273BU">
+                    <catDesc>Nebka / Sanacht</catDesc>
+                  </category>
+                  <category xml:id="tlaFDTMSNLYBNFERMB64GHLI4OXKI">
+                    <catDesc>( ) / Chaba</catDesc>
+                  </category>
+                  <category xml:id="tlaI3U2PPJRONEWZDZE3DPBLRH35Y">
+                    <catDesc>Djoser / Netjeri-chet</catDesc>
+                  </category>
+                  <category xml:id="tlaKVW4S6I4ZRECNMJTM6FFTFLMYI">
+                    <catDesc>Djeserteti / Sechemchet</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaGH2RXLTQ2BCEHPQ6R2SPBER7OM">
+                  <catDesc>6. Dyn.</catDesc>
+                  <category xml:id="tla3DBCMXAP3ZA2TCSSOGPRVOXKME">
+                    <catDesc>6. Dyn. nach Pepi II.</catDesc>
+                  </category>
+                  <category xml:id="tla3ESLSUHOURDCPFZ2UDUJACFV7Q">
+                    <catDesc>Pepi II.</catDesc>
+                  </category>
+                  <category xml:id="tlaACJUYKAESFH4JAWU2KOOHKW3HM">
+                    <catDesc>Pepi I.</catDesc>
+                  </category>
+                  <category xml:id="tlaEBTM44JP7NA5BBJ4XXKU7RMX7Y">
+                    <catDesc>Userkare</catDesc>
+                  </category>
+                  <category xml:id="tlaH5RYRC56WNGXFFMSSKXFWRRDLE">
+                    <catDesc>Merenre</catDesc>
+                  </category>
+                  <category xml:id="tlaJDHTPUAWMZBCZJDBBD2JP4PAD4">
+                    <catDesc>Teti</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaOSQYKCRYMFGJRD3LESUKPOZG4E">
+                  <catDesc>8. Dyn.</catDesc>
+                </category>
+                <category xml:id="tlaRI3TSGKXUFCE3HV43BX2N2MJVE">
+                  <catDesc>5. Dyn.</catDesc>
+                  <category xml:id="tla3X3HIVLWDVCHVM7OKEQG4RIKIA">
+                    <catDesc>Sahure</catDesc>
+                  </category>
+                  <category xml:id="tlaE3KJFINUWJGZHI3ROCURKZQF2Q">
+                    <catDesc>Neferirkare</catDesc>
+                  </category>
+                  <category xml:id="tlaF2WUXBPF6ND7ZAEU4GIZTIBOQ4">
+                    <catDesc>Niuserre</catDesc>
+                  </category>
+                  <category xml:id="tlaJISVUMEI3NG25FQDYLYD3R6MJ4">
+                    <catDesc>Schepseskare</catDesc>
+                  </category>
+                  <category xml:id="tlaKQY2F5SJVBBN7GRO5WUXKG5M6M">
+                    <catDesc>Djedkare Asosi</catDesc>
+                  </category>
+                  <category xml:id="tlaLOCJJXDY4RDZRFMENMXLKBKYYQ">
+                    <catDesc>Neferefre</catDesc>
+                  </category>
+                  <category xml:id="tlaSC4IKOXD5NFI7B6FO3LGEM4P34">
+                    <catDesc>Menkauhor</catDesc>
+                  </category>
+                  <category xml:id="tlaVXCXYJF7QFDKHG4XNG7B7JSOIM">
+                    <catDesc>Unas</catDesc>
+                  </category>
+                  <category xml:id="tlaWM77TXYU2VAYJJGYHPUZPZXSGA">
+                    <catDesc>Userkaf</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaWCVSHAEC7ZA4FKQOWR4E2GC6OM">
+                  <catDesc>4. Dyn.</catDesc>
+                  <category xml:id="tla4SJRB25AURBUZMSZBBXRRHDO3A">
+                    <catDesc>Djedefre</catDesc>
+                  </category>
+                  <category xml:id="tla4XVWKCUISJDA5OWB724D2CPBRI">
+                    <catDesc>Chefren</catDesc>
+                  </category>
+                  <category xml:id="tlaB6LUZDUOMJDC3G3JVUHHECQCAM">
+                    <catDesc>Schepseskaf</catDesc>
+                  </category>
+                  <category xml:id="tlaHOX5L57VFFDMTBCTWJNSHQ3OJA">
+                    <catDesc>Snofru</catDesc>
+                  </category>
+                  <category xml:id="tlaIS52YO4UPBG6ZO5BFFVWJ26OWY">
+                    <catDesc>Cheops</catDesc>
+                  </category>
+                  <category xml:id="tlaONSX4LNQWJH7LHFD64LQJIWJAA">
+                    <catDesc>Bicheris</catDesc>
+                  </category>
+                  <category xml:id="tlaPPBZN6VP2ZEXPAUZOK3ST3SO3M">
+                    <catDesc>Tamphthis</catDesc>
+                  </category>
+                  <category xml:id="tlaWEB5KGYGWJFUTDVTZP5PO5GBOY">
+                    <catDesc>Mykerinos</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaHYYNMJRFTVFIHB7JUA6M2QW3LQ">
+                <catDesc>Makedonen, Ptolemäer</catDesc>
+                <category xml:id="tla5EXFFIIQ2BFLJBUPM345Q52RYE">
+                  <catDesc>Ptolemaios XIII.</catDesc>
+                </category>
+                <category xml:id="tla6CEMTQHBPVCKRGBPZV3SBCJFHM">
+                  <catDesc>Ptolemaios II. Philadelphos</catDesc>
+                </category>
+                <category xml:id="tla7SZBT5EB75DZVEYNMMNDRAR6WM">
+                  <catDesc>Ptolemaios I. Soter</catDesc>
+                </category>
+                <category xml:id="tlaBB2LXNAEFRHAFOQHR7VCS2GUDE">
+                  <catDesc>Kleopatra VII.</catDesc>
+                </category>
+                <category xml:id="tlaBHAOO6DORBCPVDTRZTJSLM3MHM">
+                  <catDesc>Ptolemaios VI. Philometor</catDesc>
+                </category>
+                <category xml:id="tlaBJBGAQ4PCJHSRISGG6ZIEP26YI">
+                  <catDesc>Alexander IV.</catDesc>
+                </category>
+                <category xml:id="tlaEAIXVOD3ZFAQXCGUYG2MUERGXU">
+                  <catDesc>Ptolemaios VIII. Euergetes II.</catDesc>
+                </category>
+                <category xml:id="tlaEB27VJIJZZFPLDR5ONLBMQUJQY">
+                  <catDesc>Philipp Arrhidaios</catDesc>
+                </category>
+                <category xml:id="tlaETFKXMIJTBE45KASN7GX4BG5VI">
+                  <catDesc>Ptolemaios XIV. Philopator</catDesc>
+                </category>
+                <category xml:id="tlaKAK54XJY4BBU3PXESJCBL6YQHM">
+                  <catDesc>Ptolemaios V. Epiphanes</catDesc>
+                </category>
+                <category xml:id="tlaM2BT2KZR4RAYJIWGOO6N3P4C64">
+                  <catDesc>Alexander der Große</catDesc>
+                </category>
+                <category xml:id="tlaMHVALMEFXBE7BKJGFSD7LCSRVM">
+                  <catDesc>Ptolemaios XII. Philopator Philadelphos Neos Dionysos</catDesc>
+                </category>
+                <category xml:id="tlaMP63BC4W6NHILLBC2NAFBF7ZTA">
+                  <catDesc>Ptolemaios IX. Soter II.</catDesc>
+                </category>
+                <category xml:id="tlaPCA5EX57QNGOFAJAM3SOI6VV4M">
+                  <catDesc>Ptolemaios VII. Neos Philopator</catDesc>
+                </category>
+                <category xml:id="tlaQU2M4UGNUNDHTE5DUANDIT5K4M">
+                  <catDesc>Ptolemaios X. Alexander I.</catDesc>
+                </category>
+                <category xml:id="tlaTU4NLFP3EBHXHGMDL7F7IOGFCQ">
+                  <catDesc>Ptolemaios III. Euergetes</catDesc>
+                </category>
+                <category xml:id="tlaUGINSOQZARG3NJSLGNVX3STTIE">
+                  <catDesc>Ptolemaios XI. Alexander II.</catDesc>
+                </category>
+                <category xml:id="tlaXYP4XJ2LEVCS7DBSHGYOH4WYOU">
+                  <catDesc>Ptolemaios IV. Philopator</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaJS32JKX2CNG25GZ3B6MGYMDU4I">
+                <catDesc>Dritte Zwischenzeit</catDesc>
+                <category xml:id="tla3XW6DLUBKVCLHD6KY45JN2PRD4">
+                  <catDesc>Kuschiten</catDesc>
+                  <category xml:id="tla2ZQQIYQHVRDGTH6PPY2LWEQCUQ">
+                    <catDesc>Schabataka</catDesc>
+                  </category>
+                  <category xml:id="tla7FDXNLDP5FFK5EBDS5TKXVPP6A">
+                    <catDesc>Kaschta</catDesc>
+                  </category>
+                  <category xml:id="tla7PIUCJYC7BBVXLMOIZYT72PWJQ">
+                    <catDesc>Alara</catDesc>
+                  </category>
+                  <category xml:id="tlaEFGOT3UFWZG27GZOSTKIU3X2KE">
+                    <catDesc>Tanutamon</catDesc>
+                  </category>
+                  <category xml:id="tlaNL6KKNWSCFGGLO75JDALYFOL4U">
+                    <catDesc>Taharqa</catDesc>
+                  </category>
+                  <category xml:id="tlaSCJLUQ4CSFFRJF6XNZ34OV4DFQ">
+                    <catDesc>Pije</catDesc>
+                  </category>
+                  <category xml:id="tlaXNHKJRIXSNB77GIB66CWTBWGHQ">
+                    <catDesc>Schabaka</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla744HIAA6FRHBROALBB3DV4VV3I">
+                  <catDesc>25. Dyn.</catDesc>
+                  <category xml:id="tlaCWZ4MSSSSBEIPK2RBFSX45ZBMI">
+                    <catDesc>Schabataka</catDesc>
+                  </category>
+                  <category xml:id="tlaFLAXS36WHJA5TJUDDWKHQONVEM">
+                    <catDesc>Tanutamon</catDesc>
+                  </category>
+                  <category xml:id="tlaUWRHN5WFJ5GGBCYKPZXK4YE2GU">
+                    <catDesc>Schabaka</catDesc>
+                  </category>
+                  <category xml:id="tlaVNUNBFCAMNFC7KMHL4QWVJXFTE">
+                    <catDesc>Taharqa</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla7J6HVBL7CJHQPJHG6TBBXJMYMM">
+                  <catDesc>24. Dyn.</catDesc>
+                  <category xml:id="tla47CU2AIR3BAGXEDHUKRZ5NLI44">
+                    <catDesc>Bokchoris</catDesc>
+                  </category>
+                  <category xml:id="tlaJMRTQ7BOBZCUPEREM5VMJ2WJZE">
+                    <catDesc>Tefnachte</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaE7YEQAEKZVEJ5PX7WKOXY2QEEM">
+                  <catDesc>21. Dyn.</catDesc>
+                  <category xml:id="tla677YHBKQIRHB3HVZG45V2N6DU4">
+                    <catDesc>Siamun</catDesc>
+                  </category>
+                  <category xml:id="tlaBBZR65BX2JHZJHOPWOGMFFE42A">
+                    <catDesc>Smendes</catDesc>
+                  </category>
+                  <category xml:id="tlaG2XFFZLE4ZHDNMISPFYCHJJB4M">
+                    <catDesc>Psusennes I.</catDesc>
+                  </category>
+                  <category xml:id="tlaNOTZ5UOGYZD2VBH6D6JXBOW6LI">
+                    <catDesc>Psusennes II.</catDesc>
+                  </category>
+                  <category xml:id="tlaO5QKFTC7YBCKNDSQJOKBWT63BY">
+                    <catDesc>Amenemopet</catDesc>
+                  </category>
+                  <category xml:id="tlaSBF7EA7BN5FOVO6JXZQHUWGYTQ">
+                    <catDesc>Amenemnisut / Nephercheres</catDesc>
+                  </category>
+                  <category xml:id="tlaXVUCQSGCYBHKFNXJYMSKRL4R2M">
+                    <catDesc>Osochor</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaWASRAHTUHNE6HDWN5URBHDIR2M">
+                  <catDesc>22. / 23. Dyn.</catDesc>
+                  <category xml:id="tlaARW2M7F3JFF7HP7XCQ34JREODY">
+                    <catDesc>Scheschonq III.</catDesc>
+                  </category>
+                  <category xml:id="tlaBFBDVC3P25FALCKMNPTNBNYQNA">
+                    <catDesc>Pemu</catDesc>
+                  </category>
+                  <category xml:id="tlaBPYQBIAZPVCWZHDS7M3C2GL53U">
+                    <catDesc>Scheschonq V.</catDesc>
+                  </category>
+                  <category xml:id="tlaBV3NUTCOVBAHDOBBNO44T2F4VY">
+                    <catDesc>Scheschonq II.</catDesc>
+                  </category>
+                  <category xml:id="tlaD7L7SMVVVFEWREVPZSXPGMDMUA">
+                    <catDesc>Harsiese</catDesc>
+                  </category>
+                  <category xml:id="tlaDUH5NGZGPZHIXA2SBPDTFYRV54">
+                    <catDesc>Psammus</catDesc>
+                  </category>
+                  <category xml:id="tlaIZT7J5CGRZEX3OT5ERPRYWQTYY">
+                    <catDesc>Scheschonq IV.</catDesc>
+                  </category>
+                  <category xml:id="tlaKNKTVZBWMBDOPKZ4RVIK43DSME">
+                    <catDesc>Osorkon IV.</catDesc>
+                  </category>
+                  <category xml:id="tlaLJNCZ3RENZGYDDTSANDPNMVKRI">
+                    <catDesc>Petubastis I.</catDesc>
+                  </category>
+                  <category xml:id="tlaMPKA3BGQ5VDRDE4SQKHBU7I5RM">
+                    <catDesc>Osorkon II.</catDesc>
+                  </category>
+                  <category xml:id="tlaN47PT66YEVCDHFFZUVIML2BE2M">
+                    <catDesc>Petubastis II.</catDesc>
+                  </category>
+                  <category xml:id="tlaNUDYSH53HVGNTM2FTELC5TFSQI">
+                    <catDesc>Osorkon I.</catDesc>
+                  </category>
+                  <category xml:id="tlaPBUFJKFM4NH2XEBUVIEZCB6A3M">
+                    <catDesc>Takelot II.</catDesc>
+                  </category>
+                  <category xml:id="tlaR2UVPCKDIRFOBF4QR5W6UY73QY">
+                    <catDesc>Osorkon III.</catDesc>
+                  </category>
+                  <category xml:id="tlaT3PXE2RRVRCIFCRUQP4PCSQMOI">
+                    <catDesc>Iuput I.</catDesc>
+                  </category>
+                  <category xml:id="tlaT6GEYS2Y3RGF3O3ZGQWHBJZMQI">
+                    <catDesc>Iuput II.</catDesc>
+                  </category>
+                  <category xml:id="tlaTLM3NFHYG5HRHICGSS6SI6HEBI">
+                    <catDesc>Rudamun</catDesc>
+                  </category>
+                  <category xml:id="tlaTMQJAUESNRGSXF4GT75ECQKKYQ">
+                    <catDesc>Iny</catDesc>
+                  </category>
+                  <category xml:id="tlaUUZQDMMULNCRHNP2EV4OBUNCOM">
+                    <catDesc>Takelot III.</catDesc>
+                  </category>
+                  <category xml:id="tlaVFTMODKBGZAGNENLGHGNGNBXM4">
+                    <catDesc>Takelot I.</catDesc>
+                  </category>
+                  <category xml:id="tlaXZ2WE35X5NGFTN37A7ZOS4CD54">
+                    <catDesc>Scheschonq I.</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaMM4QYACJOJCCLJWBD6VAX2FLKE">
+                <catDesc>Mittleres Reich</catDesc>
+                <category xml:id="tla7G4I7VLRZFCZFBDWXWJBCSPIPI">
+                  <catDesc>11. Dyn. (Gesamtzeitraum)</catDesc>
+                  <category xml:id="tlaDD6XPV4VBFE2ZAP66IXKVPGWKQ">
+                    <catDesc>Intef I. Sehertawi</catDesc>
+                  </category>
+                  <category xml:id="tlaE2BYRJX5Z5DSBOJFVF6WO7KZRE">
+                    <catDesc>Intef III. Nachtnebtepnefer</catDesc>
+                  </category>
+                  <category xml:id="tlaEKCGS4YHKNCBNNBKQSBLGT4J7E">
+                    <catDesc>Mentuhotep III. Seanchkare</catDesc>
+                  </category>
+                  <category xml:id="tlaEUFPI7IUJFHVJGT6AOATFIZPNA">
+                    <catDesc>Intef II. Wahanch</catDesc>
+                  </category>
+                  <category xml:id="tlaKXXWNISHB5AWFHAYWKV5PCALSY">
+                    <catDesc>Mentuhotep IV. Nebtawire</catDesc>
+                  </category>
+                  <category xml:id="tlaPGZO7FG47BFK3LN2IQEOJBZJNU">
+                    <catDesc>Mentuhotep I. Tepi-a</catDesc>
+                  </category>
+                  <category xml:id="tlaQH4ZVV4SZREKNEY5UDCC3AZ3E4">
+                    <catDesc>Mentuhotep II. Nebhepetre</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaJVTUL4HL45FRHF7TREHQXYZSWM">
+                  <catDesc>11. Dyn., 2. Hälfte</catDesc>
+                  <category xml:id="tlaB2OHIBEXNZHCTNGEXMEVV2VWIU">
+                    <catDesc>Mentuhotep II. Nebhepetre (nach der Reichseinigung)</catDesc>
+                  </category>
+                  <category xml:id="tlaIVVRWFXHMZCXBJRH5W2ZRMMVUE">
+                    <catDesc>Mentuhotep III. Seanchkare</catDesc>
+                  </category>
+                  <category xml:id="tlaUD2UDBHPXBCUXB5XZOMXZ5AN6E">
+                    <catDesc>Mentuhotep IV. Nebtawire</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaWFSMZWLWMFDG5FAGQOB436TKUU">
+                  <catDesc>12. Dyn.</catDesc>
+                  <category xml:id="tla2N3CSTWVMRCXXLTRGTLKLJQZZU">
+                    <catDesc>Sobeknofru</catDesc>
+                  </category>
+                  <category xml:id="tla3O45XPYQXJATRP5CHBOH2EZYG4">
+                    <catDesc>Amenemhet III.</catDesc>
+                  </category>
+                  <category xml:id="tla43UOVHLOUVCWVK3L543HR44GSA">
+                    <catDesc>Amenemhet I.</catDesc>
+                  </category>
+                  <category xml:id="tlaCHLJ7SQNMVF33JVUBIZTIYH5PQ">
+                    <catDesc>Amenemhet II.</catDesc>
+                  </category>
+                  <category xml:id="tlaEBGTMF7GURDVZDFRV6XQU7OEOE">
+                    <catDesc>Sesostris I.</catDesc>
+                  </category>
+                  <category xml:id="tlaOKZXTLKCTZHVRGYAIBR5BGKZRI">
+                    <catDesc>Amenemhet IV.</catDesc>
+                  </category>
+                  <category xml:id="tlaQGFPPB7TBJC4DOC46YTOAH4UYM">
+                    <catDesc>Sesostris III.</catDesc>
+                  </category>
+                  <category xml:id="tlaUODUII6XLBAJFCSQQNBMW7H4XM">
+                    <catDesc>Sesostris II.</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaQBN55U2GTFA27GHK3IACBTMK2U">
+                <catDesc>Erste Zwischenzeit</catDesc>
+                <category xml:id="tlaGAQRDJP4OBB27JFBUQHAKXFEK4">
+                  <catDesc>9./10. Dyn. parallel zur frühen 11. Dyn.</catDesc>
+                </category>
+                <category xml:id="tlaPLVPK4FNBFHC3JQJC4J5YYJA2E">
+                  <catDesc>11. Dyn., 1. Hälfte</catDesc>
+                  <category xml:id="tlaGD5TMK62EREULP3HDTZUOIAEKA">
+                    <catDesc>Intef III. Nachtnebtepnefer</catDesc>
+                  </category>
+                  <category xml:id="tlaGQP66JAMPVHVLPQOJF72DRIEGA">
+                    <catDesc>Intef II. Wahanch</catDesc>
+                  </category>
+                  <category xml:id="tlaHVQOKLCRNZAP3BAXQMXFG2HQY4">
+                    <catDesc>Mentuhotep II. Nebhepetre (vor der Reichseinigung)</catDesc>
+                  </category>
+                  <category xml:id="tlaPNCIHL25ZFEW3EUOF47LJL45BE">
+                    <catDesc>Intef I. Sehertawi</catDesc>
+                  </category>
+                  <category xml:id="tlaSD3DMLVNJZETRPVYBPQJ353T34">
+                    <catDesc>Mentuhotep I. Tepi-a</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaR5VWTPWBVBAAHA5VCWLUUD4SFU">
+                  <catDesc>9./10. Dyn. vor Beginn der 11. Dyn.</catDesc>
+                </category>
+                <category xml:id="tlaSQN2QN7IYZBYHCEUH7PBTHMKAU">
+                  <catDesc>Herakleopolitenzeit (Gesamtzeitraum)</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaS62ITYADMZGCHBHTHTAFV3RUGQ">
+                <catDesc>byzantinische Zeit</catDesc>
+              </category>
+              <category xml:id="tlaUGTUTKXZHBDYLG7YJZ5AGOJXQY">
+                <catDesc>Spätzeit</catDesc>
+                <category xml:id="tla2AVEQ3VFT5EEPF7NBH7RHCVBXA">
+                  <catDesc>27. Dyn.</catDesc>
+                  <category xml:id="tla7MP3UDFCTNH7HPPCH3RRJGEUOI">
+                    <catDesc>Kambyses</catDesc>
+                  </category>
+                  <category xml:id="tlaAY5C3JQWXNAM5NIBQVZFPAU7OU">
+                    <catDesc>Artaxerxes I.</catDesc>
+                  </category>
+                  <category xml:id="tlaCX7WTFO76NEIREYNBAZEMCKZJA">
+                    <catDesc>Artaxerxes II.</catDesc>
+                  </category>
+                  <category xml:id="tlaDFOATHXUQJFSJLTVPASC3TQF7M">
+                    <catDesc>Xerxes II.</catDesc>
+                  </category>
+                  <category xml:id="tlaDHKNUBJOYVE4DNGXMYMVUFJHTU">
+                    <catDesc>Dareios II.</catDesc>
+                  </category>
+                  <category xml:id="tlaLG2ZONR34VEQROX4FJ7MTCXKLM">
+                    <catDesc>Dareios I.</catDesc>
+                  </category>
+                  <category xml:id="tlaMJ3WULDBQVD3NJM4NFJQWMAYWI">
+                    <catDesc>Xerxes I.</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla2Z7FB3JW3BHGRPWOII5PAYY4DM">
+                  <catDesc>31. Dyn.</catDesc>
+                  <category xml:id="tla6XFG65VENRHERHIHREIUEPT7V4">
+                    <catDesc>Arses</catDesc>
+                  </category>
+                  <category xml:id="tlaHULJPMHB4FGENJGZ7DPTWIADZE">
+                    <catDesc>Artaxerxes III. Ochos</catDesc>
+                  </category>
+                  <category xml:id="tlaI6OREN4DZFDKDDCN6FDFJDB5ZE">
+                    <catDesc>Dareios III.</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tla42CP5AWFYFFVXFWGXMJLO2ZWWI">
+                  <catDesc>28. Dyn.</catDesc>
+                  <category xml:id="tlaONG6H7BR5VBQPMWVKIG5RYZQWE">
+                    <catDesc>Amyrtaios</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaFZRARLPZPZG5JM6XGGLTTEU3KM">
+                  <catDesc>29. Dyn.</catDesc>
+                  <category xml:id="tlaR3R4WMMU3VANVIGTRB5VPTHDYY">
+                    <catDesc>Nepherites II.</catDesc>
+                  </category>
+                  <category xml:id="tlaRX4OI7SAIJD4PIPLKCSDEHC5DQ">
+                    <catDesc>Nepherites I.</catDesc>
+                  </category>
+                  <category xml:id="tlaWSDXCFS7NBAZ7J6P6XHEKJ4CZA">
+                    <catDesc>Achoris</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaQHQZNMAUZFCTZMLD5BGMDIKS6M">
+                  <catDesc>26. Dyn.</catDesc>
+                  <category xml:id="tla26FQR3PAGBFZLNTFH2VIKTYGVY">
+                    <catDesc>Necho</catDesc>
+                  </category>
+                  <category xml:id="tlaAX5RS54IHNHLLHTG5ACTVOAUII">
+                    <catDesc>Amasis</catDesc>
+                  </category>
+                  <category xml:id="tlaL3OEF7GYRZAVDA5J3RRDFHKKSQ">
+                    <catDesc>Psammetich III.</catDesc>
+                  </category>
+                  <category xml:id="tlaRWBAUHG5OVARXHA3ZVA4TFKSHQ">
+                    <catDesc>Psammetich II.</catDesc>
+                  </category>
+                  <category xml:id="tlaSSHXBGXDW5BJ3AEFHXVYZLBWAI">
+                    <catDesc>Psammetich I.</catDesc>
+                  </category>
+                  <category xml:id="tlaWBJEV25Q3RHT5NUYRUEGBY5LC4">
+                    <catDesc>Apries</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaZAQON3S37NHEJMZP33RUX47ZY4">
+                  <catDesc>30. Dyn.</catDesc>
+                  <category xml:id="tla2EYHVBPX4NGUZPVTRAKO36TDWE">
+                    <catDesc>Teos</catDesc>
+                  </category>
+                  <category xml:id="tla5J7P2WPKN5GMNJD735VZP5JARQ">
+                    <catDesc>Nektanebos II.</catDesc>
+                  </category>
+                  <category xml:id="tlaAS735FI63FEQTISOFW6R6ITQQI">
+                    <catDesc>Nektanebos I.</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaWX32K2TQTRETLDX2IO6SL5DDBU">
+                <catDesc>Neues Reich</catDesc>
+                <category xml:id="tlaKXND4U5N5VBQLN4XMZGFVBHOCM">
+                  <catDesc>20. Dyn.</catDesc>
+                  <category xml:id="tla3L7VTD3RIFDP3P6WD55HOUP5ZU">
+                    <catDesc>Ramses IV.</catDesc>
+                  </category>
+                  <category xml:id="tla6JOFBEHJGJD3FKFGPRMBGDT6XM">
+                    <catDesc>Ramses VIII.</catDesc>
+                  </category>
+                  <category xml:id="tlaD3JLTVY33NF4VBTVIJRR4N5QUY">
+                    <catDesc>Ramses III.</catDesc>
+                  </category>
+                  <category xml:id="tlaEJKPV5YRHZDUNFSHN2C5CZ22YU">
+                    <catDesc>Ramses VI.</catDesc>
+                  </category>
+                  <category xml:id="tlaLRSMDL7ITFEJBAHAZN2KSV7IRE">
+                    <catDesc>Ramses VII.</catDesc>
+                  </category>
+                  <category xml:id="tlaMOM3DW5NLZAB5JCM2ZKX5GICCE">
+                    <catDesc>Ramses IX.</catDesc>
+                  </category>
+                  <category xml:id="tlaPNMK6Q7XZNESBJPTUSW7FGQ7YA">
+                    <catDesc>Ramses XI.</catDesc>
+                  </category>
+                  <category xml:id="tlaT5G5CJPBKBGW3DAGCAUTS35JRY">
+                    <catDesc>Ramses V.</catDesc>
+                  </category>
+                  <category xml:id="tlaTNO3MXXXJFF45IUPEUMCNHXK4Q">
+                    <catDesc>Ramses X.</catDesc>
+                  </category>
+                  <category xml:id="tlaVP6WK4UCRJAXHJT6XQEO2ZG6OI">
+                    <catDesc>Sethnachte</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaNUW3K7UK3BBUFDPHZDD2ZZ3LYI">
+                  <catDesc>18. Dyn.</catDesc>
+                  <category xml:id="tla4EVBMCD2U5GQPBJ6QS622PTSQQ">
+                    <catDesc>Amenophis IV. / Echnaton</catDesc>
+                  </category>
+                  <category xml:id="tla4QEIACZDZ5F7ZHVQCMJKSBMZXM">
+                    <catDesc>Thutmosis III. (Gesamtzeitraum)</catDesc>
+                  </category>
+                  <category xml:id="tlaBVENTZHAEJERXCJI2Y45XAYKN4">
+                    <catDesc>Amenophis I.</catDesc>
+                  </category>
+                  <category xml:id="tlaDTH6NOX35ZBYNMGQH4SCKDS4GQ">
+                    <catDesc>Ahmose</catDesc>
+                  </category>
+                  <category xml:id="tlaF52ILUTH6RBWJI36ENPFTB22SI">
+                    <catDesc>Thutmosis I.</catDesc>
+                  </category>
+                  <category xml:id="tlaKMQ26R2F3VEJDIOTNUTDWO4Z4Y">
+                    <catDesc>Amenophis II.</catDesc>
+                  </category>
+                  <category xml:id="tlaMOFI6DFV5VD7RBARIW4TL33IZE">
+                    <catDesc>Semenchkare</catDesc>
+                  </category>
+                  <category xml:id="tlaPRDOZUMR2FDPNKK2OV6TUS4XEA">
+                    <catDesc>Thutmosis II.</catDesc>
+                  </category>
+                  <category xml:id="tlaQYLA6ANYSRER7I3JFTCKIPRHOY">
+                    <catDesc>Hatschepsut</catDesc>
+                  </category>
+                  <category xml:id="tlaTGGVPV3PMFAP5O5OBSMOIKEX74">
+                    <catDesc>Amenophis III.</catDesc>
+                  </category>
+                  <category xml:id="tlaU3LID524EVGI7MWJUIJYNLNSAE">
+                    <catDesc>Haremhab</catDesc>
+                  </category>
+                  <category xml:id="tlaWMSRSEY4LBALVAQEKU4GKNLTMU">
+                    <catDesc>Thutmosis IV.</catDesc>
+                  </category>
+                  <category xml:id="tlaXB6A2YYCL5AGHN4YU24CWFOVKY">
+                    <catDesc>Thutmosis III. (Alleinregierung)</catDesc>
+                  </category>
+                  <category xml:id="tlaZ45USXGJBNCVZLOVM5CRMAAL3Y">
+                    <catDesc>Tutanchamun</catDesc>
+                  </category>
+                  <category xml:id="tlaZHZNTKKCLJFT5FUOH2Y7QESCWM">
+                    <catDesc>Eje</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaPFJ4POQ5VBFU3EHNXP4MRDLXBA">
+                  <catDesc>19. Dyn.</catDesc>
+                  <category xml:id="tla54VED6E3TBESLGFQGGQVXZ6GLM">
+                    <catDesc>Merenptah</catDesc>
+                  </category>
+                  <category xml:id="tla6KMCKKTQ4FFMLOYH264TPBW4IU">
+                    <catDesc>Siptah u. Tausret</catDesc>
+                  </category>
+                  <category xml:id="tlaBVMSDQRPX5ECXFKTIGQWIOXQOM">
+                    <catDesc>Sethos I.</catDesc>
+                  </category>
+                  <category xml:id="tlaFCJURX24JZGXZEKP3TW36U3ZFA">
+                    <catDesc>Ramses II.</catDesc>
+                  </category>
+                  <category xml:id="tlaSP2O7AHMRVFFNA6YJ2TIIYPS3A">
+                    <catDesc>Sethos II.</catDesc>
+                  </category>
+                  <category xml:id="tlaW4R7J6OTNFAVTN24X6SJGFKZ6I">
+                    <catDesc>Ramses I.</catDesc>
+                  </category>
+                  <category xml:id="tlaYOIYNB3BFVBEFDDS5V3AZCVFNQ">
+                    <catDesc>Amenmesse</catDesc>
+                  </category>
+                </category>
+              </category>
+              <category xml:id="tlaYZP5WTOZV5FB5EZFGQDY7MYKIQ">
+                <catDesc>römische Zeit</catDesc>
+                <category xml:id="tla2A6LYDLVHRBPXFZKPZU7CEOAIM">
+                  <catDesc>"Soldatenkaiser"</catDesc>
+                </category>
+                <category xml:id="tla4XAVOEBBHVCGZIGICZCPL2N2N4">
+                  <catDesc>Severer</catDesc>
+                  <category xml:id="tla3TAIGNOV5BDMLOMA5QOH4OOHHU">
+                    <catDesc>Macrinus</catDesc>
+                  </category>
+                  <category xml:id="tla5IHX5Q7WPNEM3GUPGVUQJ55S2M">
+                    <catDesc>Severus Alexander</catDesc>
+                  </category>
+                  <category xml:id="tla6I2IJQAXYVG3ZCPOQE2JR6RFGU">
+                    <catDesc>Septimius Severus</catDesc>
+                  </category>
+                  <category xml:id="tlaJCO2GZFWPJHT3O2VMQLPOCWMQU">
+                    <catDesc>Caracalla</catDesc>
+                  </category>
+                  <category xml:id="tlaU4NUJYYIJFBYRJP3OHALCEQSM4">
+                    <catDesc>Elagabal</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaFLZYUFLZMBCYZFIV6HIBSRIMPM">
+                  <catDesc>Adoptivkaiser</catDesc>
+                  <category xml:id="tla67URIQ5T5BAC5H7TPXM437SPU4">
+                    <catDesc>Antoninus Pius</catDesc>
+                  </category>
+                  <category xml:id="tla7CND52XKPNC5PIVU42CQ7FWAF4">
+                    <catDesc>Nerva</catDesc>
+                  </category>
+                  <category xml:id="tlaK7FNLUAFURALDGBN4FV3LSUWZI">
+                    <catDesc>Commodus</catDesc>
+                  </category>
+                  <category xml:id="tlaSBPP7UMVLNFRROVHN5MV4P3JMY">
+                    <catDesc>Hadrian</catDesc>
+                  </category>
+                  <category xml:id="tlaT5JLVAADRVCFFEE4AYQG7JUZXQ">
+                    <catDesc>Marcus Aurelius</catDesc>
+                  </category>
+                  <category xml:id="tlaXPSJ2LYDHBGNFD6CCPHJDKX4AY">
+                    <catDesc>Trajan</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaKNI3FP7F3ZD7NLNZLEQOAIIG5U">
+                  <catDesc>Tetrarchenzeit</catDesc>
+                </category>
+                <category xml:id="tlaNWBNCEAMTFCPTNGFVWWNQMPTVI">
+                  <catDesc>julisch-claudische Dynastie</catDesc>
+                  <category xml:id="tla2HOJVMMCYBGGZBLAJPG2UMXHP4">
+                    <catDesc>Augustus</catDesc>
+                  </category>
+                  <category xml:id="tla6JNLCELRGFGW5DDAMGPF56DUAY">
+                    <catDesc>Tiberius</catDesc>
+                  </category>
+                  <category xml:id="tlaGKPIXD7FTBDQJETU2TITXC4QFQ">
+                    <catDesc>Claudius</catDesc>
+                  </category>
+                  <category xml:id="tlaOTVJNIXD7NCJZHX4YZ7HEWCPXM">
+                    <catDesc>Gaius</catDesc>
+                  </category>
+                  <category xml:id="tlaQVSUL54D5ZHFXP3S7MIOEU6GGA">
+                    <catDesc>Nero</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaTLFBMDUZ2RE6JNZW7GZDBHWATM">
+                  <catDesc>Flavier</catDesc>
+                  <category xml:id="tla7QV5OTUCG5BG3HMCRBR4CCVYGU">
+                    <catDesc>Domitian</catDesc>
+                  </category>
+                  <category xml:id="tlaOSXPG6CJZNHRFG3CC7SYHU654Q">
+                    <catDesc>Titus</catDesc>
+                  </category>
+                  <category xml:id="tlaUEGCHD2YV5HL3E4DQ2C57NYFIU">
+                    <catDesc>Verspasian</catDesc>
+                  </category>
+                </category>
+              </category>
+            </category>
+            <category xml:id="tlaFHZEINDCEJAOTHIVC35NYGMC2Q">
+              <catDesc>(Jahrhunderte n.Chr.)</catDesc>
+              <category xml:id="tla4GVKWKAP4VFSLFPBUBAI7XF2YA">
+                <catDesc>5. Jhdt. n.Chr.</catDesc>
+                <category xml:id="tla57U3TQQLHZGSFHQ3GAWVITBYUQ">
+                  <catDesc>1. Viertel 5. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaAGZE4BISKREPFOZJJ5SZMRBKJQ">
+                  <catDesc>3. Viertel 5. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaDHJI2BOMWFCKBM52LDN3NEUYO4">
+                  <catDesc>2. Viertel 5. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaNXGHKWOMDZCZRHV474Y3FSMSVU">
+                  <catDesc>2. Hälfte 5. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaPZP2HLFD4ZD7PAJWWJA4C6IDHQ">
+                  <catDesc>1. Hälfte 5. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaXDJUGWOTXFFDZD344WXR5QQBPQ">
+                  <catDesc>4. Viertel 5. Jhdt. n.Chr.</catDesc>
+                </category>
+              </category>
+              <category xml:id="tla77UKMRWAJZC5LALMVTEAD6L7VA">
+                <catDesc>1. Jhdt. n.Chr.</catDesc>
+                <category xml:id="tla2EGWXRGUCBHIDCTZXMZGGEYHPE">
+                  <catDesc>2. Viertel 1. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tla4GCBH775S5GTVNDXXASM2HFY3Q">
+                  <catDesc>3. Viertel 1. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaAIVG3ELQKNC4HKUIDHONGLB4TQ">
+                  <catDesc>1. Hälfte 1. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaJSFEL3SGN5DW5JSWMKHGRW7GSA">
+                  <catDesc>2. Hälfte 1. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaOZZZBMWUEBA7FHBJFEKZRKK3SQ">
+                  <catDesc>1. Viertel 1. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaWRWGTJLJNRHETBFC52BVHERDCQ">
+                  <catDesc>4. Viertel 1. Jhdt. n.Chr.</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaDU6YTUV2IZEYTOA7GVBMTBCV3I">
+                <catDesc>4. Jhdt. n.Chr.</catDesc>
+                <category xml:id="tla5J4Y3SI54NGWZHHKU63JMNFKCA">
+                  <catDesc>1. Viertel 4. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tla6Y3WYJK76VFQRLZIMWF443PLUI">
+                  <catDesc>3. Viertel 4. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaMG2USRRI6BB57BC2SCZTBMIG4Q">
+                  <catDesc>2. Hälfte 4. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaNP53EQUQQ5AN7JPKA77LISIWPI">
+                  <catDesc>2. Viertel 4. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaWDMZ3ZJLVVAYTA4ZX4SXLI4MPA">
+                  <catDesc>1. Hälfte 4. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaWPEQO2GQTNE5XHPPIYVJG75WLE">
+                  <catDesc>4. Viertel 4. Jhdt. n.Chr.</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaEQM4LZPKYJCWFNQ445M6XU3UCY">
+                <catDesc>2. Jhdt. n.Chr.</catDesc>
+                <category xml:id="tla5HNMTTVLOREQ3LKMJOCIH7Z5GU">
+                  <catDesc>1. Hälfte 2. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaDXLYH5WDSRHZVE3XTFKN72X7ZQ">
+                  <catDesc>2. Hälfte 2. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaHT44AOEA5ZFFJBINX2DBUS3LYE">
+                  <catDesc>1. Viertel 2. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaIIPELUHXL5G3TEZXTVQMSJCMIE">
+                  <catDesc>2. Viertel 2. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaIO2NFBCQMJDSJGZB4QF7QRMMSY">
+                  <catDesc>4. Viertel 2. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaMPCVCKDBWNC77GRCMHQQM66CUE">
+                  <catDesc>3. Viertel 2. Jhdt. n.Chr.</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaFV6TQYR4MJBDTCWZABXH4E4OMY">
+                <catDesc>9. Jhdt. n.Chr.</catDesc>
+                <category xml:id="tla3MEPLXDHJZH25EFWG4ONSPBADU">
+                  <catDesc>1. Hälfte 9. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaGCOGRW2AFNFAZC7CAH5VY2TIYI">
+                  <catDesc>4. Viertel 9. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaMVDHBIPHCNEEVIZYTF4HL7XTGM">
+                  <catDesc>1. Viertel 9. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaQSRVICICSJD6VOVHOP3Z3BBG5Y">
+                  <catDesc>3. Viertel 9. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaSQYBTEXKORB6VCUCL5P5CABDBY">
+                  <catDesc>2. Hälfte 9. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaZ2OYYVNKXNCUDJRR6ZFGJHBBZ4">
+                  <catDesc>2. Viertel 9. Jhdt. n.Chr.</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaIMBHKBIKV5AUHEAAU2DL2K2GN4">
+                <catDesc>3. Jhdt. n.Chr.</catDesc>
+                <category xml:id="tlaC5KTZJIALBBA3BP3DB3BHAF3RA">
+                  <catDesc>4. Viertel 3. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaKENXXLN7BRAYHAMA7O447DA73Y">
+                  <catDesc>2. Viertel 3. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaQPUHN5VYWVAGPKZ3ZHYQFMYPNQ">
+                  <catDesc>2. Hälfte 3. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaRNVKCEB3GJBZNDSHZSA6UDH5BU">
+                  <catDesc>1. Hälfte 3. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaX7UGMEM77FBDXEPEMLGPVANWOI">
+                  <catDesc>3. Viertel 3. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaZDX4UT6C7NGQZEUL55SAXFWDIQ">
+                  <catDesc>1. Viertel 3. Jhdt. n.Chr.</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaMRHDSYHO4FCH5FRYRE3F47QHSQ">
+                <catDesc>6. Jhdt. n.Chr.</catDesc>
+                <category xml:id="tla4BMTXUOSFBH6VBJLBMCOBFANBQ">
+                  <catDesc>1. Viertel 6. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaOJPO7GMS75E75LTRJNRX2DCTGQ">
+                  <catDesc>2. Hälfte 6. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaUGV7KEWHUBBHNOKSVSU6EDZ5UU">
+                  <catDesc>4. Viertel 6. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaXNT2W3PJZZHY7C46BD6UZHRLJA">
+                  <catDesc>2. Viertel 6. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaXWW436FZEZC23OUSX7IPSXLWXA">
+                  <catDesc>1. Hälfte 6. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaZYRH3FYJNNAQDOACTPR2YKSV6U">
+                  <catDesc>3. Viertel 6. Jhdt. n.Chr.</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaTU6P6HMKY5AB7DLLOJVA77746E">
+                <catDesc>7. Jhdt. n.Chr.</catDesc>
+                <category xml:id="tla22SCMOXZQFDXRNHIOVRBPNOPZM">
+                  <catDesc>1. Viertel 7. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tla74MF3BTZAVEBBFNK6KFLKUEHVA">
+                  <catDesc>4. Viertel 7. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaFMT2DC5ZUJD2HEQACDEMXUFZB4">
+                  <catDesc>2. Viertel 7. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaI5IQORK3F5BVZPETMCXQSJP5WA">
+                  <catDesc>1. Hälfte 7. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaTZTJKFTIEZCKBGVD2NSIPT2JQY">
+                  <catDesc>3. Viertel 7. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaUKKBW2H6HJFIZCVHBREHPIGGVQ">
+                  <catDesc>2. Hälfte 7. Jhdt. n.Chr.</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaY55AYTMYANAOFCYUMYJWZRPSZA">
+                <catDesc>8. Jhdt. n.Chr.</catDesc>
+                <category xml:id="tlaI5GTTHOZWJCY5LTQLIFAM4WYDM">
+                  <catDesc>3. Viertel 8. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaPTTURIUYEVGRNIDYMJWFOHLZSI">
+                  <catDesc>2. Hälfte 8. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaPVZ6R3YIHZBRPNWWLX5VZTIUZU">
+                  <catDesc>1. Hälfte 8. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaQVPJSG5RUFGMNMAQNWUHEBYJKM">
+                  <catDesc>1. Viertel 8. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaSJGD7JW3PZAHHB2FHJKWVTSIBM">
+                  <catDesc>4. Viertel 8. Jhdt. n.Chr.</catDesc>
+                </category>
+                <category xml:id="tlaVTOAVISRORHJPAQK3FTRPHYAQE">
+                  <catDesc>2. Viertel 8. Jhdt. n.Chr.</catDesc>
+                </category>
+              </category>
+            </category>
+            <category xml:id="tlaFKLXKTC5RJFSZCBDU5HWK6KHGU">
+              <catDesc>(unbekannt)</catDesc>
+            </category>
+            <category xml:id="tlaGTIHALKZWJFTNCLZ3ITXK7HBXA">
+              <catDesc>(unbestimmt)</catDesc>
+            </category>
+          </category>
+          <category xml:id="tlaN4EKSVODAND4VALYASB5BQOFB4">
+            <catDesc>26 = Modell</catDesc>
+            <category xml:id="tlaXAP23YHBTNCCRJYJGDRHLURSE4">
+              <catDesc>Modell</catDesc>
+            </category>
+          </category>
+          <category xml:id="tlaOQCVRKIWEBFTHMH5XORMHYCMRM">
+            <catDesc>4 = Sprachen</catDesc>
+            <category xml:id="tla3SDSQWACYZBF5BQPORO2IYGKK4">
+              <catDesc>Semitische Sprachen</catDesc>
+              <category xml:id="tla5FQLDVWUMREZVLDMDUCGYRF3W4">
+                <catDesc>Akkadisch</catDesc>
+              </category>
+              <category xml:id="tlaIIXDCYEWE5BJPG5JD4FC6NPLHM">
+                <catDesc>Aramäisch</catDesc>
+              </category>
+              <category xml:id="tlaJH6OFL5DJJEY3OIDTSP6Q23CIU">
+                <catDesc>Arabisch</catDesc>
+              </category>
+              <category xml:id="tlaKHIFJEW7S5DNRDEWECCC2LWKGY">
+                <catDesc>Hebräisch</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaIBMOCXFSHFFYXNIJ4M6LKU7ODM">
+              <catDesc>Ägyptisch-Koptisch</catDesc>
+              <category xml:id="tla3UOTPOGTZVBXJBAEKNXMOPSNG4">
+                <catDesc>Ägyptisch</catDesc>
+                <category xml:id="tla2MWPAPVOK5EORDGYCLKVMF2EPU">
+                  <catDesc>Mittelägyptisch</catDesc>
+                  <category xml:id="tlaGJKKSU5V6VHKBPVTIYQ4PFOBJ4">
+                    <catDesc>frühes und klassisches Mittelägyptisch</catDesc>
+                  </category>
+                  <category xml:id="tlaRXK2LXKUFREIJP2QQVZHHUSKLI">
+                    <catDesc>traditionelles Mittelägyptisch</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaJ3SNMB4AF5ERPDGE4VPMBZSYRE">
+                  <catDesc>Neuägyptisch</catDesc>
+                  <category xml:id="tla6OVKIYNZEZCUHADVKMCAL6TTLQ">
+                    <catDesc>literarisches Neuägyptisch</catDesc>
+                  </category>
+                  <category xml:id="tlaG4CEYVBUZRDLLAEUPRZAOCVFNE">
+                    <catDesc>neuägyptische Geschäfts- und Kanzleisprache</catDesc>
+                  </category>
+                </category>
+                <category xml:id="tlaRYVHCFERAVCABE2VHI7FRKB6PM">
+                  <catDesc>Altägyptisch</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaR3BF4BGUFFBMZFKMX3YMA4EINE">
+                <catDesc>Koptisch</catDesc>
+                <category xml:id="tla2AR6H4MCONHXBFZOQULXVCBNXI">
+                  <catDesc>Achmimisch</catDesc>
+                </category>
+                <category xml:id="tla5CYPHYWWSRDXZDXNVNER7YVZWU">
+                  <catDesc>Sahidisch</catDesc>
+                </category>
+                <category xml:id="tla5JGJ5FT7ORFFNOQTACML47C2GY">
+                  <catDesc>Bohairisch</catDesc>
+                </category>
+                <category xml:id="tlaBJTCRK7HFRCKDCYPXRFB47C2MU">
+                  <catDesc>Altkoptisch</catDesc>
+                </category>
+                <category xml:id="tlaFT6T5GHUDJAQDNG2UQEGD3YZWE">
+                  <catDesc>Fajumisch</catDesc>
+                </category>
+                <category xml:id="tlaMN53OUCBWNGCXLY5P7BE6VUFEA">
+                  <catDesc>Subachmimisch / Lykopolitanisch</catDesc>
+                </category>
+                <category xml:id="tlaPLXSBMH7A5B5RCGHOY5TLLPOGM">
+                  <catDesc>Mittelägyptisch / Oxyrhynchitisch</catDesc>
+                </category>
+              </category>
+              <category xml:id="tlaWGLEOWZBQNE6TFLKV3JGNB66GE">
+                <catDesc>Demotisch</catDesc>
+                <category xml:id="tla6OQRGDEY5BDZFHKTHKPWB6EX7E">
+                  <catDesc>Frühdemotisch</catDesc>
+                </category>
+                <category xml:id="tlaTBCPVG5LEJEEBBCXKE6AWWALQA">
+                  <catDesc>ptolemäisches Demotisch</catDesc>
+                </category>
+                <category xml:id="tlaXOS6A6Q7ZRGYLNGNRZXGV2H75M">
+                  <catDesc>römisches Demotisch</catDesc>
+                </category>
+              </category>
+            </category>
+            <category xml:id="tlaIDQRSSGSQ5F6VEN3QEYVJHXBHM">
+              <catDesc>Nilosaharanische Sprachen</catDesc>
+              <category xml:id="tla6KPEYMCYMZEAJPTGC5HP3XRTJQ">
+                <catDesc>nubische Sprache(n) der pharaonischen Zeit</catDesc>
+              </category>
+              <category xml:id="tlaS4SLR4HKWRCOXPZ32XG2QILYIA">
+                <catDesc>Meroitisch</catDesc>
+              </category>
+              <category xml:id="tlaTWF73ENRUFGNHK4FPY33266TPM">
+                <catDesc>Altnubisch</catDesc>
+              </category>
+            </category>
+            <category xml:id="tlaSELUQECNFZHHFPC5WQM7T6IXB4">
+              <catDesc>Indoeuropäische Sprachen</catDesc>
+              <category xml:id="tlaN5K5S75ZMVEKNBRXZN7G2B2ECE">
+                <catDesc>Griechisch</catDesc>
+              </category>
+              <category xml:id="tlaVDSLR44XTNAKZPIRJIAIZWE76M">
+                <catDesc>Lateinisch</catDesc>
+              </category>
+            </category>
+          </category>
+        </taxonomy>
+      </classDecl>
+    </encodingDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <p>No text.</p>
+    </body>
+  </text>
 </TEI>


### PR DESCRIPTION
- Adds 30498 relations between lemma entries to dictionary file. Only relations to existing entries (in AED) are included, and their respective inverse relations have been generated for the lemma entries on their receiving ends. Relations are encoded as `//entry/xr/ref` elements:
```xml
<xr type="contains">
  <ref target="tla100340"/>
  <ref target="tla100350"/>
  <ref target="tla100370"/>
  <ref target="tla873176"/>
</xr>
<xr type="root">
  <ref target="tla872840"/>
</xr>
```
- Adds 16971 english translations to dictionary file.
- Fixes `sourceDesc` node in thesaurus file (https://github.com/simondschweitzer/aed-tei/commit/ff71bb544e1cd08be2ed97853dca51ea165e7509)
- Format both dictionary and thesaurus files for readibility