### PR TITLE
Thesaurus dateranges

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,6 @@
 ---
 cff-version: 1.2.0
+type: dataset
 message: >
   Please cite using these metadata when using this dataset.
 title: >

--- a/files/thesaurus.xml
+++ b/files/thesaurus.xml
@@ -8327,199 +8327,199 @@
           <category xml:id="tlaMXWX4WG43ZHI7D4RLTGK3IBGXY">
             <catDesc>9 = Datierungen</catDesc>
             <category xml:id="tlaD3R5CH5NZBDA7IZMCKKJPWYZKU">
-              <catDesc>(Jahrhunderte v.Chr.)<date from="0" to="0"/></catDesc>
+              <catDesc>(Jahrhunderte v.Chr.)<date from="0000" to="0000"/></catDesc>
               <category xml:id="tla2ZIZTYBKYNFNVFTFBA32CAAY7A">
-                <catDesc>1. Jhdt. v.Chr.<date from="-100" to="-1"/></catDesc>
+                <catDesc>1. Jhdt. v.Chr.<date from="-0100" to="-0001"/></catDesc>
                 <category xml:id="tla3V5NOJIC3VBIZBA7QCD6OFSAQY">
-                  <catDesc>4. Viertel 1. Jhdt. v.Chr.<date from="-25" to="-1"/></catDesc>
+                  <catDesc>4. Viertel 1. Jhdt. v.Chr.<date from="-0025" to="-0001"/></catDesc>
                 </category>
                 <category xml:id="tla7LG7A3WDXNFCVDQICH6CXVIJXM">
-                  <catDesc>1. Hälfte 1. Jhdt. v.Chr.<date from="-100" to="-51"/></catDesc>
+                  <catDesc>1. Hälfte 1. Jhdt. v.Chr.<date from="-0100" to="-0051"/></catDesc>
                 </category>
                 <category xml:id="tlaEIO2LWBQURGJVC7LQZE5UHGMPU">
-                  <catDesc>2. Viertel 1. Jhdt. v.Chr.<date from="-75" to="-51"/></catDesc>
+                  <catDesc>2. Viertel 1. Jhdt. v.Chr.<date from="-0075" to="-0051"/></catDesc>
                 </category>
                 <category xml:id="tlaOSHKAITIJJAOVE4XNMQOVUA6JA">
-                  <catDesc>2. Hälfte 1. Jhdt. v.Chr.<date from="-50" to="-1"/></catDesc>
+                  <catDesc>2. Hälfte 1. Jhdt. v.Chr.<date from="-0050" to="-0001"/></catDesc>
                 </category>
                 <category xml:id="tlaUQRNNAQXKBBLFEREMXSODORMFY">
-                  <catDesc>1. Viertel 1. Jhdt. v.Chr.<date from="-100" to="-76"/></catDesc>
+                  <catDesc>1. Viertel 1. Jhdt. v.Chr.<date from="-0100" to="-0076"/></catDesc>
                 </category>
                 <category xml:id="tlaZLKNXXGL7VA7VEECINB7NS65WI">
-                  <catDesc>3. Viertel 1. Jhdt. v.Chr.<date from="-50" to="-26"/></catDesc>
+                  <catDesc>3. Viertel 1. Jhdt. v.Chr.<date from="-0050" to="-0026"/></catDesc>
                 </category>
               </category>
               <category xml:id="tla5I4CKE7K4FE67NZU4FYVG66GG4">
-                <catDesc>9. Jhdt. v.Chr.<date from="-900" to="-801"/></catDesc>
+                <catDesc>9. Jhdt. v.Chr.<date from="-0900" to="-0801"/></catDesc>
                 <category xml:id="tlaEHYAY2QQMFBLXE4DYP6AR3ZN3I">
-                  <catDesc>4. Viertel 9. Jhdt. v.Chr.<date from="-825" to="-801"/></catDesc>
+                  <catDesc>4. Viertel 9. Jhdt. v.Chr.<date from="-0825" to="-0801"/></catDesc>
                 </category>
                 <category xml:id="tlaFMKPIG5ISZH6JOPISBT7M5INSU">
-                  <catDesc>2. Hälfte 9. Jhdt. v.Chr.<date from="-850" to="-801"/></catDesc>
+                  <catDesc>2. Hälfte 9. Jhdt. v.Chr.<date from="-0850" to="-0801"/></catDesc>
                 </category>
                 <category xml:id="tlaKNIVMJRE45AXBDQFA37HTNZZF4">
-                  <catDesc>1. Hälfte 9. Jhdt. v.Chr.<date from="-900" to="-851"/></catDesc>
+                  <catDesc>1. Hälfte 9. Jhdt. v.Chr.<date from="-0900" to="-0851"/></catDesc>
                 </category>
                 <category xml:id="tlaTA5P36EB5NABBB6Q4J22ZQNF3I">
-                  <catDesc>1. Viertel 9. Jhdt. v.Chr.<date from="-900" to="-876"/></catDesc>
+                  <catDesc>1. Viertel 9. Jhdt. v.Chr.<date from="-0900" to="-0876"/></catDesc>
                 </category>
                 <category xml:id="tlaVZHQZE6KPJFARE6JBNNOWVD7JI">
-                  <catDesc>3. Viertel 9. Jhdt. v.Chr.<date from="-850" to="-826"/></catDesc>
+                  <catDesc>3. Viertel 9. Jhdt. v.Chr.<date from="-0850" to="-0826"/></catDesc>
                 </category>
                 <category xml:id="tlaZBQWVJND7ZCKNG4LSV64RXUJJU">
-                  <catDesc>2. Viertel 9. Jhdt. v.Chr.<date from="-875" to="-851"/></catDesc>
+                  <catDesc>2. Viertel 9. Jhdt. v.Chr.<date from="-0875" to="-0851"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaJ5JVKLZBXJH5VGTKXCTPBJ2KZE">
-                <catDesc>4. Jhdt. v.Chr.<date from="-400" to="-301"/></catDesc>
+                <catDesc>4. Jhdt. v.Chr.<date from="-0400" to="-0301"/></catDesc>
                 <category xml:id="tla2VUPFL5N5FCC7FF4ECKTUY35Q4">
-                  <catDesc>2. Hälfte 4. Jhdt. v.Chr.<date from="-350" to="-301"/></catDesc>
+                  <catDesc>2. Hälfte 4. Jhdt. v.Chr.<date from="-0350" to="-0301"/></catDesc>
                 </category>
                 <category xml:id="tla33LKEBW63FFSNCVMGOSMDBGFNQ">
-                  <catDesc>1. Hälfte 4. Jhdt. v.Chr.<date from="-400" to="-351"/></catDesc>
+                  <catDesc>1. Hälfte 4. Jhdt. v.Chr.<date from="-0400" to="-0351"/></catDesc>
                 </category>
                 <category xml:id="tlaCSL4LTLEQBBSXGZ353PCVGCFZQ">
-                  <catDesc>1. Viertel 4. Jhdt. v.Chr.<date from="-400" to="-376"/></catDesc>
+                  <catDesc>1. Viertel 4. Jhdt. v.Chr.<date from="-0400" to="-0376"/></catDesc>
                 </category>
                 <category xml:id="tlaIPYKL4XDHJBFJE7D7AZ47HXVIM">
-                  <catDesc>3. Viertel 4. Jhdt. v.Chr.<date from="-350" to="-326"/></catDesc>
+                  <catDesc>3. Viertel 4. Jhdt. v.Chr.<date from="-0350" to="-0326"/></catDesc>
                 </category>
                 <category xml:id="tlaPYJNB3V355DMZERYYWMFHZ5NNI">
-                  <catDesc>4. Viertel 4. Jhdt. v.Chr.<date from="-325" to="-301"/></catDesc>
+                  <catDesc>4. Viertel 4. Jhdt. v.Chr.<date from="-0325" to="-0301"/></catDesc>
                 </category>
                 <category xml:id="tlaSX4FBQBUQFCSHBJFDSCPRLRRY4">
-                  <catDesc>2. Viertel 4. Jhdt. v.Chr.<date from="-375" to="-351"/></catDesc>
+                  <catDesc>2. Viertel 4. Jhdt. v.Chr.<date from="-0375" to="-0351"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaL34UY7MQCRB2JCBPNZKLGP2ZL4">
-                <catDesc>2. Jhdt. v.Chr.<date from="-200" to="-101"/></catDesc>
+                <catDesc>2. Jhdt. v.Chr.<date from="-0200" to="-0101"/></catDesc>
                 <category xml:id="tlaBZNFBS76HVCPTJSYIUV22TSXBQ">
-                  <catDesc>2. Hälfte 2. Jhdt. v.Chr.<date from="-150" to="-101"/></catDesc>
+                  <catDesc>2. Hälfte 2. Jhdt. v.Chr.<date from="-0150" to="-0101"/></catDesc>
                 </category>
                 <category xml:id="tlaDZUK4KHXJZBK5DIDGR6JDOMV4A">
-                  <catDesc>2. Viertel 2. Jhdt. v.Chr.<date from="-175" to="-151"/></catDesc>
+                  <catDesc>2. Viertel 2. Jhdt. v.Chr.<date from="-0175" to="-0151"/></catDesc>
                 </category>
                 <category xml:id="tlaHXGOS6R4BFGJRAFU6ZWTFAIYOA">
-                  <catDesc>1. Hälfte 2. Jhdt. v.Chr.<date from="-200" to="-151"/></catDesc>
+                  <catDesc>1. Hälfte 2. Jhdt. v.Chr.<date from="-0200" to="-0151"/></catDesc>
                 </category>
                 <category xml:id="tlaPTSGMJ72MVDM3LGZS63DM4ENQI">
-                  <catDesc>1. Viertel 2. Jhdt. v.Chr.<date from="-200" to="-176"/></catDesc>
+                  <catDesc>1. Viertel 2. Jhdt. v.Chr.<date from="-0200" to="-0176"/></catDesc>
                 </category>
                 <category xml:id="tlaWFXACEBXJZA77IUNL2T2G4WJWA">
-                  <catDesc>4. Viertel 2. Jhdt. v.Chr.<date from="-125" to="-101"/></catDesc>
+                  <catDesc>4. Viertel 2. Jhdt. v.Chr.<date from="-0125" to="-0101"/></catDesc>
                 </category>
                 <category xml:id="tlaXQOCZAYRS5B4FA7XUIXRLZXOCA">
-                  <catDesc>3. Viertel 2. Jhdt. v.Chr.<date from="-150" to="-126"/></catDesc>
+                  <catDesc>3. Viertel 2. Jhdt. v.Chr.<date from="-0150" to="-0126"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaNVFQR5PSCZEFPELBXY57W2VQPM">
-                <catDesc>3. Jhdt. v.Chr.<date from="-300" to="-201"/></catDesc>
+                <catDesc>3. Jhdt. v.Chr.<date from="-0300" to="-0201"/></catDesc>
                 <category xml:id="tla2EPYVX63FFBRJBCOEKC2E42K6Y">
-                  <catDesc>2. Viertel 3. Jhdt. v.Chr.<date from="-275" to="-251"/></catDesc>
+                  <catDesc>2. Viertel 3. Jhdt. v.Chr.<date from="-0275" to="-0251"/></catDesc>
                 </category>
                 <category xml:id="tla2RNQRYRR75HBHJQXKCIINNWCIE">
-                  <catDesc>2. Hälfte 3. Jhdt. v.Chr.<date from="-250" to="-201"/></catDesc>
+                  <catDesc>2. Hälfte 3. Jhdt. v.Chr.<date from="-0250" to="-0201"/></catDesc>
                 </category>
                 <category xml:id="tla7FG3AE5TKBHCBCQIUHZIQS5SPE">
-                  <catDesc>3. Viertel 3. Jhdt. v.Chr.<date from="-250" to="-226"/></catDesc>
+                  <catDesc>3. Viertel 3. Jhdt. v.Chr.<date from="-0250" to="-0226"/></catDesc>
                 </category>
                 <category xml:id="tlaCXCXYSLLUFHMPGQ7ROYMAHLCAA">
-                  <catDesc>1. Hälfte 3. Jhdt. v.Chr.<date from="-300" to="-251"/></catDesc>
+                  <catDesc>1. Hälfte 3. Jhdt. v.Chr.<date from="-0300" to="-0251"/></catDesc>
                 </category>
                 <category xml:id="tlaRDSBFVI3QJG7XNZOXVDLV3LU6I">
-                  <catDesc>1. Viertel 3. Jhdt. v.Chr.<date from="-300" to="-276"/></catDesc>
+                  <catDesc>1. Viertel 3. Jhdt. v.Chr.<date from="-0300" to="-0276"/></catDesc>
                 </category>
                 <category xml:id="tlaRUEGPD2BQBAIRAF35NA3L4VJHY">
-                  <catDesc>4. Viertel 3. Jhdt. v.Chr.<date from="-225" to="-201"/></catDesc>
+                  <catDesc>4. Viertel 3. Jhdt. v.Chr.<date from="-0225" to="-0201"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaPBLVUQXCI5HETLV6ICT7YYYOZI">
-                <catDesc>7. Jhdt. v.Chr.<date from="-700" to="-601"/></catDesc>
+                <catDesc>7. Jhdt. v.Chr.<date from="-0700" to="-0601"/></catDesc>
                 <category xml:id="tlaQIVC46ND4BDUXAWR4EYMD4AUME">
-                  <catDesc>4. Viertel 7. Jhdt. v.Chr.<date from="-625" to="-601"/></catDesc>
+                  <catDesc>4. Viertel 7. Jhdt. v.Chr.<date from="-0625" to="-0601"/></catDesc>
                 </category>
                 <category xml:id="tlaR7RP4HBK7FCSTB74WGGFMBAXJE">
-                  <catDesc>1. Hälfte 7. Jhdt. v.Chr.<date from="-700" to="-651"/></catDesc>
+                  <catDesc>1. Hälfte 7. Jhdt. v.Chr.<date from="-0700" to="-0651"/></catDesc>
                 </category>
                 <category xml:id="tlaVPDCMRCERVH3JBGCJQFWOEV4PE">
-                  <catDesc>2. Viertel 7. Jhdt. v.Chr.<date from="-675" to="-651"/></catDesc>
+                  <catDesc>2. Viertel 7. Jhdt. v.Chr.<date from="-0675" to="-0651"/></catDesc>
                 </category>
                 <category xml:id="tlaVRYK3DNABFC37OCSLTNEE6SX2M">
-                  <catDesc>2. Hälfte 7. Jhdt. v.Chr.<date from="-650" to="-601"/></catDesc>
+                  <catDesc>2. Hälfte 7. Jhdt. v.Chr.<date from="-0650" to="-0601"/></catDesc>
                 </category>
                 <category xml:id="tlaYJ43LQBBSNEVHJTOY2KXTZ4KSQ">
-                  <catDesc>1. Viertel 7. Jhdt. v.Chr.<date from="-700" to="-676"/></catDesc>
+                  <catDesc>1. Viertel 7. Jhdt. v.Chr.<date from="-0700" to="-0676"/></catDesc>
                 </category>
                 <category xml:id="tlaZ7SE63TCNBHDNCAJXDFKZVI43M">
-                  <catDesc>3. Viertel 7. Jhdt. v.Chr.<date from="-650" to="-626"/></catDesc>
+                  <catDesc>3. Viertel 7. Jhdt. v.Chr.<date from="-0650" to="-0626"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaSUWAELMXDVA5VF7G6BGY5FP24Q">
-                <catDesc>5. Jhdt. v.Chr.<date from="-500" to="-401"/></catDesc>
+                <catDesc>5. Jhdt. v.Chr.<date from="-0500" to="-0401"/></catDesc>
                 <category xml:id="tla2SVJUWTG65CGBPSRR2JVGCFZQI">
-                  <catDesc>3. Viertel 5. Jhdt. v.Chr.<date from="-450" to="-426"/></catDesc>
+                  <catDesc>3. Viertel 5. Jhdt. v.Chr.<date from="-0450" to="-0426"/></catDesc>
                 </category>
                 <category xml:id="tla37AKJCT3O5EXHKZVR4OERWJUMM">
-                  <catDesc>2. Viertel 5. Jhdt. v.Chr.<date from="-475" to="-451"/></catDesc>
+                  <catDesc>2. Viertel 5. Jhdt. v.Chr.<date from="-0475" to="-0451"/></catDesc>
                 </category>
                 <category xml:id="tla3RSAUA2SMZGCDEMLGVH47P6IOM">
-                  <catDesc>1. Hälfte 5. Jhdt. v.Chr.<date from="-500" to="-451"/></catDesc>
+                  <catDesc>1. Hälfte 5. Jhdt. v.Chr.<date from="-0500" to="-0451"/></catDesc>
                 </category>
                 <category xml:id="tlaGGPOQYXYZBDUZNTFBXUVFYGDEM">
-                  <catDesc>2. Hälfte 5. Jhdt. v.Chr.<date from="-450" to="-401"/></catDesc>
+                  <catDesc>2. Hälfte 5. Jhdt. v.Chr.<date from="-0450" to="-0401"/></catDesc>
                 </category>
                 <category xml:id="tlaM5RNBQZBHJDSJLRFTESD5PXUUM">
-                  <catDesc>4. Viertel 5. Jhdt. v.Chr.<date from="-425" to="-401"/></catDesc>
+                  <catDesc>4. Viertel 5. Jhdt. v.Chr.<date from="-0425" to="-0401"/></catDesc>
                 </category>
                 <category xml:id="tlaSWTOWPX765HQBK4FBHAFFBF4XE">
-                  <catDesc>1. Viertel 5. Jhdt. v.Chr.<date from="-500" to="-476"/></catDesc>
+                  <catDesc>1. Viertel 5. Jhdt. v.Chr.<date from="-0500" to="-0476"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaSYVSDPY4UFC7VFGH34ZDTEPMMM">
-                <catDesc>6. Jhdt. v.Chr.<date from="-600" to="-501"/></catDesc>
+                <catDesc>6. Jhdt. v.Chr.<date from="-0600" to="-0501"/></catDesc>
                 <category xml:id="tla5RWQE6I76ZDJ7C6RZZHDZ5NZOA">
-                  <catDesc>2. Hälfte 6. Jhdt. v.Chr.<date from="-550" to="-501"/></catDesc>
+                  <catDesc>2. Hälfte 6. Jhdt. v.Chr.<date from="-0550" to="-0501"/></catDesc>
                 </category>
                 <category xml:id="tla742V5NN54JCLRMXZSWDVTG4YK4">
-                  <catDesc>4. Viertel 6. Jhdt. v.Chr.<date from="-525" to="-501"/></catDesc>
+                  <catDesc>4. Viertel 6. Jhdt. v.Chr.<date from="-0525" to="-0501"/></catDesc>
                 </category>
                 <category xml:id="tla7WVJGW33WFHVZI2UBOIDWIKIPI">
-                  <catDesc>1. Hälfte 6. Jhdt. v.Chr.<date from="-600" to="-551"/></catDesc>
+                  <catDesc>1. Hälfte 6. Jhdt. v.Chr.<date from="-0600" to="-0551"/></catDesc>
                 </category>
                 <category xml:id="tlaONBKOHQ33BA2ZC2SC2HQHOG3UY">
-                  <catDesc>2. Viertel 6. Jhdt. v.Chr.<date from="-575" to="-551"/></catDesc>
+                  <catDesc>2. Viertel 6. Jhdt. v.Chr.<date from="-0575" to="-0551"/></catDesc>
                 </category>
                 <category xml:id="tlaRDVGZ5PV4BAGRG2ZBOUB4SBJHI">
-                  <catDesc>3. Viertel 6. Jhdt. v.Chr.<date from="-550" to="-526"/></catDesc>
+                  <catDesc>3. Viertel 6. Jhdt. v.Chr.<date from="-0550" to="-0526"/></catDesc>
                 </category>
                 <category xml:id="tlaWHI6OSNIHJEDFI4VOSPL3NGNQM">
-                  <catDesc>1. Viertel 6. Jhdt. v.Chr.<date from="-600" to="-576"/></catDesc>
+                  <catDesc>1. Viertel 6. Jhdt. v.Chr.<date from="-0600" to="-0576"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaTIKGPKBTXVA6PHCKCHQJ6VIM2M">
-                <catDesc>8. Jhdt. v.Chr.<date from="-800" to="-701"/></catDesc>
+                <catDesc>8. Jhdt. v.Chr.<date from="-0800" to="-0701"/></catDesc>
                 <category xml:id="tla3T5D7CE7MZFTXM5NHH6TB354A4">
-                  <catDesc>1. Hälfte 8. Jhdt. v.Chr.<date from="-800" to="-751"/></catDesc>
+                  <catDesc>1. Hälfte 8. Jhdt. v.Chr.<date from="-0800" to="-0751"/></catDesc>
                 </category>
                 <category xml:id="tla6SL7CB3TV5GCDOFNO6SEKXCPDU">
-                  <catDesc>1. Viertel 8. Jhdt. v.Chr.<date from="-800" to="-776"/></catDesc>
+                  <catDesc>1. Viertel 8. Jhdt. v.Chr.<date from="-0800" to="-0776"/></catDesc>
                 </category>
                 <category xml:id="tlaAY7RFFECHJFYXJVVW7UO73DNDM">
-                  <catDesc>3. Viertel 8. Jhdt. v.Chr.<date from="-750" to="-726"/></catDesc>
+                  <catDesc>3. Viertel 8. Jhdt. v.Chr.<date from="-0750" to="-0726"/></catDesc>
                 </category>
                 <category xml:id="tlaG4YYFKH7ARFA5JOTIHYTNEI4LY">
-                  <catDesc>2. Viertel 8. Jhdt. v.Chr.<date from="-775" to="-751"/></catDesc>
+                  <catDesc>2. Viertel 8. Jhdt. v.Chr.<date from="-0775" to="-0751"/></catDesc>
                 </category>
                 <category xml:id="tlaUH3G5FM2SREITBEJ5RTX7TZYZ4">
-                  <catDesc>2. Hälfte 8. Jhdt. v.Chr.<date from="-750" to="-701"/></catDesc>
+                  <catDesc>2. Hälfte 8. Jhdt. v.Chr.<date from="-0750" to="-0701"/></catDesc>
                 </category>
                 <category xml:id="tlaVIZ3CULWTNB6FPFNJ3OBEDTL5I">
-                  <catDesc>4. Viertel 8. Jhdt. v.Chr.<date from="-725" to="-701"/></catDesc>
+                  <catDesc>4. Viertel 8. Jhdt. v.Chr.<date from="-0725" to="-0701"/></catDesc>
                 </category>
               </category>
             </category>
             <category xml:id="tlaDUVGWT7GSRCKDM5LFTGU6MZ3GY">
-              <catDesc>(Epochen und Dynastien)<date from="0" to="0"/></catDesc>
+              <catDesc>(Epochen und Dynastien)<date from="0000" to="0000"/></catDesc>
               <category xml:id="tla3GGZCLNRQVF6PAEQA6LCFBNE6M">
                 <catDesc>Zweite Zwischenzeit<date from="-1793" to="-1551"/></catDesc>
                 <category xml:id="tlaE4VXX5LISZC2XIR6AYPM3Y3TQI">
@@ -8535,19 +8535,19 @@
               <category xml:id="tla7FUWX6PWFJDAXEWQDOAA4FYXFU">
                 <catDesc>prädynastische Zeit<date from="-5500" to="-3151"/></catDesc>
                 <category xml:id="tla6YAAR2WRI5F6BLP6YMW3G67P6Q">
-                  <catDesc>Neolithikum vor der Badari-Kultur<date from="0" to="0"/></catDesc>
+                  <catDesc>Neolithikum vor der Badari-Kultur<date from="0000" to="0000"/></catDesc>
                 </category>
                 <category xml:id="tlaFMNBFXWGA5C2TEXFRDXOGXBEPE">
-                  <catDesc>Badari-Kultur<date from="0" to="0"/></catDesc>
+                  <catDesc>Badari-Kultur<date from="0000" to="0000"/></catDesc>
                 </category>
                 <category xml:id="tlaIPXSCTKV4REDHIXWTZWDXVXJWY">
-                  <catDesc>Naqada III<date from="0" to="0"/></catDesc>
+                  <catDesc>Naqada III<date from="0000" to="0000"/></catDesc>
                 </category>
                 <category xml:id="tlaP5F2WOP6YZGBHK5KCSCP2UXJHM">
-                  <catDesc>Naqada I<date from="0" to="0"/></catDesc>
+                  <catDesc>Naqada I<date from="0000" to="0000"/></catDesc>
                 </category>
                 <category xml:id="tlaWLIRCHQ3DRF4ZOTIREDVCPKC5A">
-                  <catDesc>Naqada II<date from="0" to="0"/></catDesc>
+                  <catDesc>Naqada II<date from="0000" to="0000"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaBILVGTX4DVEERA2TQ2DFPYYTK4">
@@ -8725,200 +8725,200 @@
                 </category>
               </category>
               <category xml:id="tlaHYYNMJRFTVFIHB7JUA6M2QW3LQ">
-                <catDesc>Makedonen, Ptolemäer<date from="-332" to="-31"/></catDesc>
+                <catDesc>Makedonen, Ptolemäer<date from="-0332" to="-0031"/></catDesc>
                 <category xml:id="tla5EXFFIIQ2BFLJBUPM345Q52RYE">
-                  <catDesc>Ptolemaios XIII.<date from="-51" to="-47"/></catDesc>
+                  <catDesc>Ptolemaios XIII.<date from="-0051" to="-0047"/></catDesc>
                 </category>
                 <category xml:id="tla6CEMTQHBPVCKRGBPZV3SBCJFHM">
-                  <catDesc>Ptolemaios II. Philadelphos<date from="-285" to="-246"/></catDesc>
+                  <catDesc>Ptolemaios II. Philadelphos<date from="-0285" to="-0246"/></catDesc>
                 </category>
                 <category xml:id="tla7SZBT5EB75DZVEYNMMNDRAR6WM">
-                  <catDesc>Ptolemaios I. Soter<date from="-305" to="-283"/></catDesc>
+                  <catDesc>Ptolemaios I. Soter<date from="-0305" to="-0283"/></catDesc>
                 </category>
                 <category xml:id="tlaBB2LXNAEFRHAFOQHR7VCS2GUDE">
-                  <catDesc>Kleopatra VII.<date from="-51" to="-30"/></catDesc>
+                  <catDesc>Kleopatra VII.<date from="-0051" to="-0030"/></catDesc>
                 </category>
                 <category xml:id="tlaBHAOO6DORBCPVDTRZTJSLM3MHM">
-                  <catDesc>Ptolemaios VI. Philometor<date from="-180" to="-145"/></catDesc>
+                  <catDesc>Ptolemaios VI. Philometor<date from="-0180" to="-0145"/></catDesc>
                 </category>
                 <category xml:id="tlaBJBGAQ4PCJHSRISGG6ZIEP26YI">
-                  <catDesc>Alexander IV.<date from="-323" to="-311"/></catDesc>
+                  <catDesc>Alexander IV.<date from="-0323" to="-0311"/></catDesc>
                 </category>
                 <category xml:id="tlaEAIXVOD3ZFAQXCGUYG2MUERGXU">
-                  <catDesc>Ptolemaios VIII. Euergetes II.<date from="-170" to="-116"/></catDesc>
+                  <catDesc>Ptolemaios VIII. Euergetes II.<date from="-0170" to="-0116"/></catDesc>
                 </category>
                 <category xml:id="tlaEB27VJIJZZFPLDR5ONLBMQUJQY">
-                  <catDesc>Philipp Arrhidaios<date from="-323" to="-317"/></catDesc>
+                  <catDesc>Philipp Arrhidaios<date from="-0323" to="-0317"/></catDesc>
                 </category>
                 <category xml:id="tlaETFKXMIJTBE45KASN7GX4BG5VI">
-                  <catDesc>Ptolemaios XIV. Philopator<date from="-47" to="-44"/></catDesc>
+                  <catDesc>Ptolemaios XIV. Philopator<date from="-0047" to="-0044"/></catDesc>
                 </category>
                 <category xml:id="tlaKAK54XJY4BBU3PXESJCBL6YQHM">
-                  <catDesc>Ptolemaios V. Epiphanes<date from="-204" to="-180"/></catDesc>
+                  <catDesc>Ptolemaios V. Epiphanes<date from="-0204" to="-0180"/></catDesc>
                 </category>
                 <category xml:id="tlaM2BT2KZR4RAYJIWGOO6N3P4C64">
-                  <catDesc>Alexander der Große<date from="-332" to="-323"/></catDesc>
+                  <catDesc>Alexander der Große<date from="-0332" to="-0323"/></catDesc>
                 </category>
                 <category xml:id="tlaMHVALMEFXBE7BKJGFSD7LCSRVM">
-                  <catDesc>Ptolemaios XII. Philopator Philadelphos Neos Dionysos<date from="-80" to="-51"/></catDesc>
+                  <catDesc>Ptolemaios XII. Philopator Philadelphos Neos Dionysos<date from="-0080" to="-0051"/></catDesc>
                 </category>
                 <category xml:id="tlaMP63BC4W6NHILLBC2NAFBF7ZTA">
-                  <catDesc>Ptolemaios IX. Soter II.<date from="-116" to="-80"/></catDesc>
+                  <catDesc>Ptolemaios IX. Soter II.<date from="-0116" to="-0080"/></catDesc>
                 </category>
                 <category xml:id="tlaPCA5EX57QNGOFAJAM3SOI6VV4M">
-                  <catDesc>Ptolemaios VII. Neos Philopator<date from="-145" to="-144"/></catDesc>
+                  <catDesc>Ptolemaios VII. Neos Philopator<date from="-0145" to="-0144"/></catDesc>
                 </category>
                 <category xml:id="tlaQU2M4UGNUNDHTE5DUANDIT5K4M">
-                  <catDesc>Ptolemaios X. Alexander I.<date from="-114" to="-88"/></catDesc>
+                  <catDesc>Ptolemaios X. Alexander I.<date from="-0114" to="-0088"/></catDesc>
                 </category>
                 <category xml:id="tlaTU4NLFP3EBHXHGMDL7F7IOGFCQ">
-                  <catDesc>Ptolemaios III. Euergetes<date from="-246" to="-222"/></catDesc>
+                  <catDesc>Ptolemaios III. Euergetes<date from="-0246" to="-0222"/></catDesc>
                 </category>
                 <category xml:id="tlaUGINSOQZARG3NJSLGNVX3STTIE">
-                  <catDesc>Ptolemaios XI. Alexander II.<date from="-80" to="-80"/></catDesc>
+                  <catDesc>Ptolemaios XI. Alexander II.<date from="-0080" to="-0080"/></catDesc>
                 </category>
                 <category xml:id="tlaXYP4XJ2LEVCS7DBSHGYOH4WYOU">
-                  <catDesc>Ptolemaios IV. Philopator<date from="-221" to="-205"/></catDesc>
+                  <catDesc>Ptolemaios IV. Philopator<date from="-0221" to="-0205"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaJS32JKX2CNG25GZ3B6MGYMDU4I">
-                <catDesc>Dritte Zwischenzeit<date from="-1070" to="-665"/></catDesc>
+                <catDesc>Dritte Zwischenzeit<date from="-1070" to="-0665"/></catDesc>
                 <category xml:id="tla3XW6DLUBKVCLHD6KY45JN2PRD4">
-                  <catDesc>Kuschiten<date from="-780" to="-656"/></catDesc>
+                  <catDesc>Kuschiten<date from="-0780" to="-0656"/></catDesc>
                   <category xml:id="tla2ZQQIYQHVRDGTH6PPY2LWEQCUQ">
-                    <catDesc>Schabataka<date from="-698" to="-691"/></catDesc>
+                    <catDesc>Schabataka<date from="-0698" to="-0691"/></catDesc>
                   </category>
                   <category xml:id="tla7FDXNLDP5FFK5EBDS5TKXVPP6A">
-                    <catDesc>Kaschta<date from="-760" to="-741"/></catDesc>
+                    <catDesc>Kaschta<date from="-0760" to="-0741"/></catDesc>
                   </category>
                   <category xml:id="tla7PIUCJYC7BBVXLMOIZYT72PWJQ">
-                    <catDesc>Alara<date from="-780" to="-761"/></catDesc>
+                    <catDesc>Alara<date from="-0780" to="-0761"/></catDesc>
                   </category>
                   <category xml:id="tlaEFGOT3UFWZG27GZOSTKIU3X2KE">
-                    <catDesc>Tanutamon<date from="-664" to="-656"/></catDesc>
+                    <catDesc>Tanutamon<date from="-0664" to="-0656"/></catDesc>
                   </category>
                   <category xml:id="tlaNL6KKNWSCFGGLO75JDALYFOL4U">
-                    <catDesc>Taharqa<date from="-690" to="-665"/></catDesc>
+                    <catDesc>Taharqa<date from="-0690" to="-0665"/></catDesc>
                   </category>
                   <category xml:id="tlaSCJLUQ4CSFFRJF6XNZ34OV4DFQ">
-                    <catDesc>Pije<date from="-740" to="-714"/></catDesc>
+                    <catDesc>Pije<date from="-0740" to="-0714"/></catDesc>
                   </category>
                   <category xml:id="tlaXNHKJRIXSNB77GIB66CWTBWGHQ">
-                    <catDesc>Schabaka<date from="-713" to="-699"/></catDesc>
+                    <catDesc>Schabaka<date from="-0713" to="-0699"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tla744HIAA6FRHBROALBB3DV4VV3I">
-                  <catDesc>25. Dyn.<date from="-713" to="-656"/></catDesc>
+                  <catDesc>25. Dyn.<date from="-0713" to="-0656"/></catDesc>
                   <category xml:id="tlaCWZ4MSSSSBEIPK2RBFSX45ZBMI">
-                    <catDesc>Schabataka<date from="-698" to="-691"/></catDesc>
+                    <catDesc>Schabataka<date from="-0698" to="-0691"/></catDesc>
                   </category>
                   <category xml:id="tlaFLAXS36WHJA5TJUDDWKHQONVEM">
-                    <catDesc>Tanutamon<date from="-664" to="-656"/></catDesc>
+                    <catDesc>Tanutamon<date from="-0664" to="-0656"/></catDesc>
                   </category>
                   <category xml:id="tlaUWRHN5WFJ5GGBCYKPZXK4YE2GU">
-                    <catDesc>Schabaka<date from="-713" to="-699"/></catDesc>
+                    <catDesc>Schabaka<date from="-0713" to="-0699"/></catDesc>
                   </category>
                   <category xml:id="tlaVNUNBFCAMNFC7KMHL4QWVJXFTE">
-                    <catDesc>Taharqa<date from="-690" to="-665"/></catDesc>
+                    <catDesc>Taharqa<date from="-0690" to="-0665"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tla7J6HVBL7CJHQPJHG6TBBXJMYMM">
-                  <catDesc>24. Dyn.<date from="-740" to="-712"/></catDesc>
+                  <catDesc>24. Dyn.<date from="-0740" to="-0712"/></catDesc>
                   <category xml:id="tla47CU2AIR3BAGXEDHUKRZ5NLI44">
-                    <catDesc>Bokchoris<date from="-718" to="-712"/></catDesc>
+                    <catDesc>Bokchoris<date from="-0718" to="-0712"/></catDesc>
                   </category>
                   <category xml:id="tlaJMRTQ7BOBZCUPEREM5VMJ2WJZE">
-                    <catDesc>Tefnachte<date from="-740" to="-719"/></catDesc>
+                    <catDesc>Tefnachte<date from="-0740" to="-0719"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaE7YEQAEKZVEJ5PX7WKOXY2QEEM">
-                  <catDesc>21. Dyn.<date from="-1070" to="-946"/></catDesc>
+                  <catDesc>21. Dyn.<date from="-1070" to="-0946"/></catDesc>
                   <category xml:id="tla677YHBKQIRHB3HVZG45V2N6DU4">
-                    <catDesc>Siamun<date from="-978" to="-960"/></catDesc>
+                    <catDesc>Siamun<date from="-0978" to="-0960"/></catDesc>
                   </category>
                   <category xml:id="tlaBBZR65BX2JHZJHOPWOGMFFE42A">
                     <catDesc>Smendes<date from="-1070" to="-1044"/></catDesc>
                   </category>
                   <category xml:id="tlaG2XFFZLE4ZHDNMISPFYCHJJB4M">
-                    <catDesc>Psusennes I.<date from="-1043" to="-994"/></catDesc>
+                    <catDesc>Psusennes I.<date from="-1043" to="-0994"/></catDesc>
                   </category>
                   <category xml:id="tlaNOTZ5UOGYZD2VBH6D6JXBOW6LI">
-                    <catDesc>Psusennes II.<date from="-959" to="-946"/></catDesc>
+                    <catDesc>Psusennes II.<date from="-0959" to="-0946"/></catDesc>
                   </category>
                   <category xml:id="tlaO5QKFTC7YBCKNDSQJOKBWT63BY">
-                    <catDesc>Amenemopet<date from="-996" to="-985"/></catDesc>
+                    <catDesc>Amenemopet<date from="-0996" to="-0985"/></catDesc>
                   </category>
                   <category xml:id="tlaSBF7EA7BN5FOVO6JXZQHUWGYTQ">
                     <catDesc>Amenemnisut / Nephercheres<date from="-1043" to="-1040"/></catDesc>
                   </category>
                   <category xml:id="tlaXVUCQSGCYBHKFNXJYMSKRL4R2M">
-                    <catDesc>Osochor<date from="-984" to="-979"/></catDesc>
+                    <catDesc>Osochor<date from="-0984" to="-0979"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaWASRAHTUHNE6HDWN5URBHDIR2M">
-                  <catDesc>22. / 23. Dyn.<date from="-945" to="-712"/></catDesc>
+                  <catDesc>22. / 23. Dyn.<date from="-0945" to="-0712"/></catDesc>
                   <category xml:id="tlaARW2M7F3JFF7HP7XCQ34JREODY">
-                    <catDesc>Scheschonq III.<date from="-837" to="-785"/></catDesc>
+                    <catDesc>Scheschonq III.<date from="-0837" to="-0785"/></catDesc>
                   </category>
                   <category xml:id="tlaBFBDVC3P25FALCKMNPTNBNYQNA">
-                    <catDesc>Pemu<date from="-785" to="-774"/></catDesc>
+                    <catDesc>Pemu<date from="-0785" to="-0774"/></catDesc>
                   </category>
                   <category xml:id="tlaBPYQBIAZPVCWZHDS7M3C2GL53U">
-                    <catDesc>Scheschonq V.<date from="-774" to="-736"/></catDesc>
+                    <catDesc>Scheschonq V.<date from="-0774" to="-0736"/></catDesc>
                   </category>
                   <category xml:id="tlaBV3NUTCOVBAHDOBBNO44T2F4VY">
-                    <catDesc>Scheschonq II.<date from="-877" to="-875"/></catDesc>
+                    <catDesc>Scheschonq II.<date from="-0877" to="-0875"/></catDesc>
                   </category>
                   <category xml:id="tlaD7L7SMVVVFEWREVPZSXPGMDMUA">
-                    <catDesc>Harsiese<date from="-870" to="-850"/></catDesc>
+                    <catDesc>Harsiese<date from="-0870" to="-0850"/></catDesc>
                   </category>
                   <category xml:id="tlaDUH5NGZGPZHIXA2SBPDTFYRV54">
-                    <catDesc>Psammus<date from="-722" to="-712"/></catDesc>
+                    <catDesc>Psammus<date from="-0722" to="-0712"/></catDesc>
                   </category>
                   <category xml:id="tlaIZT7J5CGRZEX3OT5ERPRYWQTYY">
-                    <catDesc>Scheschonq IV.<date from="-805" to="-790"/></catDesc>
+                    <catDesc>Scheschonq IV.<date from="-0805" to="-0790"/></catDesc>
                   </category>
                   <category xml:id="tlaKNKTVZBWMBDOPKZ4RVIK43DSME">
-                    <catDesc>Osorkon IV.<date from="-731" to="-722"/></catDesc>
+                    <catDesc>Osorkon IV.<date from="-0731" to="-0722"/></catDesc>
                   </category>
                   <category xml:id="tlaLJNCZ3RENZGYDDTSANDPNMVKRI">
-                    <catDesc>Petubastis I.<date from="-830" to="-805"/></catDesc>
+                    <catDesc>Petubastis I.<date from="-0830" to="-0805"/></catDesc>
                   </category>
                   <category xml:id="tlaMPKA3BGQ5VDRDE4SQKHBU7I5RM">
-                    <catDesc>Osorkon II.<date from="-875" to="-837"/></catDesc>
+                    <catDesc>Osorkon II.<date from="-0875" to="-0837"/></catDesc>
                   </category>
                   <category xml:id="tlaN47PT66YEVCDHFFZUVIML2BE2M">
-                    <catDesc>Petubastis II.<date from="-756" to="-731"/></catDesc>
+                    <catDesc>Petubastis II.<date from="-0756" to="-0731"/></catDesc>
                   </category>
                   <category xml:id="tlaNUDYSH53HVGNTM2FTELC5TFSQI">
-                    <catDesc>Osorkon I.<date from="-924" to="-891"/></catDesc>
+                    <catDesc>Osorkon I.<date from="-0924" to="-0891"/></catDesc>
                   </category>
                   <category xml:id="tlaPBUFJKFM4NH2XEBUVIEZCB6A3M">
-                    <catDesc>Takelot II.<date from="-841" to="-816"/></catDesc>
+                    <catDesc>Takelot II.<date from="-0841" to="-0816"/></catDesc>
                   </category>
                   <category xml:id="tlaR2UVPCKDIRFOBF4QR5W6UY73QY">
-                    <catDesc>Osorkon III.<date from="-790" to="-762"/></catDesc>
+                    <catDesc>Osorkon III.<date from="-0790" to="-0762"/></catDesc>
                   </category>
                   <category xml:id="tlaT3PXE2RRVRCIFCRUQP4PCSQMOI">
-                    <catDesc>Iuput I.<date from="-816" to="-800"/></catDesc>
+                    <catDesc>Iuput I.<date from="-0816" to="-0800"/></catDesc>
                   </category>
                   <category xml:id="tlaT6GEYS2Y3RGF3O3ZGQWHBJZMQI">
-                    <catDesc>Iuput II.<date from="-756" to="-725"/></catDesc>
+                    <catDesc>Iuput II.<date from="-0756" to="-0725"/></catDesc>
                   </category>
                   <category xml:id="tlaTLM3NFHYG5HRHICGSS6SI6HEBI">
-                    <catDesc>Rudamun<date from="-755" to="-735"/></catDesc>
+                    <catDesc>Rudamun<date from="-0755" to="-0735"/></catDesc>
                   </category>
                   <category xml:id="tlaTMQJAUESNRGSXF4GT75ECQKKYQ">
-                    <catDesc>Iny<date from="-735" to="-730"/></catDesc>
+                    <catDesc>Iny<date from="-0735" to="-0730"/></catDesc>
                   </category>
                   <category xml:id="tlaUUZQDMMULNCRHNP2EV4OBUNCOM">
-                    <catDesc>Takelot III.<date from="-767" to="-755"/></catDesc>
+                    <catDesc>Takelot III.<date from="-0767" to="-0755"/></catDesc>
                   </category>
                   <category xml:id="tlaVFTMODKBGZAGNENLGHGNGNBXM4">
-                    <catDesc>Takelot I.<date from="-890" to="-877"/></catDesc>
+                    <catDesc>Takelot I.<date from="-0890" to="-0877"/></catDesc>
                   </category>
                   <category xml:id="tlaXZ2WE35X5NGFTN37A7ZOS4CD54">
-                    <catDesc>Scheschonq I.<date from="-945" to="-925"/></catDesc>
+                    <catDesc>Scheschonq I.<date from="-0945" to="-0925"/></catDesc>
                   </category>
                 </category>
               </category>
@@ -9019,95 +9019,95 @@
                 </category>
               </category>
               <category xml:id="tlaS62ITYADMZGCHBHTHTAFV3RUGQ">
-                <catDesc>byzantinische Zeit<date from="395" to="641"/></catDesc>
+                <catDesc>byzantinische Zeit<date from="0395" to="0641"/></catDesc>
               </category>
               <category xml:id="tlaUGTUTKXZHBDYLG7YJZ5AGOJXQY">
-                <catDesc>Spätzeit<date from="-664" to="-333"/></catDesc>
+                <catDesc>Spätzeit<date from="-0664" to="-0333"/></catDesc>
                 <category xml:id="tla2AVEQ3VFT5EEPF7NBH7RHCVBXA">
-                  <catDesc>27. Dyn.<date from="-525" to="-402"/></catDesc>
+                  <catDesc>27. Dyn.<date from="-0525" to="-0402"/></catDesc>
                   <category xml:id="tla7MP3UDFCTNH7HPPCH3RRJGEUOI">
-                    <catDesc>Kambyses<date from="-525" to="-522"/></catDesc>
+                    <catDesc>Kambyses<date from="-0525" to="-0522"/></catDesc>
                   </category>
                   <category xml:id="tlaAY5C3JQWXNAM5NIBQVZFPAU7OU">
-                    <catDesc>Artaxerxes I.<date from="-464" to="-425"/></catDesc>
+                    <catDesc>Artaxerxes I.<date from="-0464" to="-0425"/></catDesc>
                   </category>
                   <category xml:id="tlaCX7WTFO76NEIREYNBAZEMCKZJA">
-                    <catDesc>Artaxerxes II.<date from="-404" to="-402"/></catDesc>
+                    <catDesc>Artaxerxes II.<date from="-0404" to="-0402"/></catDesc>
                   </category>
                   <category xml:id="tlaDFOATHXUQJFSJLTVPASC3TQF7M">
-                    <catDesc>Xerxes II.<date from="-424" to="-424"/></catDesc>
+                    <catDesc>Xerxes II.<date from="-0424" to="-0424"/></catDesc>
                   </category>
                   <category xml:id="tlaDHKNUBJOYVE4DNGXMYMVUFJHTU">
-                    <catDesc>Dareios II.<date from="-423" to="-405"/></catDesc>
+                    <catDesc>Dareios II.<date from="-0423" to="-0405"/></catDesc>
                   </category>
                   <category xml:id="tlaLG2ZONR34VEQROX4FJ7MTCXKLM">
-                    <catDesc>Dareios I.<date from="-521" to="-486"/></catDesc>
+                    <catDesc>Dareios I.<date from="-0521" to="-0486"/></catDesc>
                   </category>
                   <category xml:id="tlaMJ3WULDBQVD3NJM4NFJQWMAYWI">
-                    <catDesc>Xerxes I.<date from="-485" to="-465"/></catDesc>
+                    <catDesc>Xerxes I.<date from="-0485" to="-0465"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tla2Z7FB3JW3BHGRPWOII5PAYY4DM">
-                  <catDesc>31. Dyn.<date from="-341" to="-333"/></catDesc>
+                  <catDesc>31. Dyn.<date from="-0341" to="-0333"/></catDesc>
                   <category xml:id="tla6XFG65VENRHERHIHREIUEPT7V4">
-                    <catDesc>Arses<date from="-338" to="-337"/></catDesc>
+                    <catDesc>Arses<date from="-0338" to="-0337"/></catDesc>
                   </category>
                   <category xml:id="tlaHULJPMHB4FGENJGZ7DPTWIADZE">
-                    <catDesc>Artaxerxes III. Ochos<date from="-341" to="-339"/></catDesc>
+                    <catDesc>Artaxerxes III. Ochos<date from="-0341" to="-0339"/></catDesc>
                   </category>
                   <category xml:id="tlaI6OREN4DZFDKDDCN6FDFJDB5ZE">
-                    <catDesc>Dareios III.<date from="-336" to="-333"/></catDesc>
+                    <catDesc>Dareios III.<date from="-0336" to="-0333"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tla42CP5AWFYFFVXFWGXMJLO2ZWWI">
-                  <catDesc>28. Dyn.<date from="-401" to="-399"/></catDesc>
+                  <catDesc>28. Dyn.<date from="-0401" to="-0399"/></catDesc>
                   <category xml:id="tlaONG6H7BR5VBQPMWVKIG5RYZQWE">
-                    <catDesc>Amyrtaios<date from="-401" to="-399"/></catDesc>
+                    <catDesc>Amyrtaios<date from="-0401" to="-0399"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaFZRARLPZPZG5JM6XGGLTTEU3KM">
-                  <catDesc>29. Dyn.<date from="-398" to="-380"/></catDesc>
+                  <catDesc>29. Dyn.<date from="-0398" to="-0380"/></catDesc>
                   <category xml:id="tlaR3R4WMMU3VANVIGTRB5VPTHDYY">
-                    <catDesc>Nepherites II.<date from="-380" to="-380"/></catDesc>
+                    <catDesc>Nepherites II.<date from="-0380" to="-0380"/></catDesc>
                   </category>
                   <category xml:id="tlaRX4OI7SAIJD4PIPLKCSDEHC5DQ">
-                    <catDesc>Nepherites I.<date from="-398" to="-394"/></catDesc>
+                    <catDesc>Nepherites I.<date from="-0398" to="-0394"/></catDesc>
                   </category>
                   <category xml:id="tlaWSDXCFS7NBAZ7J6P6XHEKJ4CZA">
-                    <catDesc>Achoris<date from="-393" to="-381"/></catDesc>
+                    <catDesc>Achoris<date from="-0393" to="-0381"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaQHQZNMAUZFCTZMLD5BGMDIKS6M">
-                  <catDesc>26. Dyn.<date from="-664" to="-526"/></catDesc>
+                  <catDesc>26. Dyn.<date from="-0664" to="-0526"/></catDesc>
                   <category xml:id="tla26FQR3PAGBFZLNTFH2VIKTYGVY">
-                    <catDesc>Necho<date from="-610" to="-596"/></catDesc>
+                    <catDesc>Necho<date from="-0610" to="-0596"/></catDesc>
                   </category>
                   <category xml:id="tlaAX5RS54IHNHLLHTG5ACTVOAUII">
-                    <catDesc>Amasis<date from="-570" to="-527"/></catDesc>
+                    <catDesc>Amasis<date from="-0570" to="-0527"/></catDesc>
                   </category>
                   <category xml:id="tlaL3OEF7GYRZAVDA5J3RRDFHKKSQ">
-                    <catDesc>Psammetich III.<date from="-526" to="-526"/></catDesc>
+                    <catDesc>Psammetich III.<date from="-0526" to="-0526"/></catDesc>
                   </category>
                   <category xml:id="tlaRWBAUHG5OVARXHA3ZVA4TFKSHQ">
-                    <catDesc>Psammetich II.<date from="-595" to="-590"/></catDesc>
+                    <catDesc>Psammetich II.<date from="-0595" to="-0590"/></catDesc>
                   </category>
                   <category xml:id="tlaSSHXBGXDW5BJ3AEFHXVYZLBWAI">
-                    <catDesc>Psammetich I.<date from="-664" to="-611"/></catDesc>
+                    <catDesc>Psammetich I.<date from="-0664" to="-0611"/></catDesc>
                   </category>
                   <category xml:id="tlaWBJEV25Q3RHT5NUYRUEGBY5LC4">
-                    <catDesc>Apries<date from="-589" to="-571"/></catDesc>
+                    <catDesc>Apries<date from="-0589" to="-0571"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaZAQON3S37NHEJMZP33RUX47ZY4">
-                  <catDesc>30. Dyn.<date from="-379" to="-342"/></catDesc>
+                  <catDesc>30. Dyn.<date from="-0379" to="-0342"/></catDesc>
                   <category xml:id="tla2EYHVBPX4NGUZPVTRAKO36TDWE">
-                    <catDesc>Teos<date from="-363" to="-361"/></catDesc>
+                    <catDesc>Teos<date from="-0363" to="-0361"/></catDesc>
                   </category>
                   <category xml:id="tla5J7P2WPKN5GMNJD735VZP5JARQ">
-                    <catDesc>Nektanebos II.<date from="-360" to="-342"/></catDesc>
+                    <catDesc>Nektanebos II.<date from="-0360" to="-0342"/></catDesc>
                   </category>
                   <category xml:id="tlaAS735FI63FEQTISOFW6R6ITQQI">
-                    <catDesc>Nektanebos I.<date from="-379" to="-364"/></catDesc>
+                    <catDesc>Nektanebos I.<date from="-0379" to="-0364"/></catDesc>
                   </category>
                 </category>
               </category>
@@ -9220,281 +9220,281 @@
                 </category>
               </category>
               <category xml:id="tlaYZP5WTOZV5FB5EZFGQDY7MYKIQ">
-                <catDesc>römische Zeit<date from="-31" to="395"/></catDesc>
+                <catDesc>römische Zeit<date from="-0031" to="0395"/></catDesc>
                 <category xml:id="tla2A6LYDLVHRBPXFZKPZU7CEOAIM">
-                  <catDesc>"Soldatenkaiser"<date from="235" to="284"/></catDesc>
+                  <catDesc>"Soldatenkaiser"<date from="0235" to="0284"/></catDesc>
                 </category>
                 <category xml:id="tla4XAVOEBBHVCGZIGICZCPL2N2N4">
-                  <catDesc>Severer<date from="193" to="235"/></catDesc>
+                  <catDesc>Severer<date from="0193" to="0235"/></catDesc>
                   <category xml:id="tla3TAIGNOV5BDMLOMA5QOH4OOHHU">
-                    <catDesc>Macrinus<date from="217" to="218"/></catDesc>
+                    <catDesc>Macrinus<date from="0217" to="0218"/></catDesc>
                   </category>
                   <category xml:id="tla5IHX5Q7WPNEM3GUPGVUQJ55S2M">
-                    <catDesc>Severus Alexander<date from="222" to="235"/></catDesc>
+                    <catDesc>Severus Alexander<date from="0222" to="0235"/></catDesc>
                   </category>
                   <category xml:id="tla6I2IJQAXYVG3ZCPOQE2JR6RFGU">
-                    <catDesc>Septimius Severus<date from="193" to="211"/></catDesc>
+                    <catDesc>Septimius Severus<date from="0193" to="0211"/></catDesc>
                   </category>
                   <category xml:id="tlaJCO2GZFWPJHT3O2VMQLPOCWMQU">
-                    <catDesc>Caracalla<date from="212" to="217"/></catDesc>
+                    <catDesc>Caracalla<date from="0212" to="0217"/></catDesc>
                   </category>
                   <category xml:id="tlaU4NUJYYIJFBYRJP3OHALCEQSM4">
-                    <catDesc>Elagabal<date from="218" to="222"/></catDesc>
+                    <catDesc>Elagabal<date from="0218" to="0222"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaFLZYUFLZMBCYZFIV6HIBSRIMPM">
-                  <catDesc>Adoptivkaiser<date from="96" to="192"/></catDesc>
+                  <catDesc>Adoptivkaiser<date from="0096" to="0192"/></catDesc>
                   <category xml:id="tla67URIQ5T5BAC5H7TPXM437SPU4">
-                    <catDesc>Antoninus Pius<date from="138" to="161"/></catDesc>
+                    <catDesc>Antoninus Pius<date from="0138" to="0161"/></catDesc>
                   </category>
                   <category xml:id="tla7CND52XKPNC5PIVU42CQ7FWAF4">
-                    <catDesc>Nerva<date from="96" to="98"/></catDesc>
+                    <catDesc>Nerva<date from="0096" to="0098"/></catDesc>
                   </category>
                   <category xml:id="tlaK7FNLUAFURALDGBN4FV3LSUWZI">
-                    <catDesc>Commodus<date from="180" to="192"/></catDesc>
+                    <catDesc>Commodus<date from="0180" to="0192"/></catDesc>
                   </category>
                   <category xml:id="tlaSBPP7UMVLNFRROVHN5MV4P3JMY">
-                    <catDesc>Hadrian<date from="117" to="138"/></catDesc>
+                    <catDesc>Hadrian<date from="0117" to="0138"/></catDesc>
                   </category>
                   <category xml:id="tlaT5JLVAADRVCFFEE4AYQG7JUZXQ">
-                    <catDesc>Marcus Aurelius<date from="161" to="180"/></catDesc>
+                    <catDesc>Marcus Aurelius<date from="0161" to="0180"/></catDesc>
                   </category>
                   <category xml:id="tlaXPSJ2LYDHBGNFD6CCPHJDKX4AY">
-                    <catDesc>Trajan<date from="98" to="117"/></catDesc>
+                    <catDesc>Trajan<date from="0098" to="0117"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaKNI3FP7F3ZD7NLNZLEQOAIIG5U">
-                  <catDesc>Tetrarchenzeit<date from="284" to="395"/></catDesc>
+                  <catDesc>Tetrarchenzeit<date from="0284" to="0395"/></catDesc>
                 </category>
                 <category xml:id="tlaNWBNCEAMTFCPTNGFVWWNQMPTVI">
-                  <catDesc>julisch-claudische Dynastie<date from="-30" to="68"/></catDesc>
+                  <catDesc>julisch-claudische Dynastie<date from="-0030" to="0068"/></catDesc>
                   <category xml:id="tla2HOJVMMCYBGGZBLAJPG2UMXHP4">
-                    <catDesc>Augustus<date from="-30" to="14"/></catDesc>
+                    <catDesc>Augustus<date from="-0030" to="0014"/></catDesc>
                   </category>
                   <category xml:id="tla6JNLCELRGFGW5DDAMGPF56DUAY">
-                    <catDesc>Tiberius<date from="14" to="37"/></catDesc>
+                    <catDesc>Tiberius<date from="0014" to="0037"/></catDesc>
                   </category>
                   <category xml:id="tlaGKPIXD7FTBDQJETU2TITXC4QFQ">
-                    <catDesc>Claudius<date from="41" to="54"/></catDesc>
+                    <catDesc>Claudius<date from="0041" to="0054"/></catDesc>
                   </category>
                   <category xml:id="tlaOTVJNIXD7NCJZHX4YZ7HEWCPXM">
-                    <catDesc>Gaius<date from="37" to="41"/></catDesc>
+                    <catDesc>Gaius<date from="0037" to="0041"/></catDesc>
                   </category>
                   <category xml:id="tlaQVSUL54D5ZHFXP3S7MIOEU6GGA">
-                    <catDesc>Nero<date from="54" to="68"/></catDesc>
+                    <catDesc>Nero<date from="0054" to="0068"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaTLFBMDUZ2RE6JNZW7GZDBHWATM">
-                  <catDesc>Flavier<date from="69" to="96"/></catDesc>
+                  <catDesc>Flavier<date from="0069" to="0096"/></catDesc>
                   <category xml:id="tla7QV5OTUCG5BG3HMCRBR4CCVYGU">
-                    <catDesc>Domitian<date from="81" to="96"/></catDesc>
+                    <catDesc>Domitian<date from="0081" to="0096"/></catDesc>
                   </category>
                   <category xml:id="tlaOSXPG6CJZNHRFG3CC7SYHU654Q">
-                    <catDesc>Titus<date from="79" to="81"/></catDesc>
+                    <catDesc>Titus<date from="0079" to="0081"/></catDesc>
                   </category>
                   <category xml:id="tlaUEGCHD2YV5HL3E4DQ2C57NYFIU">
-                    <catDesc>Verspasian<date from="69" to="79"/></catDesc>
+                    <catDesc>Verspasian<date from="0069" to="0079"/></catDesc>
                   </category>
                 </category>
               </category>
             </category>
             <category xml:id="tlaFHZEINDCEJAOTHIVC35NYGMC2Q">
-              <catDesc>(Jahrhunderte n.Chr.)<date from="0" to="0"/></catDesc>
+              <catDesc>(Jahrhunderte n.Chr.)<date from="0000" to="0000"/></catDesc>
               <category xml:id="tla4GVKWKAP4VFSLFPBUBAI7XF2YA">
-                <catDesc>5. Jhdt. n.Chr.<date from="401" to="500"/></catDesc>
+                <catDesc>5. Jhdt. n.Chr.<date from="0401" to="0500"/></catDesc>
                 <category xml:id="tla57U3TQQLHZGSFHQ3GAWVITBYUQ">
-                  <catDesc>1. Viertel 5. Jhdt. n.Chr.<date from="401" to="425"/></catDesc>
+                  <catDesc>1. Viertel 5. Jhdt. n.Chr.<date from="0401" to="0425"/></catDesc>
                 </category>
                 <category xml:id="tlaAGZE4BISKREPFOZJJ5SZMRBKJQ">
-                  <catDesc>3. Viertel 5. Jhdt. n.Chr.<date from="451" to="475"/></catDesc>
+                  <catDesc>3. Viertel 5. Jhdt. n.Chr.<date from="0451" to="0475"/></catDesc>
                 </category>
                 <category xml:id="tlaDHJI2BOMWFCKBM52LDN3NEUYO4">
-                  <catDesc>2. Viertel 5. Jhdt. n.Chr.<date from="426" to="450"/></catDesc>
+                  <catDesc>2. Viertel 5. Jhdt. n.Chr.<date from="0426" to="0450"/></catDesc>
                 </category>
                 <category xml:id="tlaNXGHKWOMDZCZRHV474Y3FSMSVU">
-                  <catDesc>2. Hälfte 5. Jhdt. n.Chr.<date from="451" to="500"/></catDesc>
+                  <catDesc>2. Hälfte 5. Jhdt. n.Chr.<date from="0451" to="0500"/></catDesc>
                 </category>
                 <category xml:id="tlaPZP2HLFD4ZD7PAJWWJA4C6IDHQ">
-                  <catDesc>1. Hälfte 5. Jhdt. n.Chr.<date from="401" to="450"/></catDesc>
+                  <catDesc>1. Hälfte 5. Jhdt. n.Chr.<date from="0401" to="0450"/></catDesc>
                 </category>
                 <category xml:id="tlaXDJUGWOTXFFDZD344WXR5QQBPQ">
-                  <catDesc>4. Viertel 5. Jhdt. n.Chr.<date from="476" to="500"/></catDesc>
+                  <catDesc>4. Viertel 5. Jhdt. n.Chr.<date from="0476" to="0500"/></catDesc>
                 </category>
               </category>
               <category xml:id="tla77UKMRWAJZC5LALMVTEAD6L7VA">
-                <catDesc>1. Jhdt. n.Chr.<date from="1" to="100"/></catDesc>
+                <catDesc>1. Jhdt. n.Chr.<date from="0001" to="0100"/></catDesc>
                 <category xml:id="tla2EGWXRGUCBHIDCTZXMZGGEYHPE">
-                  <catDesc>2. Viertel 1. Jhdt. n.Chr.<date from="26" to="50"/></catDesc>
+                  <catDesc>2. Viertel 1. Jhdt. n.Chr.<date from="0026" to="0050"/></catDesc>
                 </category>
                 <category xml:id="tla4GCBH775S5GTVNDXXASM2HFY3Q">
-                  <catDesc>3. Viertel 1. Jhdt. n.Chr.<date from="51" to="75"/></catDesc>
+                  <catDesc>3. Viertel 1. Jhdt. n.Chr.<date from="0051" to="0075"/></catDesc>
                 </category>
                 <category xml:id="tlaAIVG3ELQKNC4HKUIDHONGLB4TQ">
-                  <catDesc>1. Hälfte 1. Jhdt. n.Chr.<date from="1" to="50"/></catDesc>
+                  <catDesc>1. Hälfte 1. Jhdt. n.Chr.<date from="0001" to="0050"/></catDesc>
                 </category>
                 <category xml:id="tlaJSFEL3SGN5DW5JSWMKHGRW7GSA">
-                  <catDesc>2. Hälfte 1. Jhdt. n.Chr.<date from="51" to="100"/></catDesc>
+                  <catDesc>2. Hälfte 1. Jhdt. n.Chr.<date from="0051" to="0100"/></catDesc>
                 </category>
                 <category xml:id="tlaOZZZBMWUEBA7FHBJFEKZRKK3SQ">
-                  <catDesc>1. Viertel 1. Jhdt. n.Chr.<date from="1" to="25"/></catDesc>
+                  <catDesc>1. Viertel 1. Jhdt. n.Chr.<date from="0001" to="0025"/></catDesc>
                 </category>
                 <category xml:id="tlaWRWGTJLJNRHETBFC52BVHERDCQ">
-                  <catDesc>4. Viertel 1. Jhdt. n.Chr.<date from="76" to="100"/></catDesc>
+                  <catDesc>4. Viertel 1. Jhdt. n.Chr.<date from="0076" to="0100"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaDU6YTUV2IZEYTOA7GVBMTBCV3I">
-                <catDesc>4. Jhdt. n.Chr.<date from="301" to="400"/></catDesc>
+                <catDesc>4. Jhdt. n.Chr.<date from="0301" to="0400"/></catDesc>
                 <category xml:id="tla5J4Y3SI54NGWZHHKU63JMNFKCA">
-                  <catDesc>1. Viertel 4. Jhdt. n.Chr.<date from="301" to="325"/></catDesc>
+                  <catDesc>1. Viertel 4. Jhdt. n.Chr.<date from="0301" to="0325"/></catDesc>
                 </category>
                 <category xml:id="tla6Y3WYJK76VFQRLZIMWF443PLUI">
-                  <catDesc>3. Viertel 4. Jhdt. n.Chr.<date from="351" to="375"/></catDesc>
+                  <catDesc>3. Viertel 4. Jhdt. n.Chr.<date from="0351" to="0375"/></catDesc>
                 </category>
                 <category xml:id="tlaMG2USRRI6BB57BC2SCZTBMIG4Q">
-                  <catDesc>2. Hälfte 4. Jhdt. n.Chr.<date from="351" to="400"/></catDesc>
+                  <catDesc>2. Hälfte 4. Jhdt. n.Chr.<date from="0351" to="0400"/></catDesc>
                 </category>
                 <category xml:id="tlaNP53EQUQQ5AN7JPKA77LISIWPI">
-                  <catDesc>2. Viertel 4. Jhdt. n.Chr.<date from="326" to="350"/></catDesc>
+                  <catDesc>2. Viertel 4. Jhdt. n.Chr.<date from="0326" to="0350"/></catDesc>
                 </category>
                 <category xml:id="tlaWDMZ3ZJLVVAYTA4ZX4SXLI4MPA">
-                  <catDesc>1. Hälfte 4. Jhdt. n.Chr.<date from="301" to="350"/></catDesc>
+                  <catDesc>1. Hälfte 4. Jhdt. n.Chr.<date from="0301" to="0350"/></catDesc>
                 </category>
                 <category xml:id="tlaWPEQO2GQTNE5XHPPIYVJG75WLE">
-                  <catDesc>4. Viertel 4. Jhdt. n.Chr.<date from="376" to="400"/></catDesc>
+                  <catDesc>4. Viertel 4. Jhdt. n.Chr.<date from="0376" to="0400"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaEQM4LZPKYJCWFNQ445M6XU3UCY">
-                <catDesc>2. Jhdt. n.Chr.<date from="101" to="200"/></catDesc>
+                <catDesc>2. Jhdt. n.Chr.<date from="0101" to="0200"/></catDesc>
                 <category xml:id="tla5HNMTTVLOREQ3LKMJOCIH7Z5GU">
-                  <catDesc>1. Hälfte 2. Jhdt. n.Chr.<date from="101" to="150"/></catDesc>
+                  <catDesc>1. Hälfte 2. Jhdt. n.Chr.<date from="0101" to="0150"/></catDesc>
                 </category>
                 <category xml:id="tlaDXLYH5WDSRHZVE3XTFKN72X7ZQ">
-                  <catDesc>2. Hälfte 2. Jhdt. n.Chr.<date from="151" to="200"/></catDesc>
+                  <catDesc>2. Hälfte 2. Jhdt. n.Chr.<date from="0151" to="0200"/></catDesc>
                 </category>
                 <category xml:id="tlaHT44AOEA5ZFFJBINX2DBUS3LYE">
-                  <catDesc>1. Viertel 2. Jhdt. n.Chr.<date from="101" to="125"/></catDesc>
+                  <catDesc>1. Viertel 2. Jhdt. n.Chr.<date from="0101" to="0125"/></catDesc>
                 </category>
                 <category xml:id="tlaIIPELUHXL5G3TEZXTVQMSJCMIE">
-                  <catDesc>2. Viertel 2. Jhdt. n.Chr.<date from="126" to="150"/></catDesc>
+                  <catDesc>2. Viertel 2. Jhdt. n.Chr.<date from="0126" to="0150"/></catDesc>
                 </category>
                 <category xml:id="tlaIO2NFBCQMJDSJGZB4QF7QRMMSY">
-                  <catDesc>4. Viertel 2. Jhdt. n.Chr.<date from="176" to="200"/></catDesc>
+                  <catDesc>4. Viertel 2. Jhdt. n.Chr.<date from="0176" to="0200"/></catDesc>
                 </category>
                 <category xml:id="tlaMPCVCKDBWNC77GRCMHQQM66CUE">
-                  <catDesc>3. Viertel 2. Jhdt. n.Chr.<date from="151" to="175"/></catDesc>
+                  <catDesc>3. Viertel 2. Jhdt. n.Chr.<date from="0151" to="0175"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaFV6TQYR4MJBDTCWZABXH4E4OMY">
-                <catDesc>9. Jhdt. n.Chr.<date from="801" to="900"/></catDesc>
+                <catDesc>9. Jhdt. n.Chr.<date from="0801" to="0900"/></catDesc>
                 <category xml:id="tla3MEPLXDHJZH25EFWG4ONSPBADU">
-                  <catDesc>1. Hälfte 9. Jhdt. n.Chr.<date from="801" to="850"/></catDesc>
+                  <catDesc>1. Hälfte 9. Jhdt. n.Chr.<date from="0801" to="0850"/></catDesc>
                 </category>
                 <category xml:id="tlaGCOGRW2AFNFAZC7CAH5VY2TIYI">
-                  <catDesc>4. Viertel 9. Jhdt. n.Chr.<date from="876" to="900"/></catDesc>
+                  <catDesc>4. Viertel 9. Jhdt. n.Chr.<date from="0876" to="0900"/></catDesc>
                 </category>
                 <category xml:id="tlaMVDHBIPHCNEEVIZYTF4HL7XTGM">
-                  <catDesc>1. Viertel 9. Jhdt. n.Chr.<date from="801" to="825"/></catDesc>
+                  <catDesc>1. Viertel 9. Jhdt. n.Chr.<date from="0801" to="0825"/></catDesc>
                 </category>
                 <category xml:id="tlaQSRVICICSJD6VOVHOP3Z3BBG5Y">
-                  <catDesc>3. Viertel 9. Jhdt. n.Chr.<date from="851" to="875"/></catDesc>
+                  <catDesc>3. Viertel 9. Jhdt. n.Chr.<date from="0851" to="0875"/></catDesc>
                 </category>
                 <category xml:id="tlaSQYBTEXKORB6VCUCL5P5CABDBY">
-                  <catDesc>2. Hälfte 9. Jhdt. n.Chr.<date from="851" to="900"/></catDesc>
+                  <catDesc>2. Hälfte 9. Jhdt. n.Chr.<date from="0851" to="0900"/></catDesc>
                 </category>
                 <category xml:id="tlaZ2OYYVNKXNCUDJRR6ZFGJHBBZ4">
-                  <catDesc>2. Viertel 9. Jhdt. n.Chr.<date from="826" to="850"/></catDesc>
+                  <catDesc>2. Viertel 9. Jhdt. n.Chr.<date from="0826" to="0850"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaIMBHKBIKV5AUHEAAU2DL2K2GN4">
-                <catDesc>3. Jhdt. n.Chr.<date from="201" to="300"/></catDesc>
+                <catDesc>3. Jhdt. n.Chr.<date from="0201" to="0300"/></catDesc>
                 <category xml:id="tlaC5KTZJIALBBA3BP3DB3BHAF3RA">
-                  <catDesc>4. Viertel 3. Jhdt. n.Chr.<date from="276" to="300"/></catDesc>
+                  <catDesc>4. Viertel 3. Jhdt. n.Chr.<date from="0276" to="0300"/></catDesc>
                 </category>
                 <category xml:id="tlaKENXXLN7BRAYHAMA7O447DA73Y">
-                  <catDesc>2. Viertel 3. Jhdt. n.Chr.<date from="226" to="250"/></catDesc>
+                  <catDesc>2. Viertel 3. Jhdt. n.Chr.<date from="0226" to="0250"/></catDesc>
                 </category>
                 <category xml:id="tlaQPUHN5VYWVAGPKZ3ZHYQFMYPNQ">
-                  <catDesc>2. Hälfte 3. Jhdt. n.Chr.<date from="251" to="300"/></catDesc>
+                  <catDesc>2. Hälfte 3. Jhdt. n.Chr.<date from="0251" to="0300"/></catDesc>
                 </category>
                 <category xml:id="tlaRNVKCEB3GJBZNDSHZSA6UDH5BU">
-                  <catDesc>1. Hälfte 3. Jhdt. n.Chr.<date from="201" to="250"/></catDesc>
+                  <catDesc>1. Hälfte 3. Jhdt. n.Chr.<date from="0201" to="0250"/></catDesc>
                 </category>
                 <category xml:id="tlaX7UGMEM77FBDXEPEMLGPVANWOI">
-                  <catDesc>3. Viertel 3. Jhdt. n.Chr.<date from="251" to="275"/></catDesc>
+                  <catDesc>3. Viertel 3. Jhdt. n.Chr.<date from="0251" to="0275"/></catDesc>
                 </category>
                 <category xml:id="tlaZDX4UT6C7NGQZEUL55SAXFWDIQ">
-                  <catDesc>1. Viertel 3. Jhdt. n.Chr.<date from="201" to="225"/></catDesc>
+                  <catDesc>1. Viertel 3. Jhdt. n.Chr.<date from="0201" to="0225"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaMRHDSYHO4FCH5FRYRE3F47QHSQ">
-                <catDesc>6. Jhdt. n.Chr.<date from="501" to="600"/></catDesc>
+                <catDesc>6. Jhdt. n.Chr.<date from="0501" to="0600"/></catDesc>
                 <category xml:id="tla4BMTXUOSFBH6VBJLBMCOBFANBQ">
-                  <catDesc>1. Viertel 6. Jhdt. n.Chr.<date from="501" to="525"/></catDesc>
+                  <catDesc>1. Viertel 6. Jhdt. n.Chr.<date from="0501" to="0525"/></catDesc>
                 </category>
                 <category xml:id="tlaOJPO7GMS75E75LTRJNRX2DCTGQ">
-                  <catDesc>2. Hälfte 6. Jhdt. n.Chr.<date from="551" to="600"/></catDesc>
+                  <catDesc>2. Hälfte 6. Jhdt. n.Chr.<date from="0551" to="0600"/></catDesc>
                 </category>
                 <category xml:id="tlaUGV7KEWHUBBHNOKSVSU6EDZ5UU">
-                  <catDesc>4. Viertel 6. Jhdt. n.Chr.<date from="576" to="600"/></catDesc>
+                  <catDesc>4. Viertel 6. Jhdt. n.Chr.<date from="0576" to="0600"/></catDesc>
                 </category>
                 <category xml:id="tlaXNT2W3PJZZHY7C46BD6UZHRLJA">
-                  <catDesc>2. Viertel 6. Jhdt. n.Chr.<date from="526" to="550"/></catDesc>
+                  <catDesc>2. Viertel 6. Jhdt. n.Chr.<date from="0526" to="0550"/></catDesc>
                 </category>
                 <category xml:id="tlaXWW436FZEZC23OUSX7IPSXLWXA">
-                  <catDesc>1. Hälfte 6. Jhdt. n.Chr.<date from="501" to="550"/></catDesc>
+                  <catDesc>1. Hälfte 6. Jhdt. n.Chr.<date from="0501" to="0550"/></catDesc>
                 </category>
                 <category xml:id="tlaZYRH3FYJNNAQDOACTPR2YKSV6U">
-                  <catDesc>3. Viertel 6. Jhdt. n.Chr.<date from="551" to="575"/></catDesc>
+                  <catDesc>3. Viertel 6. Jhdt. n.Chr.<date from="0551" to="0575"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaTU6P6HMKY5AB7DLLOJVA77746E">
-                <catDesc>7. Jhdt. n.Chr.<date from="601" to="700"/></catDesc>
+                <catDesc>7. Jhdt. n.Chr.<date from="0601" to="0700"/></catDesc>
                 <category xml:id="tla22SCMOXZQFDXRNHIOVRBPNOPZM">
-                  <catDesc>1. Viertel 7. Jhdt. n.Chr.<date from="601" to="625"/></catDesc>
+                  <catDesc>1. Viertel 7. Jhdt. n.Chr.<date from="0601" to="0625"/></catDesc>
                 </category>
                 <category xml:id="tla74MF3BTZAVEBBFNK6KFLKUEHVA">
-                  <catDesc>4. Viertel 7. Jhdt. n.Chr.<date from="675" to="700"/></catDesc>
+                  <catDesc>4. Viertel 7. Jhdt. n.Chr.<date from="0675" to="0700"/></catDesc>
                 </category>
                 <category xml:id="tlaFMT2DC5ZUJD2HEQACDEMXUFZB4">
-                  <catDesc>2. Viertel 7. Jhdt. n.Chr.<date from="626" to="650"/></catDesc>
+                  <catDesc>2. Viertel 7. Jhdt. n.Chr.<date from="0626" to="0650"/></catDesc>
                 </category>
                 <category xml:id="tlaI5IQORK3F5BVZPETMCXQSJP5WA">
-                  <catDesc>1. Hälfte 7. Jhdt. n.Chr.<date from="601" to="650"/></catDesc>
+                  <catDesc>1. Hälfte 7. Jhdt. n.Chr.<date from="0601" to="0650"/></catDesc>
                 </category>
                 <category xml:id="tlaTZTJKFTIEZCKBGVD2NSIPT2JQY">
-                  <catDesc>3. Viertel 7. Jhdt. n.Chr.<date from="651" to="675"/></catDesc>
+                  <catDesc>3. Viertel 7. Jhdt. n.Chr.<date from="0651" to="0675"/></catDesc>
                 </category>
                 <category xml:id="tlaUKKBW2H6HJFIZCVHBREHPIGGVQ">
-                  <catDesc>2. Hälfte 7. Jhdt. n.Chr.<date from="651" to="700"/></catDesc>
+                  <catDesc>2. Hälfte 7. Jhdt. n.Chr.<date from="0651" to="0700"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaY55AYTMYANAOFCYUMYJWZRPSZA">
-                <catDesc>8. Jhdt. n.Chr.<date from="701" to="800"/></catDesc>
+                <catDesc>8. Jhdt. n.Chr.<date from="0701" to="0800"/></catDesc>
                 <category xml:id="tlaI5GTTHOZWJCY5LTQLIFAM4WYDM">
-                  <catDesc>3. Viertel 8. Jhdt. n.Chr.<date from="751" to="775"/></catDesc>
+                  <catDesc>3. Viertel 8. Jhdt. n.Chr.<date from="0751" to="0775"/></catDesc>
                 </category>
                 <category xml:id="tlaPTTURIUYEVGRNIDYMJWFOHLZSI">
-                  <catDesc>2. Hälfte 8. Jhdt. n.Chr.<date from="751" to="800"/></catDesc>
+                  <catDesc>2. Hälfte 8. Jhdt. n.Chr.<date from="0751" to="0800"/></catDesc>
                 </category>
                 <category xml:id="tlaPVZ6R3YIHZBRPNWWLX5VZTIUZU">
-                  <catDesc>1. Hälfte 8. Jhdt. n.Chr.<date from="701" to="750"/></catDesc>
+                  <catDesc>1. Hälfte 8. Jhdt. n.Chr.<date from="0701" to="0750"/></catDesc>
                 </category>
                 <category xml:id="tlaQVPJSG5RUFGMNMAQNWUHEBYJKM">
-                  <catDesc>1. Viertel 8. Jhdt. n.Chr.<date from="701" to="725"/></catDesc>
+                  <catDesc>1. Viertel 8. Jhdt. n.Chr.<date from="0701" to="0725"/></catDesc>
                 </category>
                 <category xml:id="tlaSJGD7JW3PZAHHB2FHJKWVTSIBM">
-                  <catDesc>4. Viertel 8. Jhdt. n.Chr.<date from="776" to="800"/></catDesc>
+                  <catDesc>4. Viertel 8. Jhdt. n.Chr.<date from="0776" to="0800"/></catDesc>
                 </category>
                 <category xml:id="tlaVTOAVISRORHJPAQK3FTRPHYAQE">
-                  <catDesc>2. Viertel 8. Jhdt. n.Chr.<date from="726" to="750"/></catDesc>
+                  <catDesc>2. Viertel 8. Jhdt. n.Chr.<date from="0726" to="0750"/></catDesc>
                 </category>
               </category>
             </category>
             <category xml:id="tlaFKLXKTC5RJFSZCBDU5HWK6KHGU">
-              <catDesc>(unbekannt)<date from="0" to="0"/></catDesc>
+              <catDesc>(unbekannt)<date from="0000" to="0000"/></catDesc>
             </category>
             <category xml:id="tlaGTIHALKZWJFTNCLZ3ITXK7HBXA">
-              <catDesc>(unbestimmt)<date from="0" to="0"/></catDesc>
+              <catDesc>(unbestimmt)<date from="0000" to="0000"/></catDesc>
             </category>
           </category>
           <category xml:id="tlaN4EKSVODAND4VALYASB5BQOFB4">

--- a/files/thesaurus.xml
+++ b/files/thesaurus.xml
@@ -8325,9 +8325,9 @@
             </category>
           </category>
           <category xml:id="tlaMXWX4WG43ZHI7D4RLTGK3IBGXY">
-            <catDesc>9 = Datierungen</catDesc>
+            <catDesc>9 = Datierungen<date from="-5500" to="0900"/></catDesc>
             <category xml:id="tlaD3R5CH5NZBDA7IZMCKKJPWYZKU">
-              <catDesc>(Jahrhunderte v.Chr.)<date from="0000" to="0000"/></catDesc>
+              <catDesc>(Jahrhunderte v.Chr.)<date from="-0900" to="-0001"/></catDesc>
               <category xml:id="tla2ZIZTYBKYNFNVFTFBA32CAAY7A">
                 <catDesc>1. Jhdt. v.Chr.<date from="-0100" to="-0001"/></catDesc>
                 <category xml:id="tla3V5NOJIC3VBIZBA7QCD6OFSAQY">
@@ -8519,7 +8519,7 @@
               </category>
             </category>
             <category xml:id="tlaDUVGWT7GSRCKDM5LFTGU6MZ3GY">
-              <catDesc>(Epochen und Dynastien)<date from="0000" to="0000"/></catDesc>
+              <catDesc>(Epochen und Dynastien)<date from="-5500" to="0641"/></catDesc>
               <category xml:id="tla3GGZCLNRQVF6PAEQA6LCFBNE6M">
                 <catDesc>Zweite Zwischenzeit<date from="-1793" to="-1551"/></catDesc>
                 <category xml:id="tlaE4VXX5LISZC2XIR6AYPM3Y3TQI">
@@ -8535,19 +8535,19 @@
               <category xml:id="tla7FUWX6PWFJDAXEWQDOAA4FYXFU">
                 <catDesc>prädynastische Zeit<date from="-5500" to="-3151"/></catDesc>
                 <category xml:id="tla6YAAR2WRI5F6BLP6YMW3G67P6Q">
-                  <catDesc>Neolithikum vor der Badari-Kultur<date from="0000" to="0000"/></catDesc>
+                  <catDesc>Neolithikum vor der Badari-Kultur<date from="-5500" to="-5000"/></catDesc>
                 </category>
                 <category xml:id="tlaFMNBFXWGA5C2TEXFRDXOGXBEPE">
-                  <catDesc>Badari-Kultur<date from="0000" to="0000"/></catDesc>
+                  <catDesc>Badari-Kultur<date from="-5000" to="-3900"/></catDesc>
                 </category>
                 <category xml:id="tlaIPXSCTKV4REDHIXWTZWDXVXJWY">
-                  <catDesc>Naqada III<date from="0000" to="0000"/></catDesc>
+                  <catDesc>Naqada III<date from="-3300" to="-3151"/></catDesc>
                 </category>
                 <category xml:id="tlaP5F2WOP6YZGBHK5KCSCP2UXJHM">
-                  <catDesc>Naqada I<date from="0000" to="0000"/></catDesc>
+                  <catDesc>Naqada I<date from="-3900" to="-3650"/></catDesc>
                 </category>
                 <category xml:id="tlaWLIRCHQ3DRF4ZOTIREDVCPKC5A">
-                  <catDesc>Naqada II<date from="0000" to="0000"/></catDesc>
+                  <catDesc>Naqada II<date from="-3650" to="-3300"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaBILVGTX4DVEERA2TQ2DFPYYTK4">
@@ -8725,7 +8725,7 @@
                 </category>
               </category>
               <category xml:id="tlaHYYNMJRFTVFIHB7JUA6M2QW3LQ">
-                <catDesc>Makedonen, Ptolemäer<date from="-0332" to="-0031"/></catDesc>
+                <catDesc>Makedonen, Ptolemäer<date from="-0332" to="-0030"/></catDesc>
                 <category xml:id="tla5EXFFIIQ2BFLJBUPM345Q52RYE">
                   <catDesc>Ptolemaios XIII.<date from="-0051" to="-0047"/></catDesc>
                 </category>
@@ -8782,7 +8782,7 @@
                 </category>
               </category>
               <category xml:id="tlaJS32JKX2CNG25GZ3B6MGYMDU4I">
-                <catDesc>Dritte Zwischenzeit<date from="-1070" to="-0665"/></catDesc>
+                <catDesc>Dritte Zwischenzeit<date from="-1070" to="-0656"/></catDesc>
                 <category xml:id="tla3XW6DLUBKVCLHD6KY45JN2PRD4">
                   <catDesc>Kuschiten<date from="-0780" to="-0656"/></catDesc>
                   <category xml:id="tla2ZQQIYQHVRDGTH6PPY2LWEQCUQ">
@@ -8923,7 +8923,7 @@
                 </category>
               </category>
               <category xml:id="tlaMM4QYACJOJCCLJWBD6VAX2FLKE">
-                <catDesc>Mittleres Reich<date from="-2026" to="-1794"/></catDesc>
+                <catDesc>Mittleres Reich<date from="-2135" to="-1794"/></catDesc>
                 <category xml:id="tla7G4I7VLRZFCZFBDWXWJBCSPIPI">
                   <catDesc>11. Dyn. (Gesamtzeitraum)<date from="-2135" to="-1993"/></catDesc>
                   <category xml:id="tlaDD6XPV4VBFE2ZAP66IXKVPGWKQ">
@@ -9299,7 +9299,7 @@
               </category>
             </category>
             <category xml:id="tlaFHZEINDCEJAOTHIVC35NYGMC2Q">
-              <catDesc>(Jahrhunderte n.Chr.)<date from="0000" to="0000"/></catDesc>
+              <catDesc>(Jahrhunderte n.Chr.)<date from="0001" to="0900"/></catDesc>
               <category xml:id="tla4GVKWKAP4VFSLFPBUBAI7XF2YA">
                 <catDesc>5. Jhdt. n.Chr.<date from="0401" to="0500"/></catDesc>
                 <category xml:id="tla57U3TQQLHZGSFHQ3GAWVITBYUQ">
@@ -9491,10 +9491,10 @@
               </category>
             </category>
             <category xml:id="tlaFKLXKTC5RJFSZCBDU5HWK6KHGU">
-              <catDesc>(unbekannt)<date from="0000" to="0000"/></catDesc>
+              <catDesc>(unbekannt)<date from="-5500" to="0900"/></catDesc>
             </category>
             <category xml:id="tlaGTIHALKZWJFTNCLZ3ITXK7HBXA">
-              <catDesc>(unbestimmt)<date from="0000" to="0000"/></catDesc>
+              <catDesc>(unbestimmt)<date from="-5500" to="0900"/></catDesc>
             </category>
           </category>
           <category xml:id="tlaN4EKSVODAND4VALYASB5BQOFB4">

--- a/files/thesaurus.xml
+++ b/files/thesaurus.xml
@@ -8327,1174 +8327,1174 @@
           <category xml:id="tlaMXWX4WG43ZHI7D4RLTGK3IBGXY">
             <catDesc>9 = Datierungen</catDesc>
             <category xml:id="tlaD3R5CH5NZBDA7IZMCKKJPWYZKU">
-              <catDesc>(Jahrhunderte v.Chr.)</catDesc>
+              <catDesc>(Jahrhunderte v.Chr.)<date from="0" to="0"/></catDesc>
               <category xml:id="tla2ZIZTYBKYNFNVFTFBA32CAAY7A">
-                <catDesc>1. Jhdt. v.Chr.</catDesc>
+                <catDesc>1. Jhdt. v.Chr.<date from="-100" to="-1"/></catDesc>
                 <category xml:id="tla3V5NOJIC3VBIZBA7QCD6OFSAQY">
-                  <catDesc>4. Viertel 1. Jhdt. v.Chr.</catDesc>
+                  <catDesc>4. Viertel 1. Jhdt. v.Chr.<date from="-25" to="-1"/></catDesc>
                 </category>
                 <category xml:id="tla7LG7A3WDXNFCVDQICH6CXVIJXM">
-                  <catDesc>1. Hälfte 1. Jhdt. v.Chr.</catDesc>
+                  <catDesc>1. Hälfte 1. Jhdt. v.Chr.<date from="-100" to="-51"/></catDesc>
                 </category>
                 <category xml:id="tlaEIO2LWBQURGJVC7LQZE5UHGMPU">
-                  <catDesc>2. Viertel 1. Jhdt. v.Chr.</catDesc>
+                  <catDesc>2. Viertel 1. Jhdt. v.Chr.<date from="-75" to="-51"/></catDesc>
                 </category>
                 <category xml:id="tlaOSHKAITIJJAOVE4XNMQOVUA6JA">
-                  <catDesc>2. Hälfte 1. Jhdt. v.Chr.</catDesc>
+                  <catDesc>2. Hälfte 1. Jhdt. v.Chr.<date from="-50" to="-1"/></catDesc>
                 </category>
                 <category xml:id="tlaUQRNNAQXKBBLFEREMXSODORMFY">
-                  <catDesc>1. Viertel 1. Jhdt. v.Chr.</catDesc>
+                  <catDesc>1. Viertel 1. Jhdt. v.Chr.<date from="-100" to="-76"/></catDesc>
                 </category>
                 <category xml:id="tlaZLKNXXGL7VA7VEECINB7NS65WI">
-                  <catDesc>3. Viertel 1. Jhdt. v.Chr.</catDesc>
+                  <catDesc>3. Viertel 1. Jhdt. v.Chr.<date from="-50" to="-26"/></catDesc>
                 </category>
               </category>
               <category xml:id="tla5I4CKE7K4FE67NZU4FYVG66GG4">
-                <catDesc>9. Jhdt. v.Chr.</catDesc>
+                <catDesc>9. Jhdt. v.Chr.<date from="-900" to="-801"/></catDesc>
                 <category xml:id="tlaEHYAY2QQMFBLXE4DYP6AR3ZN3I">
-                  <catDesc>4. Viertel 9. Jhdt. v.Chr.</catDesc>
+                  <catDesc>4. Viertel 9. Jhdt. v.Chr.<date from="-825" to="-801"/></catDesc>
                 </category>
                 <category xml:id="tlaFMKPIG5ISZH6JOPISBT7M5INSU">
-                  <catDesc>2. Hälfte 9. Jhdt. v.Chr.</catDesc>
+                  <catDesc>2. Hälfte 9. Jhdt. v.Chr.<date from="-850" to="-801"/></catDesc>
                 </category>
                 <category xml:id="tlaKNIVMJRE45AXBDQFA37HTNZZF4">
-                  <catDesc>1. Hälfte 9. Jhdt. v.Chr.</catDesc>
+                  <catDesc>1. Hälfte 9. Jhdt. v.Chr.<date from="-900" to="-851"/></catDesc>
                 </category>
                 <category xml:id="tlaTA5P36EB5NABBB6Q4J22ZQNF3I">
-                  <catDesc>1. Viertel 9. Jhdt. v.Chr.</catDesc>
+                  <catDesc>1. Viertel 9. Jhdt. v.Chr.<date from="-900" to="-876"/></catDesc>
                 </category>
                 <category xml:id="tlaVZHQZE6KPJFARE6JBNNOWVD7JI">
-                  <catDesc>3. Viertel 9. Jhdt. v.Chr.</catDesc>
+                  <catDesc>3. Viertel 9. Jhdt. v.Chr.<date from="-850" to="-826"/></catDesc>
                 </category>
                 <category xml:id="tlaZBQWVJND7ZCKNG4LSV64RXUJJU">
-                  <catDesc>2. Viertel 9. Jhdt. v.Chr.</catDesc>
+                  <catDesc>2. Viertel 9. Jhdt. v.Chr.<date from="-875" to="-851"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaJ5JVKLZBXJH5VGTKXCTPBJ2KZE">
-                <catDesc>4. Jhdt. v.Chr.</catDesc>
+                <catDesc>4. Jhdt. v.Chr.<date from="-400" to="-301"/></catDesc>
                 <category xml:id="tla2VUPFL5N5FCC7FF4ECKTUY35Q4">
-                  <catDesc>2. Hälfte 4. Jhdt. v.Chr.</catDesc>
+                  <catDesc>2. Hälfte 4. Jhdt. v.Chr.<date from="-350" to="-301"/></catDesc>
                 </category>
                 <category xml:id="tla33LKEBW63FFSNCVMGOSMDBGFNQ">
-                  <catDesc>1. Hälfte 4. Jhdt. v.Chr.</catDesc>
+                  <catDesc>1. Hälfte 4. Jhdt. v.Chr.<date from="-400" to="-351"/></catDesc>
                 </category>
                 <category xml:id="tlaCSL4LTLEQBBSXGZ353PCVGCFZQ">
-                  <catDesc>1. Viertel 4. Jhdt. v.Chr.</catDesc>
+                  <catDesc>1. Viertel 4. Jhdt. v.Chr.<date from="-400" to="-376"/></catDesc>
                 </category>
                 <category xml:id="tlaIPYKL4XDHJBFJE7D7AZ47HXVIM">
-                  <catDesc>3. Viertel 4. Jhdt. v.Chr.</catDesc>
+                  <catDesc>3. Viertel 4. Jhdt. v.Chr.<date from="-350" to="-326"/></catDesc>
                 </category>
                 <category xml:id="tlaPYJNB3V355DMZERYYWMFHZ5NNI">
-                  <catDesc>4. Viertel 4. Jhdt. v.Chr.</catDesc>
+                  <catDesc>4. Viertel 4. Jhdt. v.Chr.<date from="-325" to="-301"/></catDesc>
                 </category>
                 <category xml:id="tlaSX4FBQBUQFCSHBJFDSCPRLRRY4">
-                  <catDesc>2. Viertel 4. Jhdt. v.Chr.</catDesc>
+                  <catDesc>2. Viertel 4. Jhdt. v.Chr.<date from="-375" to="-351"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaL34UY7MQCRB2JCBPNZKLGP2ZL4">
-                <catDesc>2. Jhdt. v.Chr.</catDesc>
+                <catDesc>2. Jhdt. v.Chr.<date from="-200" to="-101"/></catDesc>
                 <category xml:id="tlaBZNFBS76HVCPTJSYIUV22TSXBQ">
-                  <catDesc>2. Hälfte 2. Jhdt. v.Chr.</catDesc>
+                  <catDesc>2. Hälfte 2. Jhdt. v.Chr.<date from="-150" to="-101"/></catDesc>
                 </category>
                 <category xml:id="tlaDZUK4KHXJZBK5DIDGR6JDOMV4A">
-                  <catDesc>2. Viertel 2. Jhdt. v.Chr.</catDesc>
+                  <catDesc>2. Viertel 2. Jhdt. v.Chr.<date from="-175" to="-151"/></catDesc>
                 </category>
                 <category xml:id="tlaHXGOS6R4BFGJRAFU6ZWTFAIYOA">
-                  <catDesc>1. Hälfte 2. Jhdt. v.Chr.</catDesc>
+                  <catDesc>1. Hälfte 2. Jhdt. v.Chr.<date from="-200" to="-151"/></catDesc>
                 </category>
                 <category xml:id="tlaPTSGMJ72MVDM3LGZS63DM4ENQI">
-                  <catDesc>1. Viertel 2. Jhdt. v.Chr.</catDesc>
+                  <catDesc>1. Viertel 2. Jhdt. v.Chr.<date from="-200" to="-176"/></catDesc>
                 </category>
                 <category xml:id="tlaWFXACEBXJZA77IUNL2T2G4WJWA">
-                  <catDesc>4. Viertel 2. Jhdt. v.Chr.</catDesc>
+                  <catDesc>4. Viertel 2. Jhdt. v.Chr.<date from="-125" to="-101"/></catDesc>
                 </category>
                 <category xml:id="tlaXQOCZAYRS5B4FA7XUIXRLZXOCA">
-                  <catDesc>3. Viertel 2. Jhdt. v.Chr.</catDesc>
+                  <catDesc>3. Viertel 2. Jhdt. v.Chr.<date from="-150" to="-126"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaNVFQR5PSCZEFPELBXY57W2VQPM">
-                <catDesc>3. Jhdt. v.Chr.</catDesc>
+                <catDesc>3. Jhdt. v.Chr.<date from="-300" to="-201"/></catDesc>
                 <category xml:id="tla2EPYVX63FFBRJBCOEKC2E42K6Y">
-                  <catDesc>2. Viertel 3. Jhdt. v.Chr.</catDesc>
+                  <catDesc>2. Viertel 3. Jhdt. v.Chr.<date from="-275" to="-251"/></catDesc>
                 </category>
                 <category xml:id="tla2RNQRYRR75HBHJQXKCIINNWCIE">
-                  <catDesc>2. Hälfte 3. Jhdt. v.Chr.</catDesc>
+                  <catDesc>2. Hälfte 3. Jhdt. v.Chr.<date from="-250" to="-201"/></catDesc>
                 </category>
                 <category xml:id="tla7FG3AE5TKBHCBCQIUHZIQS5SPE">
-                  <catDesc>3. Viertel 3. Jhdt. v.Chr.</catDesc>
+                  <catDesc>3. Viertel 3. Jhdt. v.Chr.<date from="-250" to="-226"/></catDesc>
                 </category>
                 <category xml:id="tlaCXCXYSLLUFHMPGQ7ROYMAHLCAA">
-                  <catDesc>1. Hälfte 3. Jhdt. v.Chr.</catDesc>
+                  <catDesc>1. Hälfte 3. Jhdt. v.Chr.<date from="-300" to="-251"/></catDesc>
                 </category>
                 <category xml:id="tlaRDSBFVI3QJG7XNZOXVDLV3LU6I">
-                  <catDesc>1. Viertel 3. Jhdt. v.Chr.</catDesc>
+                  <catDesc>1. Viertel 3. Jhdt. v.Chr.<date from="-300" to="-276"/></catDesc>
                 </category>
                 <category xml:id="tlaRUEGPD2BQBAIRAF35NA3L4VJHY">
-                  <catDesc>4. Viertel 3. Jhdt. v.Chr.</catDesc>
+                  <catDesc>4. Viertel 3. Jhdt. v.Chr.<date from="-225" to="-201"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaPBLVUQXCI5HETLV6ICT7YYYOZI">
-                <catDesc>7. Jhdt. v.Chr.</catDesc>
+                <catDesc>7. Jhdt. v.Chr.<date from="-700" to="-601"/></catDesc>
                 <category xml:id="tlaQIVC46ND4BDUXAWR4EYMD4AUME">
-                  <catDesc>4. Viertel 7. Jhdt. v.Chr.</catDesc>
+                  <catDesc>4. Viertel 7. Jhdt. v.Chr.<date from="-625" to="-601"/></catDesc>
                 </category>
                 <category xml:id="tlaR7RP4HBK7FCSTB74WGGFMBAXJE">
-                  <catDesc>1. Hälfte 7. Jhdt. v.Chr.</catDesc>
+                  <catDesc>1. Hälfte 7. Jhdt. v.Chr.<date from="-700" to="-651"/></catDesc>
                 </category>
                 <category xml:id="tlaVPDCMRCERVH3JBGCJQFWOEV4PE">
-                  <catDesc>2. Viertel 7. Jhdt. v.Chr.</catDesc>
+                  <catDesc>2. Viertel 7. Jhdt. v.Chr.<date from="-675" to="-651"/></catDesc>
                 </category>
                 <category xml:id="tlaVRYK3DNABFC37OCSLTNEE6SX2M">
-                  <catDesc>2. Hälfte 7. Jhdt. v.Chr.</catDesc>
+                  <catDesc>2. Hälfte 7. Jhdt. v.Chr.<date from="-650" to="-601"/></catDesc>
                 </category>
                 <category xml:id="tlaYJ43LQBBSNEVHJTOY2KXTZ4KSQ">
-                  <catDesc>1. Viertel 7. Jhdt. v.Chr.</catDesc>
+                  <catDesc>1. Viertel 7. Jhdt. v.Chr.<date from="-700" to="-676"/></catDesc>
                 </category>
                 <category xml:id="tlaZ7SE63TCNBHDNCAJXDFKZVI43M">
-                  <catDesc>3. Viertel 7. Jhdt. v.Chr.</catDesc>
+                  <catDesc>3. Viertel 7. Jhdt. v.Chr.<date from="-650" to="-626"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaSUWAELMXDVA5VF7G6BGY5FP24Q">
-                <catDesc>5. Jhdt. v.Chr.</catDesc>
+                <catDesc>5. Jhdt. v.Chr.<date from="-500" to="-401"/></catDesc>
                 <category xml:id="tla2SVJUWTG65CGBPSRR2JVGCFZQI">
-                  <catDesc>3. Viertel 5. Jhdt. v.Chr.</catDesc>
+                  <catDesc>3. Viertel 5. Jhdt. v.Chr.<date from="-450" to="-426"/></catDesc>
                 </category>
                 <category xml:id="tla37AKJCT3O5EXHKZVR4OERWJUMM">
-                  <catDesc>2. Viertel 5. Jhdt. v.Chr.</catDesc>
+                  <catDesc>2. Viertel 5. Jhdt. v.Chr.<date from="-475" to="-451"/></catDesc>
                 </category>
                 <category xml:id="tla3RSAUA2SMZGCDEMLGVH47P6IOM">
-                  <catDesc>1. Hälfte 5. Jhdt. v.Chr.</catDesc>
+                  <catDesc>1. Hälfte 5. Jhdt. v.Chr.<date from="-500" to="-451"/></catDesc>
                 </category>
                 <category xml:id="tlaGGPOQYXYZBDUZNTFBXUVFYGDEM">
-                  <catDesc>2. Hälfte 5. Jhdt. v.Chr.</catDesc>
+                  <catDesc>2. Hälfte 5. Jhdt. v.Chr.<date from="-450" to="-401"/></catDesc>
                 </category>
                 <category xml:id="tlaM5RNBQZBHJDSJLRFTESD5PXUUM">
-                  <catDesc>4. Viertel 5. Jhdt. v.Chr.</catDesc>
+                  <catDesc>4. Viertel 5. Jhdt. v.Chr.<date from="-425" to="-401"/></catDesc>
                 </category>
                 <category xml:id="tlaSWTOWPX765HQBK4FBHAFFBF4XE">
-                  <catDesc>1. Viertel 5. Jhdt. v.Chr.</catDesc>
+                  <catDesc>1. Viertel 5. Jhdt. v.Chr.<date from="-500" to="-476"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaSYVSDPY4UFC7VFGH34ZDTEPMMM">
-                <catDesc>6. Jhdt. v.Chr.</catDesc>
+                <catDesc>6. Jhdt. v.Chr.<date from="-600" to="-501"/></catDesc>
                 <category xml:id="tla5RWQE6I76ZDJ7C6RZZHDZ5NZOA">
-                  <catDesc>2. Hälfte 6. Jhdt. v.Chr.</catDesc>
+                  <catDesc>2. Hälfte 6. Jhdt. v.Chr.<date from="-550" to="-501"/></catDesc>
                 </category>
                 <category xml:id="tla742V5NN54JCLRMXZSWDVTG4YK4">
-                  <catDesc>4. Viertel 6. Jhdt. v.Chr.</catDesc>
+                  <catDesc>4. Viertel 6. Jhdt. v.Chr.<date from="-525" to="-501"/></catDesc>
                 </category>
                 <category xml:id="tla7WVJGW33WFHVZI2UBOIDWIKIPI">
-                  <catDesc>1. Hälfte 6. Jhdt. v.Chr.</catDesc>
+                  <catDesc>1. Hälfte 6. Jhdt. v.Chr.<date from="-600" to="-551"/></catDesc>
                 </category>
                 <category xml:id="tlaONBKOHQ33BA2ZC2SC2HQHOG3UY">
-                  <catDesc>2. Viertel 6. Jhdt. v.Chr.</catDesc>
+                  <catDesc>2. Viertel 6. Jhdt. v.Chr.<date from="-575" to="-551"/></catDesc>
                 </category>
                 <category xml:id="tlaRDVGZ5PV4BAGRG2ZBOUB4SBJHI">
-                  <catDesc>3. Viertel 6. Jhdt. v.Chr.</catDesc>
+                  <catDesc>3. Viertel 6. Jhdt. v.Chr.<date from="-550" to="-526"/></catDesc>
                 </category>
                 <category xml:id="tlaWHI6OSNIHJEDFI4VOSPL3NGNQM">
-                  <catDesc>1. Viertel 6. Jhdt. v.Chr.</catDesc>
+                  <catDesc>1. Viertel 6. Jhdt. v.Chr.<date from="-600" to="-576"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaTIKGPKBTXVA6PHCKCHQJ6VIM2M">
-                <catDesc>8. Jhdt. v.Chr.</catDesc>
+                <catDesc>8. Jhdt. v.Chr.<date from="-800" to="-701"/></catDesc>
                 <category xml:id="tla3T5D7CE7MZFTXM5NHH6TB354A4">
-                  <catDesc>1. Hälfte 8. Jhdt. v.Chr.</catDesc>
+                  <catDesc>1. Hälfte 8. Jhdt. v.Chr.<date from="-800" to="-751"/></catDesc>
                 </category>
                 <category xml:id="tla6SL7CB3TV5GCDOFNO6SEKXCPDU">
-                  <catDesc>1. Viertel 8. Jhdt. v.Chr.</catDesc>
+                  <catDesc>1. Viertel 8. Jhdt. v.Chr.<date from="-800" to="-776"/></catDesc>
                 </category>
                 <category xml:id="tlaAY7RFFECHJFYXJVVW7UO73DNDM">
-                  <catDesc>3. Viertel 8. Jhdt. v.Chr.</catDesc>
+                  <catDesc>3. Viertel 8. Jhdt. v.Chr.<date from="-750" to="-726"/></catDesc>
                 </category>
                 <category xml:id="tlaG4YYFKH7ARFA5JOTIHYTNEI4LY">
-                  <catDesc>2. Viertel 8. Jhdt. v.Chr.</catDesc>
+                  <catDesc>2. Viertel 8. Jhdt. v.Chr.<date from="-775" to="-751"/></catDesc>
                 </category>
                 <category xml:id="tlaUH3G5FM2SREITBEJ5RTX7TZYZ4">
-                  <catDesc>2. Hälfte 8. Jhdt. v.Chr.</catDesc>
+                  <catDesc>2. Hälfte 8. Jhdt. v.Chr.<date from="-750" to="-701"/></catDesc>
                 </category>
                 <category xml:id="tlaVIZ3CULWTNB6FPFNJ3OBEDTL5I">
-                  <catDesc>4. Viertel 8. Jhdt. v.Chr.</catDesc>
+                  <catDesc>4. Viertel 8. Jhdt. v.Chr.<date from="-725" to="-701"/></catDesc>
                 </category>
               </category>
             </category>
             <category xml:id="tlaDUVGWT7GSRCKDM5LFTGU6MZ3GY">
-              <catDesc>(Epochen und Dynastien)</catDesc>
+              <catDesc>(Epochen und Dynastien)<date from="0" to="0"/></catDesc>
               <category xml:id="tla3GGZCLNRQVF6PAEQA6LCFBNE6M">
-                <catDesc>Zweite Zwischenzeit</catDesc>
+                <catDesc>Zweite Zwischenzeit<date from="-1793" to="-1551"/></catDesc>
                 <category xml:id="tlaE4VXX5LISZC2XIR6AYPM3Y3TQI">
-                  <catDesc>15. / 16. / 17. Dynastie</catDesc>
+                  <catDesc>15. / 16. / 17. Dynastie<date from="-1649" to="-1551"/></catDesc>
                 </category>
                 <category xml:id="tlaGKB34UGJLZA6ZPUYTDRQ7UNPH4">
-                  <catDesc>13. / 14. Dynastie</catDesc>
+                  <catDesc>13. / 14. Dynastie<date from="-1793" to="-1650"/></catDesc>
                   <category xml:id="tlaQXLWLXSIOBEBRBINKZ7WPX6C3U">
-                    <catDesc>Sebekhotep IV.</catDesc>
+                    <catDesc>Sebekhotep IV.<date from="-1745" to="-1730"/></catDesc>
                   </category>
                 </category>
               </category>
               <category xml:id="tla7FUWX6PWFJDAXEWQDOAA4FYXFU">
-                <catDesc>prädynastische Zeit</catDesc>
+                <catDesc>prädynastische Zeit<date from="-5500" to="-3151"/></catDesc>
                 <category xml:id="tla6YAAR2WRI5F6BLP6YMW3G67P6Q">
-                  <catDesc>Neolithikum vor der Badari-Kultur</catDesc>
+                  <catDesc>Neolithikum vor der Badari-Kultur<date from="0" to="0"/></catDesc>
                 </category>
                 <category xml:id="tlaFMNBFXWGA5C2TEXFRDXOGXBEPE">
-                  <catDesc>Badari-Kultur</catDesc>
+                  <catDesc>Badari-Kultur<date from="0" to="0"/></catDesc>
                 </category>
                 <category xml:id="tlaIPXSCTKV4REDHIXWTZWDXVXJWY">
-                  <catDesc>Naqada III</catDesc>
+                  <catDesc>Naqada III<date from="0" to="0"/></catDesc>
                 </category>
                 <category xml:id="tlaP5F2WOP6YZGBHK5KCSCP2UXJHM">
-                  <catDesc>Naqada I</catDesc>
+                  <catDesc>Naqada I<date from="0" to="0"/></catDesc>
                 </category>
                 <category xml:id="tlaWLIRCHQ3DRF4ZOTIREDVCPKC5A">
-                  <catDesc>Naqada II</catDesc>
+                  <catDesc>Naqada II<date from="0" to="0"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaBILVGTX4DVEERA2TQ2DFPYYTK4">
-                <catDesc>Thinitenzeit</catDesc>
+                <catDesc>Thinitenzeit<date from="-3150" to="-2724"/></catDesc>
                 <category xml:id="tlaRHWO4WZITFG7LC64PRWKXGSBLE">
-                  <catDesc>1. Dyn.</catDesc>
+                  <catDesc>1. Dyn.<date from="-3048" to="-2870"/></catDesc>
                   <category xml:id="tla6OQR45RINVBEXKRXU67UUYG5WI">
-                    <catDesc>Semerchet / Semempses</catDesc>
+                    <catDesc>Semerchet / Semempses<date from="-2902" to="-2895"/></catDesc>
                   </category>
                   <category xml:id="tla7W7ATEIEBBB7JBXHCOIEEDK3X4">
-                    <catDesc>( ) / Itj</catDesc>
+                    <catDesc>( ) / Itj<date from="-3016" to="-3016"/></catDesc>
                   </category>
                   <category xml:id="tlaC36PPQYVH5G4LLVMYYF4KAQ7V4">
-                    <catDesc>Den / Usaphais</catDesc>
+                    <catDesc>Den / Usaphais<date from="-2955" to="-2909"/></catDesc>
                   </category>
                   <category xml:id="tlaDXQSYPUVZ5ENLH22UECZNJZFSY">
-                    <catDesc>Aha / Menes</catDesc>
+                    <catDesc>Aha / Menes<date from="-3048" to="-3017"/></catDesc>
                   </category>
                   <category xml:id="tlaIT24BFWQQ5FL7NSNEPBYN3JUQA">
-                    <catDesc>Wadj / Ita</catDesc>
+                    <catDesc>Wadj / Ita<date from="-2968" to="-2956"/></catDesc>
                   </category>
                   <category xml:id="tlaO23PARFR5BEZDPKFYTPTWNISIM">
-                    <catDesc>Adj-ib / Miebis</catDesc>
+                    <catDesc>Adj-ib / Miebis<date from="-2908" to="-2903"/></catDesc>
                   </category>
                   <category xml:id="tlaWJGLV3QK3BEPZGHRP6D5EYZMOQ">
-                    <catDesc>Qa-a / Bieneches</catDesc>
+                    <catDesc>Qa-a / Bieneches<date from="-2894" to="-2870"/></catDesc>
                   </category>
                   <category xml:id="tlaWOKINRAGTVBY5ER4WSNTGPTAIU">
-                    <catDesc>Djer / Athotis</catDesc>
+                    <catDesc>Djer / Athotis<date from="-3015" to="-2969"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaRRYWO76XVZHRHDJI4376RX5OXM">
-                  <catDesc>2. Dyn.</catDesc>
+                  <catDesc>2. Dyn.<date from="-2869" to="-2724"/></catDesc>
                   <category xml:id="tla727RS3OFRFACXG74OQBUG4CYYA">
-                    <catDesc>unteräg. Könige parallel zu Peribsen</catDesc>
+                    <catDesc>unteräg. Könige parallel zu Peribsen<date from="-2765" to="-2751"/></catDesc>
                   </category>
                   <category xml:id="tlaGFTQ3LZ2NFFXFN5WCQWTHB25UA">
-                    <catDesc>Nebre / Kiechos</catDesc>
+                    <catDesc>Nebre / Kiechos<date from="-2841" to="-2827"/></catDesc>
                   </category>
                   <category xml:id="tlaJSG47O3RY5DP3JBUHLKVBBPI4U">
-                    <catDesc>Nineter / Binothis</catDesc>
+                    <catDesc>Nineter / Binothis<date from="-2826" to="-2784"/></catDesc>
                   </category>
                   <category xml:id="tlaKJ7NJARIAFDH3DQBXQXJPIHK44">
-                    <catDesc>Hetepsechemui / Boethos</catDesc>
+                    <catDesc>Hetepsechemui / Boethos<date from="-2869" to="-2842"/></catDesc>
                   </category>
                   <category xml:id="tlaNLBRXU2SHBA53A3CBNJNFJUNEU">
-                    <catDesc>Sechem-ib / Sethenes</catDesc>
+                    <catDesc>Sechem-ib / Sethenes<date from="-2776" to="-2766"/></catDesc>
                   </category>
                   <category xml:id="tlaOUIVW3MIHNHIPC7R333PQRIGYM">
-                    <catDesc>Chasechemui / Chasechem</catDesc>
+                    <catDesc>Chasechemui / Chasechem<date from="-2750" to="-2724"/></catDesc>
                   </category>
                   <category xml:id="tlaVHOWISQK4FB6LJYLLQUBLBINUU">
-                    <catDesc>Peribsen</catDesc>
+                    <catDesc>Peribsen<date from="-2765" to="-2751"/></catDesc>
                   </category>
                   <category xml:id="tlaY7ZEMNUP3VGFNMNVJTHPC5A7VY">
-                    <catDesc>Weneg-Nebti / Tlas</catDesc>
+                    <catDesc>Weneg-Nebti / Tlas<date from="-2783" to="-2777"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaZ4YNGVLCKBBYTETIZHVGTUQAOM">
-                  <catDesc>0. Dyn.</catDesc>
+                  <catDesc>0. Dyn.<date from="-3150" to="-3049"/></catDesc>
                   <category xml:id="tla2SRQ3JK6ZJDMNGUGSSLVAS2EUY">
-                    <catDesc>"Mund"</catDesc>
+                    <catDesc>"Mund"<date from="-3150" to="-3126"/></catDesc>
                   </category>
                   <category xml:id="tla3HF272323RDJXBXFYT7IVUSFSU">
-                    <catDesc>Skorpion</catDesc>
+                    <catDesc>Skorpion<date from="-3120" to="-3080"/></catDesc>
                   </category>
                   <category xml:id="tla7E6ZCCAAKJAUHM2T67D4D5G5CI">
-                    <catDesc>Narmer</catDesc>
+                    <catDesc>Narmer<date from="-3100" to="-3049"/></catDesc>
                   </category>
                   <category xml:id="tlaFQEHFFBL6ZEA7LVBPHY4A6JP7A">
-                    <catDesc>"Arme" / Ka / Sechen</catDesc>
+                    <catDesc>"Arme" / Ka / Sechen<date from="-3125" to="-3101"/></catDesc>
                   </category>
                 </category>
               </category>
               <category xml:id="tlaDBDBZEFDGZGGBMERHVKJ6PMPHQ">
-                <catDesc>Altes Reich</catDesc>
+                <catDesc>Altes Reich<date from="-2723" to="-2187"/></catDesc>
                 <category xml:id="tla7QKSXYEUCFHNBCFOS7XUZFGCJU">
-                  <catDesc>3. Dyn.</catDesc>
+                  <catDesc>3. Dyn.<date from="-2723" to="-2656"/></catDesc>
                   <category xml:id="tla35QR2MPL3NF4HIHPDLJJF7NC6U">
-                    <catDesc>Huni / Qahedjet</catDesc>
+                    <catDesc>Huni / Qahedjet<date from="-2680" to="-2656"/></catDesc>
                   </category>
                   <category xml:id="tlaATAYWXKNBVHT3FWOC65D5273BU">
-                    <catDesc>Nebka / Sanacht</catDesc>
+                    <catDesc>Nebka / Sanacht<date from="-2692" to="-2681"/></catDesc>
                   </category>
                   <category xml:id="tlaFDTMSNLYBNFERMB64GHLI4OXKI">
-                    <catDesc>( ) / Chaba</catDesc>
+                    <catDesc>( ) / Chaba<date from="-2697" to="-2693"/></catDesc>
                   </category>
                   <category xml:id="tlaI3U2PPJRONEWZDZE3DPBLRH35Y">
-                    <catDesc>Djoser / Netjeri-chet</catDesc>
+                    <catDesc>Djoser / Netjeri-chet<date from="-2723" to="-2704"/></catDesc>
                   </category>
                   <category xml:id="tlaKVW4S6I4ZRECNMJTM6FFTFLMYI">
-                    <catDesc>Djeserteti / Sechemchet</catDesc>
+                    <catDesc>Djeserteti / Sechemchet<date from="-2703" to="-2698"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaGH2RXLTQ2BCEHPQ6R2SPBER7OM">
-                  <catDesc>6. Dyn.</catDesc>
+                  <catDesc>6. Dyn.<date from="-2363" to="-2233"/></catDesc>
                   <category xml:id="tla3DBCMXAP3ZA2TCSSOGPRVOXKME">
-                    <catDesc>6. Dyn. nach Pepi II.</catDesc>
+                    <catDesc>6. Dyn. nach Pepi II.<date from="-2235" to="-2233"/></catDesc>
                   </category>
                   <category xml:id="tla3ESLSUHOURDCPFZ2UDUJACFV7Q">
-                    <catDesc>Pepi II.</catDesc>
+                    <catDesc>Pepi II.<date from="-2295" to="-2236"/></catDesc>
                   </category>
                   <category xml:id="tlaACJUYKAESFH4JAWU2KOOHKW3HM">
-                    <catDesc>Pepi I.</catDesc>
+                    <catDesc>Pepi I.<date from="-2351" to="-2302"/></catDesc>
                   </category>
                   <category xml:id="tlaEBTM44JP7NA5BBJ4XXKU7RMX7Y">
-                    <catDesc>Userkare</catDesc>
+                    <catDesc>Userkare<date from="-2353" to="-2352"/></catDesc>
                   </category>
                   <category xml:id="tlaH5RYRC56WNGXFFMSSKXFWRRDLE">
-                    <catDesc>Merenre</catDesc>
+                    <catDesc>Merenre<date from="-2301" to="-2296"/></catDesc>
                   </category>
                   <category xml:id="tlaJDHTPUAWMZBCZJDBBD2JP4PAD4">
-                    <catDesc>Teti</catDesc>
+                    <catDesc>Teti<date from="-2363" to="-2354"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaOSQYKCRYMFGJRD3LESUKPOZG4E">
-                  <catDesc>8. Dyn.</catDesc>
+                  <catDesc>8. Dyn.<date from="-2232" to="-2187"/></catDesc>
                 </category>
                 <category xml:id="tlaRI3TSGKXUFCE3HV43BX2N2MJVE">
-                  <catDesc>5. Dyn.</catDesc>
+                  <catDesc>5. Dyn.<date from="-2520" to="-2364"/></catDesc>
                   <category xml:id="tla3X3HIVLWDVCHVM7OKEQG4RIKIA">
-                    <catDesc>Sahure</catDesc>
+                    <catDesc>Sahure<date from="-2512" to="-2500"/></catDesc>
                   </category>
                   <category xml:id="tlaE3KJFINUWJGZHI3ROCURKZQF2Q">
-                    <catDesc>Neferirkare</catDesc>
+                    <catDesc>Neferirkare<date from="-2499" to="-2480"/></catDesc>
                   </category>
                   <category xml:id="tlaF2WUXBPF6ND7ZAEU4GIZTIBOQ4">
-                    <catDesc>Niuserre</catDesc>
+                    <catDesc>Niuserre<date from="-2461" to="-2431"/></catDesc>
                   </category>
                   <category xml:id="tlaJISVUMEI3NG25FQDYLYD3R6MJ4">
-                    <catDesc>Schepseskare</catDesc>
+                    <catDesc>Schepseskare<date from="-2479" to="-2473"/></catDesc>
                   </category>
                   <category xml:id="tlaKQY2F5SJVBBN7GRO5WUXKG5M6M">
-                    <catDesc>Djedkare Asosi</catDesc>
+                    <catDesc>Djedkare Asosi<date from="-2421" to="-2384"/></catDesc>
                   </category>
                   <category xml:id="tlaLOCJJXDY4RDZRFMENMXLKBKYYQ">
-                    <catDesc>Neferefre</catDesc>
+                    <catDesc>Neferefre<date from="-2472" to="-2462"/></catDesc>
                   </category>
                   <category xml:id="tlaSC4IKOXD5NFI7B6FO3LGEM4P34">
-                    <catDesc>Menkauhor</catDesc>
+                    <catDesc>Menkauhor<date from="-2430" to="-2422"/></catDesc>
                   </category>
                   <category xml:id="tlaVXCXYJF7QFDKHG4XNG7B7JSOIM">
-                    <catDesc>Unas</catDesc>
+                    <catDesc>Unas<date from="-2383" to="-2364"/></catDesc>
                   </category>
                   <category xml:id="tlaWM77TXYU2VAYJJGYHPUZPZXSGA">
-                    <catDesc>Userkaf</catDesc>
+                    <catDesc>Userkaf<date from="-2520" to="-2513"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaWCVSHAEC7ZA4FKQOWR4E2GC6OM">
-                  <catDesc>4. Dyn.</catDesc>
+                  <catDesc>4. Dyn.<date from="-2655" to="-2521"/></catDesc>
                   <category xml:id="tla4SJRB25AURBUZMSZBBXRRHDO3A">
-                    <catDesc>Djedefre</catDesc>
+                    <catDesc>Djedefre<date from="-2597" to="-2589"/></catDesc>
                   </category>
                   <category xml:id="tla4XVWKCUISJDA5OWB724D2CPBRI">
-                    <catDesc>Chefren</catDesc>
+                    <catDesc>Chefren<date from="-2588" to="-2563"/></catDesc>
                   </category>
                   <category xml:id="tlaB6LUZDUOMJDC3G3JVUHHECQCAM">
-                    <catDesc>Schepseskaf</catDesc>
+                    <catDesc>Schepseskaf<date from="-2527" to="-2523"/></catDesc>
                   </category>
                   <category xml:id="tlaHOX5L57VFFDMTBCTWJNSHQ3OJA">
-                    <catDesc>Snofru</catDesc>
+                    <catDesc>Snofru<date from="-2655" to="-2621"/></catDesc>
                   </category>
                   <category xml:id="tlaIS52YO4UPBG6ZO5BFFVWJ26OWY">
-                    <catDesc>Cheops</catDesc>
+                    <catDesc>Cheops<date from="-2620" to="-2598"/></catDesc>
                   </category>
                   <category xml:id="tlaONSX4LNQWJH7LHFD64LQJIWJAA">
-                    <catDesc>Bicheris</catDesc>
+                    <catDesc>Bicheris<date from="-2562" to="-2556"/></catDesc>
                   </category>
                   <category xml:id="tlaPPBZN6VP2ZEXPAUZOK3ST3SO3M">
-                    <catDesc>Tamphthis</catDesc>
+                    <catDesc>Tamphthis<date from="-2522" to="-2521"/></catDesc>
                   </category>
                   <category xml:id="tlaWEB5KGYGWJFUTDVTZP5PO5GBOY">
-                    <catDesc>Mykerinos</catDesc>
+                    <catDesc>Mykerinos<date from="-2555" to="-2528"/></catDesc>
                   </category>
                 </category>
               </category>
               <category xml:id="tlaHYYNMJRFTVFIHB7JUA6M2QW3LQ">
-                <catDesc>Makedonen, Ptolemäer</catDesc>
+                <catDesc>Makedonen, Ptolemäer<date from="-332" to="-31"/></catDesc>
                 <category xml:id="tla5EXFFIIQ2BFLJBUPM345Q52RYE">
-                  <catDesc>Ptolemaios XIII.</catDesc>
+                  <catDesc>Ptolemaios XIII.<date from="-51" to="-47"/></catDesc>
                 </category>
                 <category xml:id="tla6CEMTQHBPVCKRGBPZV3SBCJFHM">
-                  <catDesc>Ptolemaios II. Philadelphos</catDesc>
+                  <catDesc>Ptolemaios II. Philadelphos<date from="-285" to="-246"/></catDesc>
                 </category>
                 <category xml:id="tla7SZBT5EB75DZVEYNMMNDRAR6WM">
-                  <catDesc>Ptolemaios I. Soter</catDesc>
+                  <catDesc>Ptolemaios I. Soter<date from="-305" to="-283"/></catDesc>
                 </category>
                 <category xml:id="tlaBB2LXNAEFRHAFOQHR7VCS2GUDE">
-                  <catDesc>Kleopatra VII.</catDesc>
+                  <catDesc>Kleopatra VII.<date from="-51" to="-30"/></catDesc>
                 </category>
                 <category xml:id="tlaBHAOO6DORBCPVDTRZTJSLM3MHM">
-                  <catDesc>Ptolemaios VI. Philometor</catDesc>
+                  <catDesc>Ptolemaios VI. Philometor<date from="-180" to="-145"/></catDesc>
                 </category>
                 <category xml:id="tlaBJBGAQ4PCJHSRISGG6ZIEP26YI">
-                  <catDesc>Alexander IV.</catDesc>
+                  <catDesc>Alexander IV.<date from="-323" to="-311"/></catDesc>
                 </category>
                 <category xml:id="tlaEAIXVOD3ZFAQXCGUYG2MUERGXU">
-                  <catDesc>Ptolemaios VIII. Euergetes II.</catDesc>
+                  <catDesc>Ptolemaios VIII. Euergetes II.<date from="-170" to="-116"/></catDesc>
                 </category>
                 <category xml:id="tlaEB27VJIJZZFPLDR5ONLBMQUJQY">
-                  <catDesc>Philipp Arrhidaios</catDesc>
+                  <catDesc>Philipp Arrhidaios<date from="-323" to="-317"/></catDesc>
                 </category>
                 <category xml:id="tlaETFKXMIJTBE45KASN7GX4BG5VI">
-                  <catDesc>Ptolemaios XIV. Philopator</catDesc>
+                  <catDesc>Ptolemaios XIV. Philopator<date from="-47" to="-44"/></catDesc>
                 </category>
                 <category xml:id="tlaKAK54XJY4BBU3PXESJCBL6YQHM">
-                  <catDesc>Ptolemaios V. Epiphanes</catDesc>
+                  <catDesc>Ptolemaios V. Epiphanes<date from="-204" to="-180"/></catDesc>
                 </category>
                 <category xml:id="tlaM2BT2KZR4RAYJIWGOO6N3P4C64">
-                  <catDesc>Alexander der Große</catDesc>
+                  <catDesc>Alexander der Große<date from="-332" to="-323"/></catDesc>
                 </category>
                 <category xml:id="tlaMHVALMEFXBE7BKJGFSD7LCSRVM">
-                  <catDesc>Ptolemaios XII. Philopator Philadelphos Neos Dionysos</catDesc>
+                  <catDesc>Ptolemaios XII. Philopator Philadelphos Neos Dionysos<date from="-80" to="-51"/></catDesc>
                 </category>
                 <category xml:id="tlaMP63BC4W6NHILLBC2NAFBF7ZTA">
-                  <catDesc>Ptolemaios IX. Soter II.</catDesc>
+                  <catDesc>Ptolemaios IX. Soter II.<date from="-116" to="-80"/></catDesc>
                 </category>
                 <category xml:id="tlaPCA5EX57QNGOFAJAM3SOI6VV4M">
-                  <catDesc>Ptolemaios VII. Neos Philopator</catDesc>
+                  <catDesc>Ptolemaios VII. Neos Philopator<date from="-145" to="-144"/></catDesc>
                 </category>
                 <category xml:id="tlaQU2M4UGNUNDHTE5DUANDIT5K4M">
-                  <catDesc>Ptolemaios X. Alexander I.</catDesc>
+                  <catDesc>Ptolemaios X. Alexander I.<date from="-114" to="-88"/></catDesc>
                 </category>
                 <category xml:id="tlaTU4NLFP3EBHXHGMDL7F7IOGFCQ">
-                  <catDesc>Ptolemaios III. Euergetes</catDesc>
+                  <catDesc>Ptolemaios III. Euergetes<date from="-246" to="-222"/></catDesc>
                 </category>
                 <category xml:id="tlaUGINSOQZARG3NJSLGNVX3STTIE">
-                  <catDesc>Ptolemaios XI. Alexander II.</catDesc>
+                  <catDesc>Ptolemaios XI. Alexander II.<date from="-80" to="-80"/></catDesc>
                 </category>
                 <category xml:id="tlaXYP4XJ2LEVCS7DBSHGYOH4WYOU">
-                  <catDesc>Ptolemaios IV. Philopator</catDesc>
+                  <catDesc>Ptolemaios IV. Philopator<date from="-221" to="-205"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaJS32JKX2CNG25GZ3B6MGYMDU4I">
-                <catDesc>Dritte Zwischenzeit</catDesc>
+                <catDesc>Dritte Zwischenzeit<date from="-1070" to="-665"/></catDesc>
                 <category xml:id="tla3XW6DLUBKVCLHD6KY45JN2PRD4">
-                  <catDesc>Kuschiten</catDesc>
+                  <catDesc>Kuschiten<date from="-780" to="-656"/></catDesc>
                   <category xml:id="tla2ZQQIYQHVRDGTH6PPY2LWEQCUQ">
-                    <catDesc>Schabataka</catDesc>
+                    <catDesc>Schabataka<date from="-698" to="-691"/></catDesc>
                   </category>
                   <category xml:id="tla7FDXNLDP5FFK5EBDS5TKXVPP6A">
-                    <catDesc>Kaschta</catDesc>
+                    <catDesc>Kaschta<date from="-760" to="-741"/></catDesc>
                   </category>
                   <category xml:id="tla7PIUCJYC7BBVXLMOIZYT72PWJQ">
-                    <catDesc>Alara</catDesc>
+                    <catDesc>Alara<date from="-780" to="-761"/></catDesc>
                   </category>
                   <category xml:id="tlaEFGOT3UFWZG27GZOSTKIU3X2KE">
-                    <catDesc>Tanutamon</catDesc>
+                    <catDesc>Tanutamon<date from="-664" to="-656"/></catDesc>
                   </category>
                   <category xml:id="tlaNL6KKNWSCFGGLO75JDALYFOL4U">
-                    <catDesc>Taharqa</catDesc>
+                    <catDesc>Taharqa<date from="-690" to="-665"/></catDesc>
                   </category>
                   <category xml:id="tlaSCJLUQ4CSFFRJF6XNZ34OV4DFQ">
-                    <catDesc>Pije</catDesc>
+                    <catDesc>Pije<date from="-740" to="-714"/></catDesc>
                   </category>
                   <category xml:id="tlaXNHKJRIXSNB77GIB66CWTBWGHQ">
-                    <catDesc>Schabaka</catDesc>
+                    <catDesc>Schabaka<date from="-713" to="-699"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tla744HIAA6FRHBROALBB3DV4VV3I">
-                  <catDesc>25. Dyn.</catDesc>
+                  <catDesc>25. Dyn.<date from="-713" to="-656"/></catDesc>
                   <category xml:id="tlaCWZ4MSSSSBEIPK2RBFSX45ZBMI">
-                    <catDesc>Schabataka</catDesc>
+                    <catDesc>Schabataka<date from="-698" to="-691"/></catDesc>
                   </category>
                   <category xml:id="tlaFLAXS36WHJA5TJUDDWKHQONVEM">
-                    <catDesc>Tanutamon</catDesc>
+                    <catDesc>Tanutamon<date from="-664" to="-656"/></catDesc>
                   </category>
                   <category xml:id="tlaUWRHN5WFJ5GGBCYKPZXK4YE2GU">
-                    <catDesc>Schabaka</catDesc>
+                    <catDesc>Schabaka<date from="-713" to="-699"/></catDesc>
                   </category>
                   <category xml:id="tlaVNUNBFCAMNFC7KMHL4QWVJXFTE">
-                    <catDesc>Taharqa</catDesc>
+                    <catDesc>Taharqa<date from="-690" to="-665"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tla7J6HVBL7CJHQPJHG6TBBXJMYMM">
-                  <catDesc>24. Dyn.</catDesc>
+                  <catDesc>24. Dyn.<date from="-740" to="-712"/></catDesc>
                   <category xml:id="tla47CU2AIR3BAGXEDHUKRZ5NLI44">
-                    <catDesc>Bokchoris</catDesc>
+                    <catDesc>Bokchoris<date from="-718" to="-712"/></catDesc>
                   </category>
                   <category xml:id="tlaJMRTQ7BOBZCUPEREM5VMJ2WJZE">
-                    <catDesc>Tefnachte</catDesc>
+                    <catDesc>Tefnachte<date from="-740" to="-719"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaE7YEQAEKZVEJ5PX7WKOXY2QEEM">
-                  <catDesc>21. Dyn.</catDesc>
+                  <catDesc>21. Dyn.<date from="-1070" to="-946"/></catDesc>
                   <category xml:id="tla677YHBKQIRHB3HVZG45V2N6DU4">
-                    <catDesc>Siamun</catDesc>
+                    <catDesc>Siamun<date from="-978" to="-960"/></catDesc>
                   </category>
                   <category xml:id="tlaBBZR65BX2JHZJHOPWOGMFFE42A">
-                    <catDesc>Smendes</catDesc>
+                    <catDesc>Smendes<date from="-1070" to="-1044"/></catDesc>
                   </category>
                   <category xml:id="tlaG2XFFZLE4ZHDNMISPFYCHJJB4M">
-                    <catDesc>Psusennes I.</catDesc>
+                    <catDesc>Psusennes I.<date from="-1043" to="-994"/></catDesc>
                   </category>
                   <category xml:id="tlaNOTZ5UOGYZD2VBH6D6JXBOW6LI">
-                    <catDesc>Psusennes II.</catDesc>
+                    <catDesc>Psusennes II.<date from="-959" to="-946"/></catDesc>
                   </category>
                   <category xml:id="tlaO5QKFTC7YBCKNDSQJOKBWT63BY">
-                    <catDesc>Amenemopet</catDesc>
+                    <catDesc>Amenemopet<date from="-996" to="-985"/></catDesc>
                   </category>
                   <category xml:id="tlaSBF7EA7BN5FOVO6JXZQHUWGYTQ">
-                    <catDesc>Amenemnisut / Nephercheres</catDesc>
+                    <catDesc>Amenemnisut / Nephercheres<date from="-1043" to="-1040"/></catDesc>
                   </category>
                   <category xml:id="tlaXVUCQSGCYBHKFNXJYMSKRL4R2M">
-                    <catDesc>Osochor</catDesc>
+                    <catDesc>Osochor<date from="-984" to="-979"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaWASRAHTUHNE6HDWN5URBHDIR2M">
-                  <catDesc>22. / 23. Dyn.</catDesc>
+                  <catDesc>22. / 23. Dyn.<date from="-945" to="-712"/></catDesc>
                   <category xml:id="tlaARW2M7F3JFF7HP7XCQ34JREODY">
-                    <catDesc>Scheschonq III.</catDesc>
+                    <catDesc>Scheschonq III.<date from="-837" to="-785"/></catDesc>
                   </category>
                   <category xml:id="tlaBFBDVC3P25FALCKMNPTNBNYQNA">
-                    <catDesc>Pemu</catDesc>
+                    <catDesc>Pemu<date from="-785" to="-774"/></catDesc>
                   </category>
                   <category xml:id="tlaBPYQBIAZPVCWZHDS7M3C2GL53U">
-                    <catDesc>Scheschonq V.</catDesc>
+                    <catDesc>Scheschonq V.<date from="-774" to="-736"/></catDesc>
                   </category>
                   <category xml:id="tlaBV3NUTCOVBAHDOBBNO44T2F4VY">
-                    <catDesc>Scheschonq II.</catDesc>
+                    <catDesc>Scheschonq II.<date from="-877" to="-875"/></catDesc>
                   </category>
                   <category xml:id="tlaD7L7SMVVVFEWREVPZSXPGMDMUA">
-                    <catDesc>Harsiese</catDesc>
+                    <catDesc>Harsiese<date from="-870" to="-850"/></catDesc>
                   </category>
                   <category xml:id="tlaDUH5NGZGPZHIXA2SBPDTFYRV54">
-                    <catDesc>Psammus</catDesc>
+                    <catDesc>Psammus<date from="-722" to="-712"/></catDesc>
                   </category>
                   <category xml:id="tlaIZT7J5CGRZEX3OT5ERPRYWQTYY">
-                    <catDesc>Scheschonq IV.</catDesc>
+                    <catDesc>Scheschonq IV.<date from="-805" to="-790"/></catDesc>
                   </category>
                   <category xml:id="tlaKNKTVZBWMBDOPKZ4RVIK43DSME">
-                    <catDesc>Osorkon IV.</catDesc>
+                    <catDesc>Osorkon IV.<date from="-731" to="-722"/></catDesc>
                   </category>
                   <category xml:id="tlaLJNCZ3RENZGYDDTSANDPNMVKRI">
-                    <catDesc>Petubastis I.</catDesc>
+                    <catDesc>Petubastis I.<date from="-830" to="-805"/></catDesc>
                   </category>
                   <category xml:id="tlaMPKA3BGQ5VDRDE4SQKHBU7I5RM">
-                    <catDesc>Osorkon II.</catDesc>
+                    <catDesc>Osorkon II.<date from="-875" to="-837"/></catDesc>
                   </category>
                   <category xml:id="tlaN47PT66YEVCDHFFZUVIML2BE2M">
-                    <catDesc>Petubastis II.</catDesc>
+                    <catDesc>Petubastis II.<date from="-756" to="-731"/></catDesc>
                   </category>
                   <category xml:id="tlaNUDYSH53HVGNTM2FTELC5TFSQI">
-                    <catDesc>Osorkon I.</catDesc>
+                    <catDesc>Osorkon I.<date from="-924" to="-891"/></catDesc>
                   </category>
                   <category xml:id="tlaPBUFJKFM4NH2XEBUVIEZCB6A3M">
-                    <catDesc>Takelot II.</catDesc>
+                    <catDesc>Takelot II.<date from="-841" to="-816"/></catDesc>
                   </category>
                   <category xml:id="tlaR2UVPCKDIRFOBF4QR5W6UY73QY">
-                    <catDesc>Osorkon III.</catDesc>
+                    <catDesc>Osorkon III.<date from="-790" to="-762"/></catDesc>
                   </category>
                   <category xml:id="tlaT3PXE2RRVRCIFCRUQP4PCSQMOI">
-                    <catDesc>Iuput I.</catDesc>
+                    <catDesc>Iuput I.<date from="-816" to="-800"/></catDesc>
                   </category>
                   <category xml:id="tlaT6GEYS2Y3RGF3O3ZGQWHBJZMQI">
-                    <catDesc>Iuput II.</catDesc>
+                    <catDesc>Iuput II.<date from="-756" to="-725"/></catDesc>
                   </category>
                   <category xml:id="tlaTLM3NFHYG5HRHICGSS6SI6HEBI">
-                    <catDesc>Rudamun</catDesc>
+                    <catDesc>Rudamun<date from="-755" to="-735"/></catDesc>
                   </category>
                   <category xml:id="tlaTMQJAUESNRGSXF4GT75ECQKKYQ">
-                    <catDesc>Iny</catDesc>
+                    <catDesc>Iny<date from="-735" to="-730"/></catDesc>
                   </category>
                   <category xml:id="tlaUUZQDMMULNCRHNP2EV4OBUNCOM">
-                    <catDesc>Takelot III.</catDesc>
+                    <catDesc>Takelot III.<date from="-767" to="-755"/></catDesc>
                   </category>
                   <category xml:id="tlaVFTMODKBGZAGNENLGHGNGNBXM4">
-                    <catDesc>Takelot I.</catDesc>
+                    <catDesc>Takelot I.<date from="-890" to="-877"/></catDesc>
                   </category>
                   <category xml:id="tlaXZ2WE35X5NGFTN37A7ZOS4CD54">
-                    <catDesc>Scheschonq I.</catDesc>
+                    <catDesc>Scheschonq I.<date from="-945" to="-925"/></catDesc>
                   </category>
                 </category>
               </category>
               <category xml:id="tlaMM4QYACJOJCCLJWBD6VAX2FLKE">
-                <catDesc>Mittleres Reich</catDesc>
+                <catDesc>Mittleres Reich<date from="-2026" to="-1794"/></catDesc>
                 <category xml:id="tla7G4I7VLRZFCZFBDWXWJBCSPIPI">
-                  <catDesc>11. Dyn. (Gesamtzeitraum)</catDesc>
+                  <catDesc>11. Dyn. (Gesamtzeitraum)<date from="-2135" to="-1993"/></catDesc>
                   <category xml:id="tlaDD6XPV4VBFE2ZAP66IXKVPGWKQ">
-                    <catDesc>Intef I. Sehertawi</catDesc>
+                    <catDesc>Intef I. Sehertawi<date from="-2129" to="-2120"/></catDesc>
                   </category>
                   <category xml:id="tlaE2BYRJX5Z5DSBOJFVF6WO7KZRE">
-                    <catDesc>Intef III. Nachtnebtepnefer</catDesc>
+                    <catDesc>Intef III. Nachtnebtepnefer<date from="-2070" to="-2063"/></catDesc>
                   </category>
                   <category xml:id="tlaEKCGS4YHKNCBNNBKQSBLGT4J7E">
-                    <catDesc>Mentuhotep III. Seanchkare</catDesc>
+                    <catDesc>Mentuhotep III. Seanchkare<date from="-2011" to="-2000"/></catDesc>
                   </category>
                   <category xml:id="tlaEUFPI7IUJFHVJGT6AOATFIZPNA">
-                    <catDesc>Intef II. Wahanch</catDesc>
+                    <catDesc>Intef II. Wahanch<date from="-2119" to="-2071"/></catDesc>
                   </category>
                   <category xml:id="tlaKXXWNISHB5AWFHAYWKV5PCALSY">
-                    <catDesc>Mentuhotep IV. Nebtawire</catDesc>
+                    <catDesc>Mentuhotep IV. Nebtawire<date from="-1999" to="-1993"/></catDesc>
                   </category>
                   <category xml:id="tlaPGZO7FG47BFK3LN2IQEOJBZJNU">
-                    <catDesc>Mentuhotep I. Tepi-a</catDesc>
+                    <catDesc>Mentuhotep I. Tepi-a<date from="-2135" to="-2130"/></catDesc>
                   </category>
                   <category xml:id="tlaQH4ZVV4SZREKNEY5UDCC3AZ3E4">
-                    <catDesc>Mentuhotep II. Nebhepetre</catDesc>
+                    <catDesc>Mentuhotep II. Nebhepetre<date from="-2062" to="-2012"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaJVTUL4HL45FRHF7TREHQXYZSWM">
-                  <catDesc>11. Dyn., 2. Hälfte</catDesc>
+                  <catDesc>11. Dyn., 2. Hälfte<date from="-2026" to="-1993"/></catDesc>
                   <category xml:id="tlaB2OHIBEXNZHCTNGEXMEVV2VWIU">
-                    <catDesc>Mentuhotep II. Nebhepetre (nach der Reichseinigung)</catDesc>
+                    <catDesc>Mentuhotep II. Nebhepetre (nach der Reichseinigung)<date from="-2026" to="-2012"/></catDesc>
                   </category>
                   <category xml:id="tlaIVVRWFXHMZCXBJRH5W2ZRMMVUE">
-                    <catDesc>Mentuhotep III. Seanchkare</catDesc>
+                    <catDesc>Mentuhotep III. Seanchkare<date from="-2011" to="-2000"/></catDesc>
                   </category>
                   <category xml:id="tlaUD2UDBHPXBCUXB5XZOMXZ5AN6E">
-                    <catDesc>Mentuhotep IV. Nebtawire</catDesc>
+                    <catDesc>Mentuhotep IV. Nebtawire<date from="-1999" to="-1993"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaWFSMZWLWMFDG5FAGQOB436TKUU">
-                  <catDesc>12. Dyn.</catDesc>
+                  <catDesc>12. Dyn.<date from="-1992" to="-1794"/></catDesc>
                   <category xml:id="tla2N3CSTWVMRCXXLTRGTLKLJQZZU">
-                    <catDesc>Sobeknofru</catDesc>
+                    <catDesc>Sobeknofru<date from="-1798" to="-1794"/></catDesc>
                   </category>
                   <category xml:id="tla3O45XPYQXJATRP5CHBOH2EZYG4">
-                    <catDesc>Amenemhet III.</catDesc>
+                    <catDesc>Amenemhet III.<date from="-1853" to="-1808"/></catDesc>
                   </category>
                   <category xml:id="tla43UOVHLOUVCWVK3L543HR44GSA">
-                    <catDesc>Amenemhet I.</catDesc>
+                    <catDesc>Amenemhet I.<date from="-1992" to="-1963"/></catDesc>
                   </category>
                   <category xml:id="tlaCHLJ7SQNMVF33JVUBIZTIYH5PQ">
-                    <catDesc>Amenemhet II.</catDesc>
+                    <catDesc>Amenemhet II.<date from="-1917" to="-1883"/></catDesc>
                   </category>
                   <category xml:id="tlaEBGTMF7GURDVZDFRV6XQU7OEOE">
-                    <catDesc>Sesostris I.</catDesc>
+                    <catDesc>Sesostris I.<date from="-1962" to="-1918"/></catDesc>
                   </category>
                   <category xml:id="tlaOKZXTLKCTZHVRGYAIBR5BGKZRI">
-                    <catDesc>Amenemhet IV.</catDesc>
+                    <catDesc>Amenemhet IV.<date from="-1807" to="-1799"/></catDesc>
                   </category>
                   <category xml:id="tlaQGFPPB7TBJC4DOC46YTOAH4UYM">
-                    <catDesc>Sesostris III.</catDesc>
+                    <catDesc>Sesostris III.<date from="-1872" to="-1854"/></catDesc>
                   </category>
                   <category xml:id="tlaUODUII6XLBAJFCSQQNBMW7H4XM">
-                    <catDesc>Sesostris II.</catDesc>
+                    <catDesc>Sesostris II.<date from="-1882" to="-1873"/></catDesc>
                   </category>
                 </category>
               </category>
               <category xml:id="tlaQBN55U2GTFA27GHK3IACBTMK2U">
-                <catDesc>Erste Zwischenzeit</catDesc>
+                <catDesc>Erste Zwischenzeit<date from="-2186" to="-2027"/></catDesc>
                 <category xml:id="tlaGAQRDJP4OBB27JFBUQHAKXFEK4">
-                  <catDesc>9./10. Dyn. parallel zur frühen 11. Dyn.</catDesc>
+                  <catDesc>9./10. Dyn. parallel zur frühen 11. Dyn.<date from="-2135" to="-2027"/></catDesc>
                 </category>
                 <category xml:id="tlaPLVPK4FNBFHC3JQJC4J5YYJA2E">
-                  <catDesc>11. Dyn., 1. Hälfte</catDesc>
+                  <catDesc>11. Dyn., 1. Hälfte<date from="-2135" to="-2027"/></catDesc>
                   <category xml:id="tlaGD5TMK62EREULP3HDTZUOIAEKA">
-                    <catDesc>Intef III. Nachtnebtepnefer</catDesc>
+                    <catDesc>Intef III. Nachtnebtepnefer<date from="-2070" to="-2063"/></catDesc>
                   </category>
                   <category xml:id="tlaGQP66JAMPVHVLPQOJF72DRIEGA">
-                    <catDesc>Intef II. Wahanch</catDesc>
+                    <catDesc>Intef II. Wahanch<date from="-2119" to="-2071"/></catDesc>
                   </category>
                   <category xml:id="tlaHVQOKLCRNZAP3BAXQMXFG2HQY4">
-                    <catDesc>Mentuhotep II. Nebhepetre (vor der Reichseinigung)</catDesc>
+                    <catDesc>Mentuhotep II. Nebhepetre (vor der Reichseinigung)<date from="-2062" to="-2027"/></catDesc>
                   </category>
                   <category xml:id="tlaPNCIHL25ZFEW3EUOF47LJL45BE">
-                    <catDesc>Intef I. Sehertawi</catDesc>
+                    <catDesc>Intef I. Sehertawi<date from="-2129" to="-2120"/></catDesc>
                   </category>
                   <category xml:id="tlaSD3DMLVNJZETRPVYBPQJ353T34">
-                    <catDesc>Mentuhotep I. Tepi-a</catDesc>
+                    <catDesc>Mentuhotep I. Tepi-a<date from="-2135" to="-2130"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaR5VWTPWBVBAAHA5VCWLUUD4SFU">
-                  <catDesc>9./10. Dyn. vor Beginn der 11. Dyn.</catDesc>
+                  <catDesc>9./10. Dyn. vor Beginn der 11. Dyn.<date from="-2186" to="-2136"/></catDesc>
                 </category>
                 <category xml:id="tlaSQN2QN7IYZBYHCEUH7PBTHMKAU">
-                  <catDesc>Herakleopolitenzeit (Gesamtzeitraum)</catDesc>
+                  <catDesc>Herakleopolitenzeit (Gesamtzeitraum)<date from="-2186" to="-2027"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaS62ITYADMZGCHBHTHTAFV3RUGQ">
-                <catDesc>byzantinische Zeit</catDesc>
+                <catDesc>byzantinische Zeit<date from="395" to="641"/></catDesc>
               </category>
               <category xml:id="tlaUGTUTKXZHBDYLG7YJZ5AGOJXQY">
-                <catDesc>Spätzeit</catDesc>
+                <catDesc>Spätzeit<date from="-664" to="-333"/></catDesc>
                 <category xml:id="tla2AVEQ3VFT5EEPF7NBH7RHCVBXA">
-                  <catDesc>27. Dyn.</catDesc>
+                  <catDesc>27. Dyn.<date from="-525" to="-402"/></catDesc>
                   <category xml:id="tla7MP3UDFCTNH7HPPCH3RRJGEUOI">
-                    <catDesc>Kambyses</catDesc>
+                    <catDesc>Kambyses<date from="-525" to="-522"/></catDesc>
                   </category>
                   <category xml:id="tlaAY5C3JQWXNAM5NIBQVZFPAU7OU">
-                    <catDesc>Artaxerxes I.</catDesc>
+                    <catDesc>Artaxerxes I.<date from="-464" to="-425"/></catDesc>
                   </category>
                   <category xml:id="tlaCX7WTFO76NEIREYNBAZEMCKZJA">
-                    <catDesc>Artaxerxes II.</catDesc>
+                    <catDesc>Artaxerxes II.<date from="-404" to="-402"/></catDesc>
                   </category>
                   <category xml:id="tlaDFOATHXUQJFSJLTVPASC3TQF7M">
-                    <catDesc>Xerxes II.</catDesc>
+                    <catDesc>Xerxes II.<date from="-424" to="-424"/></catDesc>
                   </category>
                   <category xml:id="tlaDHKNUBJOYVE4DNGXMYMVUFJHTU">
-                    <catDesc>Dareios II.</catDesc>
+                    <catDesc>Dareios II.<date from="-423" to="-405"/></catDesc>
                   </category>
                   <category xml:id="tlaLG2ZONR34VEQROX4FJ7MTCXKLM">
-                    <catDesc>Dareios I.</catDesc>
+                    <catDesc>Dareios I.<date from="-521" to="-486"/></catDesc>
                   </category>
                   <category xml:id="tlaMJ3WULDBQVD3NJM4NFJQWMAYWI">
-                    <catDesc>Xerxes I.</catDesc>
+                    <catDesc>Xerxes I.<date from="-485" to="-465"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tla2Z7FB3JW3BHGRPWOII5PAYY4DM">
-                  <catDesc>31. Dyn.</catDesc>
+                  <catDesc>31. Dyn.<date from="-341" to="-333"/></catDesc>
                   <category xml:id="tla6XFG65VENRHERHIHREIUEPT7V4">
-                    <catDesc>Arses</catDesc>
+                    <catDesc>Arses<date from="-338" to="-337"/></catDesc>
                   </category>
                   <category xml:id="tlaHULJPMHB4FGENJGZ7DPTWIADZE">
-                    <catDesc>Artaxerxes III. Ochos</catDesc>
+                    <catDesc>Artaxerxes III. Ochos<date from="-341" to="-339"/></catDesc>
                   </category>
                   <category xml:id="tlaI6OREN4DZFDKDDCN6FDFJDB5ZE">
-                    <catDesc>Dareios III.</catDesc>
+                    <catDesc>Dareios III.<date from="-336" to="-333"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tla42CP5AWFYFFVXFWGXMJLO2ZWWI">
-                  <catDesc>28. Dyn.</catDesc>
+                  <catDesc>28. Dyn.<date from="-401" to="-399"/></catDesc>
                   <category xml:id="tlaONG6H7BR5VBQPMWVKIG5RYZQWE">
-                    <catDesc>Amyrtaios</catDesc>
+                    <catDesc>Amyrtaios<date from="-401" to="-399"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaFZRARLPZPZG5JM6XGGLTTEU3KM">
-                  <catDesc>29. Dyn.</catDesc>
+                  <catDesc>29. Dyn.<date from="-398" to="-380"/></catDesc>
                   <category xml:id="tlaR3R4WMMU3VANVIGTRB5VPTHDYY">
-                    <catDesc>Nepherites II.</catDesc>
+                    <catDesc>Nepherites II.<date from="-380" to="-380"/></catDesc>
                   </category>
                   <category xml:id="tlaRX4OI7SAIJD4PIPLKCSDEHC5DQ">
-                    <catDesc>Nepherites I.</catDesc>
+                    <catDesc>Nepherites I.<date from="-398" to="-394"/></catDesc>
                   </category>
                   <category xml:id="tlaWSDXCFS7NBAZ7J6P6XHEKJ4CZA">
-                    <catDesc>Achoris</catDesc>
+                    <catDesc>Achoris<date from="-393" to="-381"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaQHQZNMAUZFCTZMLD5BGMDIKS6M">
-                  <catDesc>26. Dyn.</catDesc>
+                  <catDesc>26. Dyn.<date from="-664" to="-526"/></catDesc>
                   <category xml:id="tla26FQR3PAGBFZLNTFH2VIKTYGVY">
-                    <catDesc>Necho</catDesc>
+                    <catDesc>Necho<date from="-610" to="-596"/></catDesc>
                   </category>
                   <category xml:id="tlaAX5RS54IHNHLLHTG5ACTVOAUII">
-                    <catDesc>Amasis</catDesc>
+                    <catDesc>Amasis<date from="-570" to="-527"/></catDesc>
                   </category>
                   <category xml:id="tlaL3OEF7GYRZAVDA5J3RRDFHKKSQ">
-                    <catDesc>Psammetich III.</catDesc>
+                    <catDesc>Psammetich III.<date from="-526" to="-526"/></catDesc>
                   </category>
                   <category xml:id="tlaRWBAUHG5OVARXHA3ZVA4TFKSHQ">
-                    <catDesc>Psammetich II.</catDesc>
+                    <catDesc>Psammetich II.<date from="-595" to="-590"/></catDesc>
                   </category>
                   <category xml:id="tlaSSHXBGXDW5BJ3AEFHXVYZLBWAI">
-                    <catDesc>Psammetich I.</catDesc>
+                    <catDesc>Psammetich I.<date from="-664" to="-611"/></catDesc>
                   </category>
                   <category xml:id="tlaWBJEV25Q3RHT5NUYRUEGBY5LC4">
-                    <catDesc>Apries</catDesc>
+                    <catDesc>Apries<date from="-589" to="-571"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaZAQON3S37NHEJMZP33RUX47ZY4">
-                  <catDesc>30. Dyn.</catDesc>
+                  <catDesc>30. Dyn.<date from="-379" to="-342"/></catDesc>
                   <category xml:id="tla2EYHVBPX4NGUZPVTRAKO36TDWE">
-                    <catDesc>Teos</catDesc>
+                    <catDesc>Teos<date from="-363" to="-361"/></catDesc>
                   </category>
                   <category xml:id="tla5J7P2WPKN5GMNJD735VZP5JARQ">
-                    <catDesc>Nektanebos II.</catDesc>
+                    <catDesc>Nektanebos II.<date from="-360" to="-342"/></catDesc>
                   </category>
                   <category xml:id="tlaAS735FI63FEQTISOFW6R6ITQQI">
-                    <catDesc>Nektanebos I.</catDesc>
+                    <catDesc>Nektanebos I.<date from="-379" to="-364"/></catDesc>
                   </category>
                 </category>
               </category>
               <category xml:id="tlaWX32K2TQTRETLDX2IO6SL5DDBU">
-                <catDesc>Neues Reich</catDesc>
+                <catDesc>Neues Reich<date from="-1550" to="-1071"/></catDesc>
                 <category xml:id="tlaKXND4U5N5VBQLN4XMZGFVBHOCM">
-                  <catDesc>20. Dyn.</catDesc>
+                  <catDesc>20. Dyn.<date from="-1186" to="-1071"/></catDesc>
                   <category xml:id="tla3L7VTD3RIFDP3P6WD55HOUP5ZU">
-                    <catDesc>Ramses IV.</catDesc>
+                    <catDesc>Ramses IV.<date from="-1152" to="-1146"/></catDesc>
                   </category>
                   <category xml:id="tla6JOFBEHJGJD3FKFGPRMBGDT6XM">
-                    <catDesc>Ramses VIII.</catDesc>
+                    <catDesc>Ramses VIII.<date from="-1126" to="-1126"/></catDesc>
                   </category>
                   <category xml:id="tlaD3JLTVY33NF4VBTVIJRR4N5QUY">
-                    <catDesc>Ramses III.</catDesc>
+                    <catDesc>Ramses III.<date from="-1183" to="-1153"/></catDesc>
                   </category>
                   <category xml:id="tlaEJKPV5YRHZDUNFSHN2C5CZ22YU">
-                    <catDesc>Ramses VI.</catDesc>
+                    <catDesc>Ramses VI.<date from="-1142" to="-1135"/></catDesc>
                   </category>
                   <category xml:id="tlaLRSMDL7ITFEJBAHAZN2KSV7IRE">
-                    <catDesc>Ramses VII.</catDesc>
+                    <catDesc>Ramses VII.<date from="-1134" to="-1127"/></catDesc>
                   </category>
                   <category xml:id="tlaMOM3DW5NLZAB5JCM2ZKX5GICCE">
-                    <catDesc>Ramses IX.</catDesc>
+                    <catDesc>Ramses IX.<date from="-1125" to="-1108"/></catDesc>
                   </category>
                   <category xml:id="tlaPNMK6Q7XZNESBJPTUSW7FGQ7YA">
-                    <catDesc>Ramses XI.</catDesc>
+                    <catDesc>Ramses XI.<date from="-1103" to="-1071"/></catDesc>
                   </category>
                   <category xml:id="tlaT5G5CJPBKBGW3DAGCAUTS35JRY">
-                    <catDesc>Ramses V.</catDesc>
+                    <catDesc>Ramses V.<date from="-1145" to="-1143"/></catDesc>
                   </category>
                   <category xml:id="tlaTNO3MXXXJFF45IUPEUMCNHXK4Q">
-                    <catDesc>Ramses X.</catDesc>
+                    <catDesc>Ramses X.<date from="-1107" to="-1104"/></catDesc>
                   </category>
                   <category xml:id="tlaVP6WK4UCRJAXHJT6XQEO2ZG6OI">
-                    <catDesc>Sethnachte</catDesc>
+                    <catDesc>Sethnachte<date from="-1186" to="-1184"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaNUW3K7UK3BBUFDPHZDD2ZZ3LYI">
-                  <catDesc>18. Dyn.</catDesc>
+                  <catDesc>18. Dyn.<date from="-1550" to="-1293"/></catDesc>
                   <category xml:id="tla4EVBMCD2U5GQPBJ6QS622PTSQQ">
-                    <catDesc>Amenophis IV. / Echnaton</catDesc>
+                    <catDesc>Amenophis IV. / Echnaton<date from="-1351" to="-1338"/></catDesc>
                   </category>
                   <category xml:id="tla4QEIACZDZ5F7ZHVQCMJKSBMZXM">
-                    <catDesc>Thutmosis III. (Gesamtzeitraum)</catDesc>
+                    <catDesc>Thutmosis III. (Gesamtzeitraum)<date from="-1479" to="-1429"/></catDesc>
                   </category>
                   <category xml:id="tlaBVENTZHAEJERXCJI2Y45XAYKN4">
-                    <catDesc>Amenophis I.</catDesc>
+                    <catDesc>Amenophis I.<date from="-1525" to="-1505"/></catDesc>
                   </category>
                   <category xml:id="tlaDTH6NOX35ZBYNMGQH4SCKDS4GQ">
-                    <catDesc>Ahmose</catDesc>
+                    <catDesc>Ahmose<date from="-1550" to="-1526"/></catDesc>
                   </category>
                   <category xml:id="tlaF52ILUTH6RBWJI36ENPFTB22SI">
-                    <catDesc>Thutmosis I.</catDesc>
+                    <catDesc>Thutmosis I.<date from="-1504" to="-1493"/></catDesc>
                   </category>
                   <category xml:id="tlaKMQ26R2F3VEJDIOTNUTDWO4Z4Y">
-                    <catDesc>Amenophis II.</catDesc>
+                    <catDesc>Amenophis II.<date from="-1428" to="-1398"/></catDesc>
                   </category>
                   <category xml:id="tlaMOFI6DFV5VD7RBARIW4TL33IZE">
-                    <catDesc>Semenchkare</catDesc>
+                    <catDesc>Semenchkare<date from="-1337" to="-1334"/></catDesc>
                   </category>
                   <category xml:id="tlaPRDOZUMR2FDPNKK2OV6TUS4XEA">
-                    <catDesc>Thutmosis II.</catDesc>
+                    <catDesc>Thutmosis II.<date from="-1492" to="-1480"/></catDesc>
                   </category>
                   <category xml:id="tlaQYLA6ANYSRER7I3JFTCKIPRHOY">
-                    <catDesc>Hatschepsut</catDesc>
+                    <catDesc>Hatschepsut<date from="-1479" to="-1458"/></catDesc>
                   </category>
                   <category xml:id="tlaTGGVPV3PMFAP5O5OBSMOIKEX74">
-                    <catDesc>Amenophis III.</catDesc>
+                    <catDesc>Amenophis III.<date from="-1388" to="-1352"/></catDesc>
                   </category>
                   <category xml:id="tlaU3LID524EVGI7MWJUIJYNLNSAE">
-                    <catDesc>Haremhab</catDesc>
+                    <catDesc>Haremhab<date from="-1319" to="-1293"/></catDesc>
                   </category>
                   <category xml:id="tlaWMSRSEY4LBALVAQEKU4GKNLTMU">
-                    <catDesc>Thutmosis IV.</catDesc>
+                    <catDesc>Thutmosis IV.<date from="-1397" to="-1389"/></catDesc>
                   </category>
                   <category xml:id="tlaXB6A2YYCL5AGHN4YU24CWFOVKY">
-                    <catDesc>Thutmosis III. (Alleinregierung)</catDesc>
+                    <catDesc>Thutmosis III. (Alleinregierung)<date from="-1457" to="-1429"/></catDesc>
                   </category>
                   <category xml:id="tlaZ45USXGJBNCVZLOVM5CRMAAL3Y">
-                    <catDesc>Tutanchamun</catDesc>
+                    <catDesc>Tutanchamun<date from="-1333" to="-1324"/></catDesc>
                   </category>
                   <category xml:id="tlaZHZNTKKCLJFT5FUOH2Y7QESCWM">
-                    <catDesc>Eje</catDesc>
+                    <catDesc>Eje<date from="-1323" to="-1320"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaPFJ4POQ5VBFU3EHNXP4MRDLXBA">
-                  <catDesc>19. Dyn.</catDesc>
+                  <catDesc>19. Dyn.<date from="-1292" to="-1187"/></catDesc>
                   <category xml:id="tla54VED6E3TBESLGFQGGQVXZ6GLM">
-                    <catDesc>Merenptah</catDesc>
+                    <catDesc>Merenptah<date from="-1213" to="-1204"/></catDesc>
                   </category>
                   <category xml:id="tla6KMCKKTQ4FFMLOYH264TPBW4IU">
-                    <catDesc>Siptah u. Tausret</catDesc>
+                    <catDesc>Siptah u. Tausret<date from="-1194" to="-1187"/></catDesc>
                   </category>
                   <category xml:id="tlaBVMSDQRPX5ECXFKTIGQWIOXQOM">
-                    <catDesc>Sethos I.</catDesc>
+                    <catDesc>Sethos I.<date from="-1290" to="-1280"/></catDesc>
                   </category>
                   <category xml:id="tlaFCJURX24JZGXZEKP3TW36U3ZFA">
-                    <catDesc>Ramses II.</catDesc>
+                    <catDesc>Ramses II.<date from="-1279" to="-1214"/></catDesc>
                   </category>
                   <category xml:id="tlaSP2O7AHMRVFFNA6YJ2TIIYPS3A">
-                    <catDesc>Sethos II.</catDesc>
+                    <catDesc>Sethos II.<date from="-1200" to="-1195"/></catDesc>
                   </category>
                   <category xml:id="tlaW4R7J6OTNFAVTN24X6SJGFKZ6I">
-                    <catDesc>Ramses I.</catDesc>
+                    <catDesc>Ramses I.<date from="-1292" to="-1291"/></catDesc>
                   </category>
                   <category xml:id="tlaYOIYNB3BFVBEFDDS5V3AZCVFNQ">
-                    <catDesc>Amenmesse</catDesc>
+                    <catDesc>Amenmesse<date from="-1203" to="-1201"/></catDesc>
                   </category>
                 </category>
               </category>
               <category xml:id="tlaYZP5WTOZV5FB5EZFGQDY7MYKIQ">
-                <catDesc>römische Zeit</catDesc>
+                <catDesc>römische Zeit<date from="-31" to="395"/></catDesc>
                 <category xml:id="tla2A6LYDLVHRBPXFZKPZU7CEOAIM">
-                  <catDesc>"Soldatenkaiser"</catDesc>
+                  <catDesc>"Soldatenkaiser"<date from="235" to="284"/></catDesc>
                 </category>
                 <category xml:id="tla4XAVOEBBHVCGZIGICZCPL2N2N4">
-                  <catDesc>Severer</catDesc>
+                  <catDesc>Severer<date from="193" to="235"/></catDesc>
                   <category xml:id="tla3TAIGNOV5BDMLOMA5QOH4OOHHU">
-                    <catDesc>Macrinus</catDesc>
+                    <catDesc>Macrinus<date from="217" to="218"/></catDesc>
                   </category>
                   <category xml:id="tla5IHX5Q7WPNEM3GUPGVUQJ55S2M">
-                    <catDesc>Severus Alexander</catDesc>
+                    <catDesc>Severus Alexander<date from="222" to="235"/></catDesc>
                   </category>
                   <category xml:id="tla6I2IJQAXYVG3ZCPOQE2JR6RFGU">
-                    <catDesc>Septimius Severus</catDesc>
+                    <catDesc>Septimius Severus<date from="193" to="211"/></catDesc>
                   </category>
                   <category xml:id="tlaJCO2GZFWPJHT3O2VMQLPOCWMQU">
-                    <catDesc>Caracalla</catDesc>
+                    <catDesc>Caracalla<date from="212" to="217"/></catDesc>
                   </category>
                   <category xml:id="tlaU4NUJYYIJFBYRJP3OHALCEQSM4">
-                    <catDesc>Elagabal</catDesc>
+                    <catDesc>Elagabal<date from="218" to="222"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaFLZYUFLZMBCYZFIV6HIBSRIMPM">
-                  <catDesc>Adoptivkaiser</catDesc>
+                  <catDesc>Adoptivkaiser<date from="96" to="192"/></catDesc>
                   <category xml:id="tla67URIQ5T5BAC5H7TPXM437SPU4">
-                    <catDesc>Antoninus Pius</catDesc>
+                    <catDesc>Antoninus Pius<date from="138" to="161"/></catDesc>
                   </category>
                   <category xml:id="tla7CND52XKPNC5PIVU42CQ7FWAF4">
-                    <catDesc>Nerva</catDesc>
+                    <catDesc>Nerva<date from="96" to="98"/></catDesc>
                   </category>
                   <category xml:id="tlaK7FNLUAFURALDGBN4FV3LSUWZI">
-                    <catDesc>Commodus</catDesc>
+                    <catDesc>Commodus<date from="180" to="192"/></catDesc>
                   </category>
                   <category xml:id="tlaSBPP7UMVLNFRROVHN5MV4P3JMY">
-                    <catDesc>Hadrian</catDesc>
+                    <catDesc>Hadrian<date from="117" to="138"/></catDesc>
                   </category>
                   <category xml:id="tlaT5JLVAADRVCFFEE4AYQG7JUZXQ">
-                    <catDesc>Marcus Aurelius</catDesc>
+                    <catDesc>Marcus Aurelius<date from="161" to="180"/></catDesc>
                   </category>
                   <category xml:id="tlaXPSJ2LYDHBGNFD6CCPHJDKX4AY">
-                    <catDesc>Trajan</catDesc>
+                    <catDesc>Trajan<date from="98" to="117"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaKNI3FP7F3ZD7NLNZLEQOAIIG5U">
-                  <catDesc>Tetrarchenzeit</catDesc>
+                  <catDesc>Tetrarchenzeit<date from="284" to="395"/></catDesc>
                 </category>
                 <category xml:id="tlaNWBNCEAMTFCPTNGFVWWNQMPTVI">
-                  <catDesc>julisch-claudische Dynastie</catDesc>
+                  <catDesc>julisch-claudische Dynastie<date from="-30" to="68"/></catDesc>
                   <category xml:id="tla2HOJVMMCYBGGZBLAJPG2UMXHP4">
-                    <catDesc>Augustus</catDesc>
+                    <catDesc>Augustus<date from="-30" to="14"/></catDesc>
                   </category>
                   <category xml:id="tla6JNLCELRGFGW5DDAMGPF56DUAY">
-                    <catDesc>Tiberius</catDesc>
+                    <catDesc>Tiberius<date from="14" to="37"/></catDesc>
                   </category>
                   <category xml:id="tlaGKPIXD7FTBDQJETU2TITXC4QFQ">
-                    <catDesc>Claudius</catDesc>
+                    <catDesc>Claudius<date from="41" to="54"/></catDesc>
                   </category>
                   <category xml:id="tlaOTVJNIXD7NCJZHX4YZ7HEWCPXM">
-                    <catDesc>Gaius</catDesc>
+                    <catDesc>Gaius<date from="37" to="41"/></catDesc>
                   </category>
                   <category xml:id="tlaQVSUL54D5ZHFXP3S7MIOEU6GGA">
-                    <catDesc>Nero</catDesc>
+                    <catDesc>Nero<date from="54" to="68"/></catDesc>
                   </category>
                 </category>
                 <category xml:id="tlaTLFBMDUZ2RE6JNZW7GZDBHWATM">
-                  <catDesc>Flavier</catDesc>
+                  <catDesc>Flavier<date from="69" to="96"/></catDesc>
                   <category xml:id="tla7QV5OTUCG5BG3HMCRBR4CCVYGU">
-                    <catDesc>Domitian</catDesc>
+                    <catDesc>Domitian<date from="81" to="96"/></catDesc>
                   </category>
                   <category xml:id="tlaOSXPG6CJZNHRFG3CC7SYHU654Q">
-                    <catDesc>Titus</catDesc>
+                    <catDesc>Titus<date from="79" to="81"/></catDesc>
                   </category>
                   <category xml:id="tlaUEGCHD2YV5HL3E4DQ2C57NYFIU">
-                    <catDesc>Verspasian</catDesc>
+                    <catDesc>Verspasian<date from="69" to="79"/></catDesc>
                   </category>
                 </category>
               </category>
             </category>
             <category xml:id="tlaFHZEINDCEJAOTHIVC35NYGMC2Q">
-              <catDesc>(Jahrhunderte n.Chr.)</catDesc>
+              <catDesc>(Jahrhunderte n.Chr.)<date from="0" to="0"/></catDesc>
               <category xml:id="tla4GVKWKAP4VFSLFPBUBAI7XF2YA">
-                <catDesc>5. Jhdt. n.Chr.</catDesc>
+                <catDesc>5. Jhdt. n.Chr.<date from="401" to="500"/></catDesc>
                 <category xml:id="tla57U3TQQLHZGSFHQ3GAWVITBYUQ">
-                  <catDesc>1. Viertel 5. Jhdt. n.Chr.</catDesc>
+                  <catDesc>1. Viertel 5. Jhdt. n.Chr.<date from="401" to="425"/></catDesc>
                 </category>
                 <category xml:id="tlaAGZE4BISKREPFOZJJ5SZMRBKJQ">
-                  <catDesc>3. Viertel 5. Jhdt. n.Chr.</catDesc>
+                  <catDesc>3. Viertel 5. Jhdt. n.Chr.<date from="451" to="475"/></catDesc>
                 </category>
                 <category xml:id="tlaDHJI2BOMWFCKBM52LDN3NEUYO4">
-                  <catDesc>2. Viertel 5. Jhdt. n.Chr.</catDesc>
+                  <catDesc>2. Viertel 5. Jhdt. n.Chr.<date from="426" to="450"/></catDesc>
                 </category>
                 <category xml:id="tlaNXGHKWOMDZCZRHV474Y3FSMSVU">
-                  <catDesc>2. Hälfte 5. Jhdt. n.Chr.</catDesc>
+                  <catDesc>2. Hälfte 5. Jhdt. n.Chr.<date from="451" to="500"/></catDesc>
                 </category>
                 <category xml:id="tlaPZP2HLFD4ZD7PAJWWJA4C6IDHQ">
-                  <catDesc>1. Hälfte 5. Jhdt. n.Chr.</catDesc>
+                  <catDesc>1. Hälfte 5. Jhdt. n.Chr.<date from="401" to="450"/></catDesc>
                 </category>
                 <category xml:id="tlaXDJUGWOTXFFDZD344WXR5QQBPQ">
-                  <catDesc>4. Viertel 5. Jhdt. n.Chr.</catDesc>
+                  <catDesc>4. Viertel 5. Jhdt. n.Chr.<date from="476" to="500"/></catDesc>
                 </category>
               </category>
               <category xml:id="tla77UKMRWAJZC5LALMVTEAD6L7VA">
-                <catDesc>1. Jhdt. n.Chr.</catDesc>
+                <catDesc>1. Jhdt. n.Chr.<date from="1" to="100"/></catDesc>
                 <category xml:id="tla2EGWXRGUCBHIDCTZXMZGGEYHPE">
-                  <catDesc>2. Viertel 1. Jhdt. n.Chr.</catDesc>
+                  <catDesc>2. Viertel 1. Jhdt. n.Chr.<date from="26" to="50"/></catDesc>
                 </category>
                 <category xml:id="tla4GCBH775S5GTVNDXXASM2HFY3Q">
-                  <catDesc>3. Viertel 1. Jhdt. n.Chr.</catDesc>
+                  <catDesc>3. Viertel 1. Jhdt. n.Chr.<date from="51" to="75"/></catDesc>
                 </category>
                 <category xml:id="tlaAIVG3ELQKNC4HKUIDHONGLB4TQ">
-                  <catDesc>1. Hälfte 1. Jhdt. n.Chr.</catDesc>
+                  <catDesc>1. Hälfte 1. Jhdt. n.Chr.<date from="1" to="50"/></catDesc>
                 </category>
                 <category xml:id="tlaJSFEL3SGN5DW5JSWMKHGRW7GSA">
-                  <catDesc>2. Hälfte 1. Jhdt. n.Chr.</catDesc>
+                  <catDesc>2. Hälfte 1. Jhdt. n.Chr.<date from="51" to="100"/></catDesc>
                 </category>
                 <category xml:id="tlaOZZZBMWUEBA7FHBJFEKZRKK3SQ">
-                  <catDesc>1. Viertel 1. Jhdt. n.Chr.</catDesc>
+                  <catDesc>1. Viertel 1. Jhdt. n.Chr.<date from="1" to="25"/></catDesc>
                 </category>
                 <category xml:id="tlaWRWGTJLJNRHETBFC52BVHERDCQ">
-                  <catDesc>4. Viertel 1. Jhdt. n.Chr.</catDesc>
+                  <catDesc>4. Viertel 1. Jhdt. n.Chr.<date from="76" to="100"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaDU6YTUV2IZEYTOA7GVBMTBCV3I">
-                <catDesc>4. Jhdt. n.Chr.</catDesc>
+                <catDesc>4. Jhdt. n.Chr.<date from="301" to="400"/></catDesc>
                 <category xml:id="tla5J4Y3SI54NGWZHHKU63JMNFKCA">
-                  <catDesc>1. Viertel 4. Jhdt. n.Chr.</catDesc>
+                  <catDesc>1. Viertel 4. Jhdt. n.Chr.<date from="301" to="325"/></catDesc>
                 </category>
                 <category xml:id="tla6Y3WYJK76VFQRLZIMWF443PLUI">
-                  <catDesc>3. Viertel 4. Jhdt. n.Chr.</catDesc>
+                  <catDesc>3. Viertel 4. Jhdt. n.Chr.<date from="351" to="375"/></catDesc>
                 </category>
                 <category xml:id="tlaMG2USRRI6BB57BC2SCZTBMIG4Q">
-                  <catDesc>2. Hälfte 4. Jhdt. n.Chr.</catDesc>
+                  <catDesc>2. Hälfte 4. Jhdt. n.Chr.<date from="351" to="400"/></catDesc>
                 </category>
                 <category xml:id="tlaNP53EQUQQ5AN7JPKA77LISIWPI">
-                  <catDesc>2. Viertel 4. Jhdt. n.Chr.</catDesc>
+                  <catDesc>2. Viertel 4. Jhdt. n.Chr.<date from="326" to="350"/></catDesc>
                 </category>
                 <category xml:id="tlaWDMZ3ZJLVVAYTA4ZX4SXLI4MPA">
-                  <catDesc>1. Hälfte 4. Jhdt. n.Chr.</catDesc>
+                  <catDesc>1. Hälfte 4. Jhdt. n.Chr.<date from="301" to="350"/></catDesc>
                 </category>
                 <category xml:id="tlaWPEQO2GQTNE5XHPPIYVJG75WLE">
-                  <catDesc>4. Viertel 4. Jhdt. n.Chr.</catDesc>
+                  <catDesc>4. Viertel 4. Jhdt. n.Chr.<date from="376" to="400"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaEQM4LZPKYJCWFNQ445M6XU3UCY">
-                <catDesc>2. Jhdt. n.Chr.</catDesc>
+                <catDesc>2. Jhdt. n.Chr.<date from="101" to="200"/></catDesc>
                 <category xml:id="tla5HNMTTVLOREQ3LKMJOCIH7Z5GU">
-                  <catDesc>1. Hälfte 2. Jhdt. n.Chr.</catDesc>
+                  <catDesc>1. Hälfte 2. Jhdt. n.Chr.<date from="101" to="150"/></catDesc>
                 </category>
                 <category xml:id="tlaDXLYH5WDSRHZVE3XTFKN72X7ZQ">
-                  <catDesc>2. Hälfte 2. Jhdt. n.Chr.</catDesc>
+                  <catDesc>2. Hälfte 2. Jhdt. n.Chr.<date from="151" to="200"/></catDesc>
                 </category>
                 <category xml:id="tlaHT44AOEA5ZFFJBINX2DBUS3LYE">
-                  <catDesc>1. Viertel 2. Jhdt. n.Chr.</catDesc>
+                  <catDesc>1. Viertel 2. Jhdt. n.Chr.<date from="101" to="125"/></catDesc>
                 </category>
                 <category xml:id="tlaIIPELUHXL5G3TEZXTVQMSJCMIE">
-                  <catDesc>2. Viertel 2. Jhdt. n.Chr.</catDesc>
+                  <catDesc>2. Viertel 2. Jhdt. n.Chr.<date from="126" to="150"/></catDesc>
                 </category>
                 <category xml:id="tlaIO2NFBCQMJDSJGZB4QF7QRMMSY">
-                  <catDesc>4. Viertel 2. Jhdt. n.Chr.</catDesc>
+                  <catDesc>4. Viertel 2. Jhdt. n.Chr.<date from="176" to="200"/></catDesc>
                 </category>
                 <category xml:id="tlaMPCVCKDBWNC77GRCMHQQM66CUE">
-                  <catDesc>3. Viertel 2. Jhdt. n.Chr.</catDesc>
+                  <catDesc>3. Viertel 2. Jhdt. n.Chr.<date from="151" to="175"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaFV6TQYR4MJBDTCWZABXH4E4OMY">
-                <catDesc>9. Jhdt. n.Chr.</catDesc>
+                <catDesc>9. Jhdt. n.Chr.<date from="801" to="900"/></catDesc>
                 <category xml:id="tla3MEPLXDHJZH25EFWG4ONSPBADU">
-                  <catDesc>1. Hälfte 9. Jhdt. n.Chr.</catDesc>
+                  <catDesc>1. Hälfte 9. Jhdt. n.Chr.<date from="801" to="850"/></catDesc>
                 </category>
                 <category xml:id="tlaGCOGRW2AFNFAZC7CAH5VY2TIYI">
-                  <catDesc>4. Viertel 9. Jhdt. n.Chr.</catDesc>
+                  <catDesc>4. Viertel 9. Jhdt. n.Chr.<date from="876" to="900"/></catDesc>
                 </category>
                 <category xml:id="tlaMVDHBIPHCNEEVIZYTF4HL7XTGM">
-                  <catDesc>1. Viertel 9. Jhdt. n.Chr.</catDesc>
+                  <catDesc>1. Viertel 9. Jhdt. n.Chr.<date from="801" to="825"/></catDesc>
                 </category>
                 <category xml:id="tlaQSRVICICSJD6VOVHOP3Z3BBG5Y">
-                  <catDesc>3. Viertel 9. Jhdt. n.Chr.</catDesc>
+                  <catDesc>3. Viertel 9. Jhdt. n.Chr.<date from="851" to="875"/></catDesc>
                 </category>
                 <category xml:id="tlaSQYBTEXKORB6VCUCL5P5CABDBY">
-                  <catDesc>2. Hälfte 9. Jhdt. n.Chr.</catDesc>
+                  <catDesc>2. Hälfte 9. Jhdt. n.Chr.<date from="851" to="900"/></catDesc>
                 </category>
                 <category xml:id="tlaZ2OYYVNKXNCUDJRR6ZFGJHBBZ4">
-                  <catDesc>2. Viertel 9. Jhdt. n.Chr.</catDesc>
+                  <catDesc>2. Viertel 9. Jhdt. n.Chr.<date from="826" to="850"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaIMBHKBIKV5AUHEAAU2DL2K2GN4">
-                <catDesc>3. Jhdt. n.Chr.</catDesc>
+                <catDesc>3. Jhdt. n.Chr.<date from="201" to="300"/></catDesc>
                 <category xml:id="tlaC5KTZJIALBBA3BP3DB3BHAF3RA">
-                  <catDesc>4. Viertel 3. Jhdt. n.Chr.</catDesc>
+                  <catDesc>4. Viertel 3. Jhdt. n.Chr.<date from="276" to="300"/></catDesc>
                 </category>
                 <category xml:id="tlaKENXXLN7BRAYHAMA7O447DA73Y">
-                  <catDesc>2. Viertel 3. Jhdt. n.Chr.</catDesc>
+                  <catDesc>2. Viertel 3. Jhdt. n.Chr.<date from="226" to="250"/></catDesc>
                 </category>
                 <category xml:id="tlaQPUHN5VYWVAGPKZ3ZHYQFMYPNQ">
-                  <catDesc>2. Hälfte 3. Jhdt. n.Chr.</catDesc>
+                  <catDesc>2. Hälfte 3. Jhdt. n.Chr.<date from="251" to="300"/></catDesc>
                 </category>
                 <category xml:id="tlaRNVKCEB3GJBZNDSHZSA6UDH5BU">
-                  <catDesc>1. Hälfte 3. Jhdt. n.Chr.</catDesc>
+                  <catDesc>1. Hälfte 3. Jhdt. n.Chr.<date from="201" to="250"/></catDesc>
                 </category>
                 <category xml:id="tlaX7UGMEM77FBDXEPEMLGPVANWOI">
-                  <catDesc>3. Viertel 3. Jhdt. n.Chr.</catDesc>
+                  <catDesc>3. Viertel 3. Jhdt. n.Chr.<date from="251" to="275"/></catDesc>
                 </category>
                 <category xml:id="tlaZDX4UT6C7NGQZEUL55SAXFWDIQ">
-                  <catDesc>1. Viertel 3. Jhdt. n.Chr.</catDesc>
+                  <catDesc>1. Viertel 3. Jhdt. n.Chr.<date from="201" to="225"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaMRHDSYHO4FCH5FRYRE3F47QHSQ">
-                <catDesc>6. Jhdt. n.Chr.</catDesc>
+                <catDesc>6. Jhdt. n.Chr.<date from="501" to="600"/></catDesc>
                 <category xml:id="tla4BMTXUOSFBH6VBJLBMCOBFANBQ">
-                  <catDesc>1. Viertel 6. Jhdt. n.Chr.</catDesc>
+                  <catDesc>1. Viertel 6. Jhdt. n.Chr.<date from="501" to="525"/></catDesc>
                 </category>
                 <category xml:id="tlaOJPO7GMS75E75LTRJNRX2DCTGQ">
-                  <catDesc>2. Hälfte 6. Jhdt. n.Chr.</catDesc>
+                  <catDesc>2. Hälfte 6. Jhdt. n.Chr.<date from="551" to="600"/></catDesc>
                 </category>
                 <category xml:id="tlaUGV7KEWHUBBHNOKSVSU6EDZ5UU">
-                  <catDesc>4. Viertel 6. Jhdt. n.Chr.</catDesc>
+                  <catDesc>4. Viertel 6. Jhdt. n.Chr.<date from="576" to="600"/></catDesc>
                 </category>
                 <category xml:id="tlaXNT2W3PJZZHY7C46BD6UZHRLJA">
-                  <catDesc>2. Viertel 6. Jhdt. n.Chr.</catDesc>
+                  <catDesc>2. Viertel 6. Jhdt. n.Chr.<date from="526" to="550"/></catDesc>
                 </category>
                 <category xml:id="tlaXWW436FZEZC23OUSX7IPSXLWXA">
-                  <catDesc>1. Hälfte 6. Jhdt. n.Chr.</catDesc>
+                  <catDesc>1. Hälfte 6. Jhdt. n.Chr.<date from="501" to="550"/></catDesc>
                 </category>
                 <category xml:id="tlaZYRH3FYJNNAQDOACTPR2YKSV6U">
-                  <catDesc>3. Viertel 6. Jhdt. n.Chr.</catDesc>
+                  <catDesc>3. Viertel 6. Jhdt. n.Chr.<date from="551" to="575"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaTU6P6HMKY5AB7DLLOJVA77746E">
-                <catDesc>7. Jhdt. n.Chr.</catDesc>
+                <catDesc>7. Jhdt. n.Chr.<date from="601" to="700"/></catDesc>
                 <category xml:id="tla22SCMOXZQFDXRNHIOVRBPNOPZM">
-                  <catDesc>1. Viertel 7. Jhdt. n.Chr.</catDesc>
+                  <catDesc>1. Viertel 7. Jhdt. n.Chr.<date from="601" to="625"/></catDesc>
                 </category>
                 <category xml:id="tla74MF3BTZAVEBBFNK6KFLKUEHVA">
-                  <catDesc>4. Viertel 7. Jhdt. n.Chr.</catDesc>
+                  <catDesc>4. Viertel 7. Jhdt. n.Chr.<date from="675" to="700"/></catDesc>
                 </category>
                 <category xml:id="tlaFMT2DC5ZUJD2HEQACDEMXUFZB4">
-                  <catDesc>2. Viertel 7. Jhdt. n.Chr.</catDesc>
+                  <catDesc>2. Viertel 7. Jhdt. n.Chr.<date from="626" to="650"/></catDesc>
                 </category>
                 <category xml:id="tlaI5IQORK3F5BVZPETMCXQSJP5WA">
-                  <catDesc>1. Hälfte 7. Jhdt. n.Chr.</catDesc>
+                  <catDesc>1. Hälfte 7. Jhdt. n.Chr.<date from="601" to="650"/></catDesc>
                 </category>
                 <category xml:id="tlaTZTJKFTIEZCKBGVD2NSIPT2JQY">
-                  <catDesc>3. Viertel 7. Jhdt. n.Chr.</catDesc>
+                  <catDesc>3. Viertel 7. Jhdt. n.Chr.<date from="651" to="675"/></catDesc>
                 </category>
                 <category xml:id="tlaUKKBW2H6HJFIZCVHBREHPIGGVQ">
-                  <catDesc>2. Hälfte 7. Jhdt. n.Chr.</catDesc>
+                  <catDesc>2. Hälfte 7. Jhdt. n.Chr.<date from="651" to="700"/></catDesc>
                 </category>
               </category>
               <category xml:id="tlaY55AYTMYANAOFCYUMYJWZRPSZA">
-                <catDesc>8. Jhdt. n.Chr.</catDesc>
+                <catDesc>8. Jhdt. n.Chr.<date from="701" to="800"/></catDesc>
                 <category xml:id="tlaI5GTTHOZWJCY5LTQLIFAM4WYDM">
-                  <catDesc>3. Viertel 8. Jhdt. n.Chr.</catDesc>
+                  <catDesc>3. Viertel 8. Jhdt. n.Chr.<date from="751" to="775"/></catDesc>
                 </category>
                 <category xml:id="tlaPTTURIUYEVGRNIDYMJWFOHLZSI">
-                  <catDesc>2. Hälfte 8. Jhdt. n.Chr.</catDesc>
+                  <catDesc>2. Hälfte 8. Jhdt. n.Chr.<date from="751" to="800"/></catDesc>
                 </category>
                 <category xml:id="tlaPVZ6R3YIHZBRPNWWLX5VZTIUZU">
-                  <catDesc>1. Hälfte 8. Jhdt. n.Chr.</catDesc>
+                  <catDesc>1. Hälfte 8. Jhdt. n.Chr.<date from="701" to="750"/></catDesc>
                 </category>
                 <category xml:id="tlaQVPJSG5RUFGMNMAQNWUHEBYJKM">
-                  <catDesc>1. Viertel 8. Jhdt. n.Chr.</catDesc>
+                  <catDesc>1. Viertel 8. Jhdt. n.Chr.<date from="701" to="725"/></catDesc>
                 </category>
                 <category xml:id="tlaSJGD7JW3PZAHHB2FHJKWVTSIBM">
-                  <catDesc>4. Viertel 8. Jhdt. n.Chr.</catDesc>
+                  <catDesc>4. Viertel 8. Jhdt. n.Chr.<date from="776" to="800"/></catDesc>
                 </category>
                 <category xml:id="tlaVTOAVISRORHJPAQK3FTRPHYAQE">
-                  <catDesc>2. Viertel 8. Jhdt. n.Chr.</catDesc>
+                  <catDesc>2. Viertel 8. Jhdt. n.Chr.<date from="726" to="750"/></catDesc>
                 </category>
               </category>
             </category>
             <category xml:id="tlaFKLXKTC5RJFSZCBDU5HWK6KHGU">
-              <catDesc>(unbekannt)</catDesc>
+              <catDesc>(unbekannt)<date from="0" to="0"/></catDesc>
             </category>
             <category xml:id="tlaGTIHALKZWJFTNCLZ3ITXK7HBXA">
-              <catDesc>(unbestimmt)</catDesc>
+              <catDesc>(unbestimmt)<date from="0" to="0"/></catDesc>
             </category>
           </category>
           <category xml:id="tlaN4EKSVODAND4VALYASB5BQOFB4">


### PR DESCRIPTION
Recreated date thesaurus dateranges from original data by implementing
and running [a new command](https://github.com/JKatzwinkel/aed-tei/blob/0255c82eaef0b642a6ead016add9015b4bbf87fd/peret/__init__.py#L122-L138) of our trusty tool:

```bash
  peret add-ths-dateranges -i dump/vocabulary.zip -f files/thesaurus.xml
```

Dateranges are included in the `@from` and `@to` attributes of `<date>`
elements inserted into the respective `<catDesc>` elements right next
to their text nodes:

```xml
  <category xml:id="tlaZLKNXXGL7VA7VEECINB7NS65WI">
    <catDesc>3. Viertel 1. Jhdt. v.Chr.<date from="-50" to="-26"/></catDesc>
  </category>
```

In order to ensure that each entry of the date thesaurus received correct
start and end dates, I tested each of them against the only assumption we have always been making
about the date thesaurus: [that all dates of a node's children lie within its own daterange](https://github.com/JKatzwinkel/aed-tei/blob/13a0590938008686a8a0292888faaeb70293521c/peret/validate/dates.py#L86-L96).
In addition, I flagged all entries as invalid whose imported dateranges only span from year 0 to year 0.

The resulting incomplete entries are as follows:

| `ID`| `name`| `start`| `end`| `descendants_start`| `descendants_end`|
|-----|-------|--------|------|--------------------|------------------|
| `MXWX4WG43ZHI7D4RLTGK3IBGXY` | 9 = Datierungen| 0| 0| -3150| 900|
| `D3R5CH5NZBDA7IZMCKKJPWYZKU` | (Jahrhunderte v.Chr.)| 0| 0| -900| -1|
| `DUVGWT7GSRCKDM5LFTGU6MZ3GY` | (Epochen und Dynastien)| 0| 0| -3150| 641|
| `7FUWX6PWFJDAXEWQDOAA4FYXFU` | prädynastische Zeit| -5500| -3151| 0| 0|
| `6YAAR2WRI5F6BLP6YMW3G67P6Q` | Neolithikum vor der Badari-Kultur| 0| 0| 0| 0|
| `FMNBFXWGA5C2TEXFRDXOGXBEPE` | Badari-Kultur| 0| 0| 0| 0|
| `IPXSCTKV4REDHIXWTZWDXVXJWY` | Naqada III| 0| 0| 0| 0|
| `P5F2WOP6YZGBHK5KCSCP2UXJHM` | Naqada I| 0| 0| 0| 0|
| `WLIRCHQ3DRF4ZOTIREDVCPKC5A` | Naqada II| 0| 0| 0| 0|
| `HYYNMJRFTVFIHB7JUA6M2QW3LQ` | Makedonen, Ptolemäer| -332| -31| -332| -30|
| `JS32JKX2CNG25GZ3B6MGYMDU4I` | Dritte Zwischenzeit| -1070| -665| -1070| -656|
| `MM4QYACJOJCCLJWBD6VAX2FLKE` | Mittleres Reich| -2026| -1794| -2135| -1794|
| `FHZEINDCEJAOTHIVC35NYGMC2Q` | (Jahrhunderte n.Chr.)| 0| 0| 1| 900|
| `FKLXKTC5RJFSZCBDU5HWK6KHGU` | (unbekannt)| 0| 0| 0| 0|
| `GTIHALKZWJFTNCLZ3ITXK7HBXA` | (unbestimmt)| 0| 0| 0| 0|


